### PR TITLE
feat: Native HTTP transport for local LLM clients (v0.7.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-mcp-integration",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-mcp-integration",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -10268,7 +10268,7 @@
     },
     "packages/foundry-module": {
       "name": "@foundry-mcp/module",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "socket.io-client": "^4.7.0"
       },
@@ -10280,7 +10280,7 @@
     },
     "packages/mcp-server": {
       "name": "@foundry-mcp/server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@foundry-mcp/shared": "*",
         "@modelcontextprotocol/sdk": "^1.7.0",
@@ -10362,7 +10362,7 @@
     },
     "shared": {
       "name": "@foundry-mcp/shared",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "zod": "^3.22.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundry-mcp-integration",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server that bridges Foundry VTT game data with Claude Desktop",
   "private": true,
   "workspaces": [

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-mcp-bridge",
   "title": "Foundry MCP Bridge",
   "description": "Connect Foundry VTT to AI models through MCP protocol. Enable AI-powered actor creation, intelligent compendium search, campaign analysis, and interactive dice roll coordination. Supports Claude, local LLMs, and future AI models with comprehensive GM-only security.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "compatibility": {
     "minimum": "13",
     "verified": "13",

--- a/packages/foundry-module/package.json
+++ b/packages/foundry-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/module",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Foundry VTT module for MCP bridge integration",
   "type": "module",
   "scripts": {

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -2891,6 +2891,33 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Get pack index for a specific compendium pack
+   * Returns the index containing all documents in the pack without loading full documents
+   */
+  async getPackIndex(packId: string): Promise<any[]> {
+    try {
+      const pack = game.packs.get(packId);
+      if (!pack) {
+        throw new Error(`Compendium pack "${packId}" not found`);
+      }
+
+      if (!pack.indexed) {
+        await pack.getIndex({});
+      }
+
+      const indexArray = Array.from(pack.index.values());
+
+      console.log(`[${this.moduleId}] Retrieved pack index for ${packId}: ${indexArray.length} entries`);
+
+      return indexArray;
+
+    } catch (error) {
+      console.error(`[${this.moduleId}] Failed to get pack index for ${packId}:`, error);
+      throw new Error(`Failed to get pack index for ${packId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
    * Sanitize data to remove sensitive information and make it JSON-safe
    */
   private sanitizeData(data: any): any {
@@ -3297,6 +3324,240 @@ export class FoundryDataAccess {
 
     } catch (error) {
       this.auditLog('updateJournalContent', request, 'failure', error instanceof Error ? error.message : 'Unknown error');
+      throw error;
+    }
+  }
+
+  /**
+   * Create an actor directly from provided actor data (generic import path).
+   * Intended for system-specific importers that already mapped source JSON to Foundry actor shape.
+   */
+  async createActorFromData(request: {
+    actorData: Record<string, unknown>;
+    addToScene?: boolean;
+    updateExisting?: boolean;
+    existingActorIdentifier?: string;
+    preserveItemTypes?: string[];
+    placement?: {
+      type: 'random' | 'grid' | 'center' | 'coordinates';
+      coordinates?: { x: number; y: number }[];
+    };
+  }): Promise<{
+    success: boolean;
+    actor?: { id: string; name: string; type: string };
+    updatedExisting?: boolean;
+    tokensPlaced?: number;
+    errors?: string[];
+  }> {
+    this.validateFoundryState();
+
+    const permissionCheck = permissionManager.checkWritePermission('createActor', { quantity: 1 });
+    if (!permissionCheck.allowed) {
+      throw new Error(`${ERROR_MESSAGES.ACCESS_DENIED}: ${permissionCheck.reason}`);
+    }
+    permissionManager.auditPermissionCheck('createActor', permissionCheck, request);
+
+    try {
+      const actorData = foundry.utils.deepClone(request.actorData) as any;
+
+      delete actorData._id;
+      delete actorData.sort;
+
+      if (!actorData.name || typeof actorData.name !== 'string') {
+        throw new Error('actorData.name is required and must be a string');
+      }
+      if (!actorData.type || typeof actorData.type !== 'string') {
+        actorData.type = 'character';
+      }
+      if (!actorData.system || typeof actorData.system !== 'object') {
+        actorData.system = {};
+      }
+
+      if (Array.isArray(actorData.items)) {
+        actorData.items = actorData.items
+          .filter((item: any) => item && typeof item === 'object')
+          .map((item: any) => {
+            const clonedItem = foundry.utils.deepClone(item);
+            delete clonedItem._id;
+            delete clonedItem.folder;
+            delete clonedItem.sort;
+            return clonedItem;
+          });
+      } else {
+        actorData.items = [];
+      }
+
+      if (Array.isArray(actorData.effects)) {
+        actorData.effects = actorData.effects
+          .filter((effect: any) => effect && typeof effect === 'object')
+          .map((effect: any) => {
+            const clonedEffect = foundry.utils.deepClone(effect);
+            delete clonedEffect._id;
+            delete clonedEffect.folder;
+            delete clonedEffect.sort;
+            return clonedEffect;
+          });
+      } else {
+        actorData.effects = [];
+      }
+
+      if (actorData.prototypeToken?.texture?.src?.startsWith('http')) {
+        actorData.prototypeToken.texture.src = null;
+      }
+
+      if (!actorData.folder) {
+        const folderId = await this.getOrCreateFolder('Foundry MCP Imported Actors', 'Actor');
+        if (folderId) {
+          actorData.folder = folderId;
+        }
+      }
+
+      const incomingItems = actorData.items;
+      const incomingEffects = actorData.effects;
+      delete actorData.items;
+      delete actorData.effects;
+
+      const findExistingActor = (): Actor | undefined => {
+        if (!request.updateExisting) return undefined;
+
+        const byIdentifier = request.existingActorIdentifier?.trim();
+        if (byIdentifier) {
+          const byId = game.actors.get(byIdentifier);
+          if (byId) return byId;
+
+          const normalizedIdentifier = byIdentifier.toLowerCase();
+          return game.actors.find((actor) => actor.name?.toLowerCase() === normalizedIdentifier);
+        }
+
+        const normalizedName = String(actorData.name).toLowerCase().trim();
+        const desiredType = String(actorData.type || '').toLowerCase().trim();
+        return game.actors.find((actor) => {
+          const actorName = actor.name?.toLowerCase().trim();
+          const actorType = String(actor.type || '').toLowerCase().trim();
+          return actorName === normalizedName && actorType === desiredType;
+        });
+      };
+
+      const existingActor = findExistingActor();
+      let targetActor: Actor | null = null;
+      let updatedExisting = false;
+
+      if (existingActor) {
+        await existingActor.update(actorData);
+
+        let mergedIncomingItems = Array.isArray(incomingItems) ? [...incomingItems] : [];
+        const preserveIdentityTypes = new Set(request.preserveItemTypes ?? []);
+        const incomingTypeSet = new Set(
+          mergedIncomingItems
+            .map((item: any) => String(item?.type || '').toLowerCase().trim())
+            .filter((itemType: string) => itemType.length > 0)
+        );
+        const missingIdentityTypes = [...preserveIdentityTypes].filter((itemType) => !incomingTypeSet.has(itemType));
+        if (missingIdentityTypes.length > 0) {
+          const incomingKeys = new Set(
+            mergedIncomingItems.map(
+              (item: any) => `${String(item?.type || '').toLowerCase().trim()}::${String(item?.name || '').toLowerCase().trim()}`
+            )
+          );
+          const preservedIdentityItems = existingActor.items
+            .filter((item) => missingIdentityTypes.includes(String(item.type || '').toLowerCase().trim()))
+            .map((item) => item.toObject())
+            .filter((itemData: any) => {
+              const key = `${String(itemData?.type || '').toLowerCase().trim()}::${String(itemData?.name || '').toLowerCase().trim()}`;
+              return !incomingKeys.has(key);
+            })
+            .map((itemData: any) => {
+              const clonedItem = foundry.utils.deepClone(itemData);
+              delete clonedItem._id;
+              delete clonedItem.folder;
+              delete clonedItem.sort;
+              return clonedItem;
+            });
+          if (preservedIdentityItems.length > 0) {
+            mergedIncomingItems = [...mergedIncomingItems, ...preservedIdentityItems];
+          }
+        }
+
+        const existingItemIds = existingActor.items
+          .map((item) => item.id)
+          .filter((id): id is string => Boolean(id));
+        if (existingItemIds.length > 0) {
+          await existingActor.deleteEmbeddedDocuments('Item', existingItemIds);
+        }
+
+        if (Array.isArray(mergedIncomingItems) && mergedIncomingItems.length > 0) {
+          await existingActor.createEmbeddedDocuments('Item', mergedIncomingItems as any[]);
+        }
+
+        const existingEffectIds = existingActor.effects
+          .map((effect) => effect.id)
+          .filter((id): id is string => Boolean(id));
+        if (existingEffectIds.length > 0) {
+          await existingActor.deleteEmbeddedDocuments('ActiveEffect', existingEffectIds);
+        }
+
+        if (Array.isArray(incomingEffects) && incomingEffects.length > 0) {
+          await existingActor.createEmbeddedDocuments('ActiveEffect', incomingEffects as any[]);
+        }
+
+        targetActor = existingActor;
+        updatedExisting = true;
+      } else {
+        const createdActor = await Actor.create({
+          ...actorData,
+          items: incomingItems,
+          effects: incomingEffects,
+        });
+        if (!createdActor) {
+          throw new Error('Failed to create actor from provided data');
+        }
+        targetActor = createdActor;
+      }
+
+      if (!targetActor?.id) {
+        throw new Error('Target actor could not be created or resolved');
+      }
+
+      let tokensPlaced = 0;
+      const errors: string[] = [];
+      if (request.addToScene) {
+        try {
+          const sceneResult = await this.addActorsToScene({
+            actorIds: [targetActor.id],
+            placement: request.placement?.type || 'grid',
+            hidden: false,
+            ...(request.placement?.coordinates ? { coordinates: request.placement.coordinates } : {}),
+          });
+          tokensPlaced = sceneResult.success ? sceneResult.tokensCreated : 0;
+        } catch (error) {
+          errors.push(`Failed to add actor to scene: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+      }
+
+      const result: {
+        success: boolean;
+        actor: { id: string; name: string; type: string };
+        updatedExisting: boolean;
+        tokensPlaced: number;
+        errors?: string[];
+      } = {
+        success: true,
+        actor: {
+          id: targetActor.id,
+          name: targetActor.name ?? String(actorData.name),
+          type: targetActor.type ?? String(actorData.type ?? 'character'),
+        },
+        updatedExisting,
+        tokensPlaced,
+      };
+      if (errors.length > 0) {
+        result.errors = errors;
+      }
+
+      this.auditLog('createActorFromData', request, 'success');
+      return result;
+    } catch (error) {
+      this.auditLog('createActorFromData', request, 'failure', error instanceof Error ? error.message : 'Unknown error');
       throw error;
     }
   }

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -36,6 +36,7 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.searchCompendium`] = this.handleSearchCompendium.bind(this);
     CONFIG.queries[`${modulePrefix}.listCreaturesByCriteria`] = this.handleListCreaturesByCriteria.bind(this);
     CONFIG.queries[`${modulePrefix}.getAvailablePacks`] = this.handleGetAvailablePacks.bind(this);
+    CONFIG.queries[`${modulePrefix}.getPackIndex`] = this.handleGetPackIndex.bind(this);
 
     // Scene queries
     CONFIG.queries[`${modulePrefix}.getActiveScene`] = this.handleGetActiveScene.bind(this);
@@ -50,6 +51,7 @@ export class QueryHandlers {
 
     // Phase 2 & 3: Write operation queries
     CONFIG.queries[`${modulePrefix}.createActorFromCompendium`] = this.handleCreateActorFromCompendium.bind(this);
+    CONFIG.queries[`${modulePrefix}.createActorFromData`] = this.handleCreateActorFromData.bind(this);
     CONFIG.queries[`${modulePrefix}.getCompendiumDocumentFull`] = this.handleGetCompendiumDocumentFull.bind(this);
     CONFIG.queries[`${modulePrefix}.addActorsToScene`] = this.handleAddActorsToScene.bind(this);
     CONFIG.queries[`${modulePrefix}.validateWritePermissions`] = this.handleValidateWritePermissions.bind(this);
@@ -282,6 +284,28 @@ export class QueryHandlers {
   }
 
   /**
+   * Handle get pack index request
+   */
+  private async handleGetPackIndex(data: { packId: string }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data.packId) {
+        throw new Error('packId is required');
+      }
+
+      return await this.dataAccess.getPackIndex(data.packId);
+    } catch (error) {
+      throw new Error(`Failed to get pack index: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
    * Handle get active scene request
    */
   private async handleGetActiveScene(): Promise<any> {
@@ -390,6 +414,63 @@ export class QueryHandlers {
       return await this.dataAccess.createActorFromCompendiumEntry(requestData);
     } catch (error) {
       throw new Error(`Failed to create actor from compendium: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Handle actor creation from raw actor data payload
+   */
+  private async handleCreateActorFromData(data: {
+    actorData: Record<string, unknown>;
+    addToScene?: boolean;
+    updateExisting?: boolean;
+    existingActorIdentifier?: string;
+    preserveItemTypes?: string[];
+    placement?: {
+      type: 'random' | 'grid' | 'center' | 'coordinates';
+      coordinates?: { x: number; y: number }[];
+    };
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data?.actorData || typeof data.actorData !== 'object') {
+        throw new Error('actorData object is required');
+      }
+
+      const requestData: {
+        actorData: Record<string, unknown>;
+        addToScene?: boolean;
+        updateExisting?: boolean;
+        existingActorIdentifier?: string;
+        preserveItemTypes?: string[];
+        placement?: {
+          type: 'random' | 'grid' | 'center' | 'coordinates';
+          coordinates?: { x: number; y: number }[];
+        };
+      } = {
+        actorData: data.actorData,
+        addToScene: data.addToScene ?? false,
+        updateExisting: data.updateExisting ?? false,
+      };
+      if (data.existingActorIdentifier) {
+        requestData.existingActorIdentifier = data.existingActorIdentifier;
+      }
+      if (data.preserveItemTypes?.length) {
+        requestData.preserveItemTypes = data.preserveItemTypes;
+      }
+      if (data.placement) {
+        requestData.placement = data.placement;
+      }
+
+      return await this.dataAccess.createActorFromData(requestData);
+    } catch (error) {
+      throw new Error(`Failed to create actor from data: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for Foundry VTT integration with Claude Desktop",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1012,6 +1012,144 @@ async function processMapGenerationInBackend(jobId: string, jobQueue: any, comfy
   }
 }
 
+/**
+ * Start optional HTTP transport for local LLM clients (LM Studio, etc.)
+ *
+ * Security model — local LLM only, not internet-facing:
+ * 1. Binds to 127.0.0.1 by default (config.http.host)
+ * 2. Checks Origin header to prevent drive-by browser attacks
+ * 3. Optional bearer token (MCP_HTTP_AUTH_TOKEN) — when set, required on every request
+ *
+ * DO NOT bind to 0.0.0.0 or expose via tunnels without hardening — this is designed
+ * for localhost communication with local LLM clients, not remote/cloud LLMs.
+ */
+async function startHttpTransport(
+  httpConfig: { enabled: boolean; host: string; port: number; authToken?: string | undefined },
+  allTools: any[],
+  dispatchTool: (name: string, args: any) => Promise<any>,
+  logger: Logger
+): Promise<void> {
+  const http = await import('http');
+
+  // Origins considered safe for localhost LM Studio-style clients
+  const isAllowedOrigin = (origin: string | undefined | null): boolean => {
+    if (!origin || origin === 'null') return true; // no Origin header or curl/native client
+    try {
+      const url = new URL(origin);
+      const host = url.hostname;
+      return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+    } catch {
+      return false;
+    }
+  };
+
+  const isAuthorized = (req: import('http').IncomingMessage): boolean => {
+    if (!httpConfig.authToken) return true; // No token configured — allow (localhost already bound)
+    const header = req.headers['authorization'];
+    if (typeof header !== 'string') return false;
+    const parts = header.split(' ');
+    return parts.length === 2 && parts[0]!.toLowerCase() === 'bearer' && parts[1] === httpConfig.authToken;
+  };
+
+  const writeJson = (res: import('http').ServerResponse, statusCode: number, body: any): void => {
+    res.statusCode = statusCode;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(body));
+  };
+
+  const readBody = (req: import('http').IncomingMessage): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      req.on('error', reject);
+    });
+  };
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const origin = req.headers['origin'] as string | undefined;
+      if (!isAllowedOrigin(origin)) {
+        logger.warn('HTTP request rejected — disallowed origin', { origin, url: req.url });
+        writeJson(res, 403, { error: 'Origin not allowed' });
+        return;
+      }
+
+      if (!isAuthorized(req)) {
+        res.setHeader('WWW-Authenticate', 'Bearer');
+        writeJson(res, 401, { error: 'Unauthorized' });
+        return;
+      }
+
+      // Health endpoint — useful for LM Studio connection verification
+      if (req.url === '/health' && req.method === 'GET') {
+        writeJson(res, 200, { status: 'ok', toolCount: allTools.length });
+        return;
+      }
+
+      // MCP JSON-RPC endpoint
+      if (req.url === '/mcp' && req.method === 'POST') {
+        const bodyText = await readBody(req);
+        let body: any;
+        try {
+          body = JSON.parse(bodyText);
+        } catch {
+          writeJson(res, 400, { jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null });
+          return;
+        }
+
+        const { id, method, params } = body as { id?: string | number; method?: string; params?: any };
+
+        if (method === 'tools/list') {
+          writeJson(res, 200, { jsonrpc: '2.0', id: id ?? null, result: { tools: allTools } });
+          return;
+        }
+
+        if (method === 'tools/call') {
+          const { name, arguments: args } = (params || {}) as { name?: string; arguments?: any };
+          if (!name) {
+            writeJson(res, 400, { jsonrpc: '2.0', id: id ?? null, error: { code: -32602, message: 'Missing tool name' } });
+            return;
+          }
+          try {
+            const result = await dispatchTool(name, args ?? {});
+            const payload = {
+              content: [{ type: 'text', text: typeof result === 'string' ? result : JSON.stringify(result) }],
+            };
+            writeJson(res, 200, { jsonrpc: '2.0', id: id ?? null, result: payload });
+          } catch (err: any) {
+            const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+            writeJson(res, 200, {
+              jsonrpc: '2.0',
+              id: id ?? null,
+              result: { content: [{ type: 'text', text: `Error: ${errorMessage}` }], isError: true },
+            });
+          }
+          return;
+        }
+
+        writeJson(res, 400, { jsonrpc: '2.0', id: id ?? null, error: { code: -32601, message: 'Method not found' } });
+        return;
+      }
+
+      writeJson(res, 404, { error: 'Not found' });
+    } catch (err: any) {
+      logger.error('HTTP transport request handling failed', { error: err?.message || String(err) });
+      writeJson(res, 500, { error: 'Internal server error' });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(httpConfig.port, httpConfig.host, () => {
+      logger.info(`HTTP transport listening on ${httpConfig.host}:${httpConfig.port}`, {
+        authRequired: !!httpConfig.authToken,
+      });
+      resolve();
+    });
+    server.on('error', reject);
+  });
+}
+
 async function startBackend(): Promise<void> {
 
   // Logger: file output allowed; avoid stdout noise
@@ -1397,9 +1535,52 @@ async function startBackend(): Promise<void> {
 
             try {
 
-              let result: any;
+              const result = await dispatchTool(name, args);
 
-              switch (name) {
+              const payload = {
+
+                content: [{ type: 'text', text: typeof result === 'string' ? result : JSON.stringify(result) }],
+
+              };
+
+              socket.write(JSON.stringify({ id: msg.id, result: payload }) + '\n');
+
+            } catch (e: any) {
+
+              const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred';
+
+              socket.write(
+
+                JSON.stringify({ id: msg.id, result: { content: [{ type: 'text', text: `Error: ${errorMessage}` }], isError: true } }) + '\n'
+
+              );
+
+            }
+
+            continue;
+
+          }
+
+          socket.write(JSON.stringify({ id: msg.id, error: { message: 'Unknown method' } }) + '\n');
+
+        } catch (e: any) {
+
+          try { socket.write(JSON.stringify({ error: { message: e?.message || 'Bad request' } }) + '\n'); } catch {}
+
+        }
+
+      }
+
+    });
+
+  });
+
+  // Central tool dispatcher - shared by TCP control channel and HTTP transport
+  async function dispatchTool(name: string, args: any): Promise<any> {
+
+    let result: any;
+
+    switch (name) {
 
                 // Character tools
 
@@ -1651,45 +1832,9 @@ async function startBackend(): Promise<void> {
 
               }
 
-              const payload = {
+              return result;
 
-                content: [{ type: 'text', text: typeof result === 'string' ? result : JSON.stringify(result) }],
-
-              };
-
-              socket.write(JSON.stringify({ id: msg.id, result: payload }) + '\n');
-
-            } catch (e: any) {
-
-              const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred';
-
-              socket.write(
-
-                JSON.stringify({ id: msg.id, result: { content: [{ type: 'text', text: `Error: ${errorMessage}` }], isError: true } }) + '\n'
-
-              );
-
-            }
-
-            continue;
-
-          }
-
-          // Unknown method
-
-          socket.write(JSON.stringify({ id: msg.id, error: { message: 'Unknown method' } }) + '\n');
-
-        } catch (e: any) {
-
-          try { socket.write(JSON.stringify({ error: { message: e?.message || 'Bad request' } }) + '\n'); } catch {}
-
-        }
-
-      }
-
-    });
-
-  });
+  }
 
   await new Promise<void>((resolve, reject) => {
 
@@ -1704,6 +1849,14 @@ async function startBackend(): Promise<void> {
     server.on('error', reject);
 
   });
+
+  // Optional HTTP transport for local LLM clients (LM Studio, etc.)
+
+  if (config.http.enabled) {
+
+    await startHttpTransport(config.http, allTools, dispatchTool, logger);
+
+  }
 
   void autoStartComfyUI();
 

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -35,6 +35,7 @@ import { MapGenerationTools } from './tools/map-generation.js';
 import { TokenManipulationTools } from './tools/token-manipulation.js';
 
 import { DSA5CharacterCreator } from './systems/dsa5/character-creator.js';
+import { DSA5JsonActorImporter } from './systems/dsa5/json-actor-importer.js';
 
 const CONTROL_HOST = '127.0.0.1';
 
@@ -1067,6 +1068,7 @@ async function startBackend(): Promise<void> {
   const actorCreationTools = new ActorCreationTools({ foundryClient, logger });
 
   const dsa5CharacterCreator = new DSA5CharacterCreator({ foundryClient, logger });
+  const dsa5JsonActorImporter = new DSA5JsonActorImporter({ foundryClient, logger });
 
   const questCreationTools = new QuestCreationTools({ foundryClient, logger });
 
@@ -1299,6 +1301,8 @@ async function startBackend(): Promise<void> {
 
     ...dsa5CharacterCreator.getToolDefinitions(),
 
+    ...dsa5JsonActorImporter.getToolDefinitions(),
+
     ...questCreationTools.getToolDefinitions(),
 
     ...diceRollTools.getToolDefinitions(),
@@ -1494,6 +1498,12 @@ async function startBackend(): Promise<void> {
                 case 'list-dsa5-archetypes':
 
                   result = await dsa5CharacterCreator.handleListArchetypes(args);
+
+                  break;
+
+                case 'import-dsa5-actor-from-json':
+
+                  result = await dsa5JsonActorImporter.handleImportActorFromJson(args);
 
                   break;
 

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -45,6 +45,12 @@ const ConfigSchema = z.object({
     pythonCommand: z.string().default('python/python.exe'), // Will be platform-specific
   }),
   toolResponseMaxChars: z.number().min(256).max(500000).default(20000),
+  http: z.object({
+    enabled: z.boolean().default(false),
+    host: z.string().default('127.0.0.1'),
+    port: z.number().min(1024).max(65535).default(3333),
+    authToken: z.string().optional(),
+  }),
   server: z.object({
     name: z.string().default('foundry-mcp-server'),
     version: z.string().default('0.4.17'),
@@ -84,6 +90,12 @@ const rawConfig = {
     pythonCommand: process.env.COMFYUI_PYTHON_COMMAND || 'python/python.exe'
   },
   toolResponseMaxChars: parseInt(process.env.TOOL_RESPONSE_MAX_CHARS || '20000', 10),
+  http: {
+    enabled: process.env.MCP_HTTP_ENABLED === 'true',
+    host: process.env.MCP_HTTP_HOST || '127.0.0.1',
+    port: parseInt(process.env.MCP_HTTP_PORT || '3333', 10),
+    authToken: process.env.MCP_HTTP_AUTH_TOKEN,
+  },
   server: {
     name: process.env.SERVER_NAME || 'foundry-mcp-server',
     version: process.env.SERVER_VERSION || '1.0.0',

--- a/packages/mcp-server/src/systems/dsa5/character-creator.ts
+++ b/packages/mcp-server/src/systems/dsa5/character-creator.ts
@@ -229,33 +229,94 @@ export class DSA5CharacterCreator {
       // Get archetypes from each pack
       for (const pack of characterPacks) {
         try {
+          this.logger.info(`Loading archetypes from pack ${pack.id}`, { packLabel: pack.label });
+          
           const packIndex = await this.foundryClient.query('foundry-mcp-bridge.getPackIndex', {
             packId: pack.id,
           });
 
-          // Filter archetypes
-          const packArchetypes = packIndex
-            .filter((entry: any) => entry.type === 'character')
-            .filter((entry: any) => {
-              if (filterBySpecies && entry.system?.details?.species?.value !== filterBySpecies) {
-                return false;
+          this.logger.info(`Pack index loaded for ${pack.id}`, {
+            totalEntries: packIndex?.length || 0,
+            firstEntry: packIndex?.[0] || null
+          });
+
+          // DSA5 Note: Don't filter by entry.type - DSA5 compendiums may use different types
+          // (npc, character, creature) or no type field at all.
+          // The pack-level filter (pack.type === 'Actor' && pack.system === 'dsa5') is sufficient.
+          const actorEntries = packIndex;
+
+          this.logger.info(`Actor entries found in ${pack.id}`, {
+            count: actorEntries.length,
+            sampleEntry: actorEntries[0] || null
+          });
+
+          // Apply optional filters and build archetype list
+          let filteredEntries = actorEntries;
+          
+          // If filters are specified, we need to fetch full data for entries
+          // since pack index doesn't contain system.details
+          if (filterBySpecies || filterByProfession) {
+            this.logger.info('Applying filters - loading full data for entries', {
+              filterBySpecies,
+              filterByProfession,
+              totalEntries: actorEntries.length
+            });
+            
+            const fullDataEntries: any[] = [];
+            
+            for (const entry of actorEntries) {
+              try {
+                const fullData = await this.foundryClient.query('foundry-mcp-bridge.getCompendiumDocumentFull', {
+                  packId: pack.id,
+                  documentId: entry._id || entry.id, // Pack index uses _id
+                });
+                
+                if (fullData) {
+                  // Check species filter (case-insensitive exact match)
+                  const speciesValue = fullData.system?.details?.species?.value || '';
+                  const speciesMatch = !filterBySpecies ||
+                    speciesValue.toLowerCase() === filterBySpecies.toLowerCase();
+
+                  // Check profession filter (case-insensitive partial match)
+                  const careerValue = fullData.system?.details?.career?.value || '';
+                  const professionMatch = !filterByProfession ||
+                    careerValue.toLowerCase().includes(filterByProfession.toLowerCase());
+                  
+                  if (speciesMatch && professionMatch) {
+                    fullDataEntries.push({
+                      id: entry._id || entry.id,
+                      name: entry.name,
+                      packId: pack.id,
+                      packLabel: pack.label,
+                      species: fullData.system?.details?.species?.value || 'Unknown',
+                      profession: fullData.system?.details?.career?.value || 'Unknown',
+                      img: entry.img,
+                    });
+                  }
+                }
+              } catch (entryError) {
+                this.logger.warn(`Failed to load full data for entry ${entry.id}`, { error: entryError });
+                // Skip this entry on error
               }
-              if (filterByProfession && !entry.system?.details?.career?.value?.includes(filterByProfession)) {
-                return false;
-              }
-              return true;
-            })
-            .map((entry: any) => ({
-              id: entry.id,
-              name: entry.name,
-              packId: pack.id,
-              packLabel: pack.label,
-              species: entry.system?.details?.species?.value || 'Unknown',
-              profession: entry.system?.details?.career?.value || 'Unknown',
-              img: entry.img,
-            }));
+            }
+            
+            filteredEntries = fullDataEntries;
+            this.logger.info(`Filtered entries: ${filteredEntries.length} out of ${actorEntries.length}`);
+          }
+          
+          // Map entries to archetype format
+          const packArchetypes = filteredEntries.map((entry: any) => ({
+            id: entry._id || entry.id, // Pack index uses _id, filtered entries use id
+            name: entry.name,
+            packId: pack.id,
+            packLabel: pack.label,
+            species: entry.species || entry.system?.details?.species?.value || 'Unknown',
+            profession: entry.profession || entry.system?.details?.career?.value || 'Unknown',
+            img: entry.img,
+          }));
 
           archetypes.push(...packArchetypes);
+          this.logger.info(`Added ${packArchetypes.length} archetypes from ${pack.id}`);
         } catch (packError) {
           this.logger.warn(`Failed to load archetypes from pack ${pack.id}`, { error: packError });
         }

--- a/packages/mcp-server/src/systems/dsa5/filters.test.ts
+++ b/packages/mcp-server/src/systems/dsa5/filters.test.ts
@@ -1,13 +1,12 @@
-/**
- * DSA5 Filter Tests
- *
- * Simple tests to validate filter logic
- */
-
-import { matchesDSA5Filters, describeDSA5Filters, isValidDSA5Species, isValidExperienceLevel } from './filters.js';
+import { describe, expect, it } from 'vitest';
+import {
+  describeDSA5Filters,
+  isValidDSA5Species,
+  isValidExperienceLevel,
+  matchesDSA5Filters,
+} from './filters.js';
 import type { DSA5Filters } from './filters.js';
 
-// Test creature data
 const testCreature = {
   id: 'test-goblin-1',
   name: 'Goblin Krieger',
@@ -19,7 +18,7 @@ const testCreature = {
     size: 'small',
     hasSpells: false,
     experiencePoints: 1200,
-  }
+  },
 };
 
 const testSpellcaster = {
@@ -33,70 +32,64 @@ const testSpellcaster = {
     size: 'medium',
     hasSpells: true,
     experiencePoints: 4000,
-  }
+  },
 };
 
-console.log('=== DSA5 Filter Tests ===\n');
+describe('DSA5 filters', () => {
+  it('matches exact level filter', () => {
+    const filter: DSA5Filters = { level: 2 };
+    expect(describeDSA5Filters(filter)).toBe('Stufe 2');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(true);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(false);
+  });
 
-// Test 1: Level filter (exact)
-console.log('Test 1: Level filter (exact)');
-const filter1: DSA5Filters = { level: 2 };
-console.log(`Filter: ${describeDSA5Filters(filter1)}`);
-console.log(`Matches Goblin (Level 2): ${matchesDSA5Filters(testCreature, filter1)}`); // true
-console.log(`Matches Magier (Level 5): ${matchesDSA5Filters(testSpellcaster, filter1)}`); // false
-console.log('');
+  it('matches level range filter', () => {
+    const filter: DSA5Filters = { level: { min: 2, max: 5 } };
+    expect(describeDSA5Filters(filter)).toBe('Stufe 2-5');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(true);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(true);
+  });
 
-// Test 2: Level range filter
-console.log('Test 2: Level range filter');
-const filter2: DSA5Filters = { level: { min: 2, max: 5 } };
-console.log(`Filter: ${describeDSA5Filters(filter2)}`);
-console.log(`Matches Goblin (Level 2): ${matchesDSA5Filters(testCreature, filter2)}`); // true
-console.log(`Matches Magier (Level 5): ${matchesDSA5Filters(testSpellcaster, filter2)}`); // true
-console.log('');
+  it('matches species filter', () => {
+    const filter: DSA5Filters = { species: 'goblin' };
+    expect(describeDSA5Filters(filter)).toBe('goblin');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(true);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(false);
+  });
 
-// Test 3: Species filter
-console.log('Test 3: Species filter');
-const filter3: DSA5Filters = { species: 'goblin' };
-console.log(`Filter: ${describeDSA5Filters(filter3)}`);
-console.log(`Matches Goblin: ${matchesDSA5Filters(testCreature, filter3)}`); // true
-console.log(`Matches Elf: ${matchesDSA5Filters(testSpellcaster, filter3)}`); // false
-console.log('');
+  it('matches hasSpells filter', () => {
+    const filter: DSA5Filters = { hasSpells: true };
+    expect(describeDSA5Filters(filter)).toBe('Zauberer');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(false);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(true);
+  });
 
-// Test 4: Has spells filter
-console.log('Test 4: Has spells filter');
-const filter4: DSA5Filters = { hasSpells: true };
-console.log(`Filter: ${describeDSA5Filters(filter4)}`);
-console.log(`Matches Goblin (no spells): ${matchesDSA5Filters(testCreature, filter4)}`); // false
-console.log(`Matches Magier (has spells): ${matchesDSA5Filters(testSpellcaster, filter4)}`); // true
-console.log('');
+  it('matches combined filters', () => {
+    const filter: DSA5Filters = {
+      level: { min: 1, max: 3 },
+      size: 'small',
+      hasSpells: false,
+    };
 
-// Test 5: Combined filters
-console.log('Test 5: Combined filters');
-const filter5: DSA5Filters = {
-  level: { min: 1, max: 3 },
-  size: 'small',
-  hasSpells: false
-};
-console.log(`Filter: ${describeDSA5Filters(filter5)}`);
-console.log(`Matches Goblin: ${matchesDSA5Filters(testCreature, filter5)}`); // true
-console.log(`Matches Magier: ${matchesDSA5Filters(testSpellcaster, filter5)}`); // false
-console.log('');
+    expect(describeDSA5Filters(filter)).toBe('Stufe 1-3, small');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(true);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(false);
+  });
 
-// Test 6: Experience points filter
-console.log('Test 6: Experience points filter');
-const filter6: DSA5Filters = { experiencePoints: { min: 1000, max: 2000 } };
-console.log(`Filter: ${describeDSA5Filters(filter6)}`);
-console.log(`Matches Goblin (1200 AP): ${matchesDSA5Filters(testCreature, filter6)}`); // true
-console.log(`Matches Magier (4000 AP): ${matchesDSA5Filters(testSpellcaster, filter6)}`); // false
-console.log('');
+  it('matches experience points range filter', () => {
+    const filter: DSA5Filters = { experiencePoints: { min: 1000, max: 2000 } };
 
-// Test 7: Validation helpers
-console.log('Test 7: Validation helpers');
-console.log(`isValidDSA5Species('goblin'): ${isValidDSA5Species('goblin')}`); // true
-console.log(`isValidDSA5Species('unicorn'): ${isValidDSA5Species('unicorn')}`); // false
-console.log(`isValidExperienceLevel(3): ${isValidExperienceLevel(3)}`); // true
-console.log(`isValidExperienceLevel(0): ${isValidExperienceLevel(0)}`); // false
-console.log(`isValidExperienceLevel(8): ${isValidExperienceLevel(8)}`); // false
-console.log('');
+    expect(describeDSA5Filters(filter)).toBe('1000-2000 AP');
+    expect(matchesDSA5Filters(testCreature, filter)).toBe(true);
+    expect(matchesDSA5Filters(testSpellcaster, filter)).toBe(false);
+  });
 
-console.log('=== All Tests Completed ===');
+  it('validates species and experience level helpers', () => {
+    expect(isValidDSA5Species('goblin')).toBe(true);
+    expect(isValidDSA5Species('unicorn')).toBe(false);
+
+    expect(isValidExperienceLevel(3)).toBe(true);
+    expect(isValidExperienceLevel(0)).toBe(false);
+    expect(isValidExperienceLevel(8)).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/systems/dsa5/index.ts
+++ b/packages/mcp-server/src/systems/dsa5/index.ts
@@ -16,6 +16,7 @@ export { DSA5Adapter } from './adapter.js';
 
 // Character creator (runs in MCP server Node.js context)
 export { DSA5CharacterCreator } from './character-creator.js';
+export { DSA5JsonActorImporter } from './json-actor-importer.js';
 
 // Filter system
 export {

--- a/packages/mcp-server/src/systems/dsa5/json-actor-importer.test.ts
+++ b/packages/mcp-server/src/systems/dsa5/json-actor-importer.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyResolvedItemOverrides,
+  detectDSA5ImportFormat,
+  mapCustomDsa5Payload,
+  mapOptolithLikePayload,
+  normalizeInputKeys,
+  validateImportPayload,
+} from './json-actor-importer.js';
+
+describe('DSA5 JSON actor importer mapper', () => {
+  it('detects custom_dsa5 format', () => {
+    const format = detectDSA5ImportFormat({
+      name: 'Loreley',
+      attribute: { mut: 10 },
+      talente: [],
+    });
+
+    expect(format).toBe('custom_dsa5');
+  });
+
+  it('detects optolith_like format', () => {
+    const format = detectDSA5ImportFormat({
+      name: 'Opto',
+      r: 'species_1',
+      c: 'culture_1',
+      p: 'profession_1',
+      attr: { values: [{ id: 'ATTR_1', value: 14 }] },
+    });
+
+    expect(format).toBe('optolith_like');
+  });
+
+  it('detects raw_foundry format', () => {
+    const format = detectDSA5ImportFormat({
+      name: 'Raw Actor',
+      type: 'character',
+      system: {},
+    });
+
+    expect(format).toBe('raw_foundry');
+  });
+
+  it('maps custom DSA5 payload into actor core fields', () => {
+    const result = mapCustomDsa5Payload({
+      name: 'Loreley',
+      spezies: 'Halbelf',
+      kultur: 'Nostria',
+      profession: 'Zauberin',
+      sozialstatus: 'II',
+      abenteuerpunkteGesammelt: 1200,
+      abenteuerpunkteAusgegeben: 1190,
+      abenteuerpunkteGesamt: 10,
+      attribute: {
+        mut: 10,
+        klugheit: 15,
+        intuition: 15,
+        charisma: 15,
+        fingerfertigkeit: 16,
+        gewandheit: 12,
+        konstitution: 11,
+        koerperkraft: 8,
+      },
+      energien: {
+        lebensenergie: 27,
+        astralenergie: 22,
+        karmaenergie: 0,
+        schicksalspunkte: 3,
+      },
+      vorteile: [{ name: 'Zauberer' }],
+      talente: [{ name: 'Sinnesschaerfe' }],
+      kampftechniken: [{ name: 'Dolche', talentwert: 9 }],
+      zauberUndLiturgien: [{ name: 'Axxeleratus', talentwert: 7 }],
+      nahkampfwaffen: [{ name: 'Dolch', anzahl: 2 }],
+    });
+
+    expect(result.actorData.name).toBe('Loreley');
+    expect((result.actorData.system as any).details.species.value).toBe('Halbelf');
+    expect((result.actorData.system as any).characteristics.mu.advances).toBe(2);
+    expect((result.actorData.system as any).status.wounds.initial).toBe(5);
+    expect((result.actorData.system as any).status.wounds.value).toBe(27);
+    expect(result.candidateItemNames).toContain('Halbelf');
+    expect(result.candidateItemNames).toContain('Zauberer');
+    expect(result.candidateItemNames).toContain('Sinnesschaerfe');
+    expect(result.itemOverrides.sinnesschaerfe?.talentValue).toBeUndefined();
+    expect(result.itemOverrides.dolche?.talentValue).toBe(9);
+    expect(result.itemOverrides.axxeleratus?.talentValue).toBe(7);
+    expect(result.itemOverrides.dolch?.quantity).toBe(2);
+  });
+
+  it('maps optolith-like payload into actor core fields', () => {
+    const result = mapOptolithLikePayload({
+      name: 'Optolith Hero',
+      sex: 'male',
+      attr: {
+        lp: 2,
+        ae: 4,
+        kp: 1,
+        values: [
+          { id: 'ATTR_1', value: 14 },
+          { id: 'ATTR_2', value: 13 },
+        ],
+      },
+      pers: {
+        age: '25',
+        family: 'Unknown',
+      },
+      ap: {
+        total: 1500,
+      },
+    });
+
+    expect(result.actorData.name).toBe('Optolith Hero');
+    expect((result.actorData.system as any).characteristics.mu.advances).toBe(6);
+    expect((result.actorData.system as any).status.astralenergy.advances).toBe(4);
+    expect((result.actorData.system as any).details.experience.total).toBe(1500);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('fixes mojibake keys in attribute object', () => {
+    const fixed = normalizeInputKeys({ 'kÃ¶rperkraft': 12 });
+    expect(fixed['körperkraft']).toBe(12);
+    expect('kÃ¶rperkraft' in fixed).toBe(false);
+  });
+
+  it('rejects unknown format with helpful message', () => {
+    const result = validateImportPayload({ foo: 'bar' });
+    expect(result.isValid).toBe(false);
+    expect(result.detectedFormat).toBe('unknown');
+    expect(result.errors[0]).toContain('Format nicht erkannt');
+  });
+
+  it('rejects optolith_like without attr.values', () => {
+    const result = validateImportPayload({
+      name: 'Test',
+      r: 'x',
+      c: 'y',
+      p: 'z',
+      attr: { values: [] },
+    });
+    expect(result.isValid).toBe(false);
+  });
+
+  it('validates correct optolith_like payload', () => {
+    const result = validateImportPayload({
+      name: 'Test',
+      r: 'x',
+      c: 'y',
+      p: 'z',
+      attr: { values: [{ id: 'ATTR_1', value: 12 }] },
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('maps optolith talents and items from belongings', () => {
+    const result = mapOptolithLikePayload({
+      name: 'Hero',
+      attr: { values: [{ id: 'ATTR_1', value: 12 }], lp: 2, ae: 0, kp: 0 },
+      talents: { TAL_1: 3, TAL_8: 7 },
+      ct: { CT_3: 10 },
+      activatable: { ADV_4: [{}] },
+      belongings: { items: { item_1: { name: 'Dolch', amount: 2 } } },
+      ap: { total: 1000 },
+    });
+
+    expect(result.itemOverrides['tal_1']?.talentValue).toBe(3);
+    expect(result.itemOverrides['ct_3']?.talentValue).toBe(10);
+    expect(result.candidateItemNames).toContain('ADV_4');
+    expect(result.itemOverrides['dolch']?.quantity).toBe(2);
+  });
+
+  it('applies item overrides to resolved embedded items', () => {
+    const items = [
+      {
+        name: 'Klettern',
+        type: 'skill',
+        system: {
+          talentValue: { value: 0 },
+        },
+      },
+      {
+        name: 'Kurzbogen',
+        type: 'rangeweapon',
+        system: {
+          quantity: { value: 1 },
+        },
+      },
+    ] as any[];
+
+    const result = applyResolvedItemOverrides(items, {
+      klettern: { sourceName: 'Klettern', talentValue: 2 },
+      kurzbogen: { sourceName: 'Kurzbogen', quantity: 3 },
+    });
+
+    expect((items[0].system as any).talentValue.value).toBe(2);
+    expect((items[1].system as any).quantity.value).toBe(3);
+    expect(result.appliedCount).toBe(2);
+    expect(result.unappliedSourceNames).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/systems/dsa5/json-actor-importer.ts
+++ b/packages/mcp-server/src/systems/dsa5/json-actor-importer.ts
@@ -1,0 +1,1083 @@
+﻿import { promises as fs } from 'node:fs';
+import { z } from 'zod';
+import { FoundryClient } from '../../foundry-client.js';
+import { Logger } from '../../logger.js';
+import { ErrorHandler } from '../../utils/error-handler.js';
+
+export interface DSA5JsonActorImporterOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+export type DSA5ImportFormat = 'raw_foundry' | 'optolith_like' | 'custom_dsa5' | 'unknown';
+
+export type DSA5ImportStrategy = 'auto' | 'raw_foundry' | 'optolith_like' | 'custom_dsa5';
+
+interface MappingResult {
+  actorData: JsonRecord;
+  candidateItemNames: string[];
+  itemOverrides: Record<string, ItemOverride>;
+  warnings: string[];
+  unmappedFields: string[];
+}
+
+interface ItemOverride {
+  sourceName: string;
+  talentValue?: number;
+  quantity?: number;
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const fixMojibake = (s: string): string =>
+  s.replace(/Ã¶/g, 'ö')
+    .replace(/Ã¼/g, 'ü')
+    .replace(/Ã¤/g, 'ä')
+    .replace(/ÃŸ/g, 'ß')
+    .replace(/Ã–/g, 'Ö')
+    .replace(/Ãœ/g, 'Ü')
+    .replace(/Ã„/g, 'Ä');
+
+const normalizeValue = (value: unknown, parentKey?: string): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeValue(entry, parentKey));
+  }
+
+  if (isRecord(value)) {
+    const normalized: JsonRecord = {};
+    for (const [key, entryValue] of Object.entries(value)) {
+      const fixedKey = fixMojibake(key);
+      normalized[fixedKey] = normalizeValue(entryValue, fixedKey);
+    }
+    return normalized;
+  }
+
+  if (typeof value === 'string' && parentKey === 'name') {
+    return fixMojibake(value);
+  }
+
+  return value;
+};
+
+export const normalizeInputKeys = (payload: JsonRecord): JsonRecord =>
+  normalizeValue(payload) as JsonRecord;
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+const toStringValue = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+};
+
+const getByKeys = (source: JsonRecord, keys: string[]): unknown => {
+  for (const key of keys) {
+    if (key in source) return source[key];
+  }
+  return undefined;
+};
+
+const getNested = (source: JsonRecord, path: string): unknown => {
+  const parts = path.split('.');
+  let current: unknown = source;
+  for (const part of parts) {
+    if (!isRecord(current) || !(part in current)) return undefined;
+    current = current[part];
+  }
+  return current;
+};
+
+const characteristicAdvance = (value: unknown): number | undefined => {
+  const numeric = toNumber(value);
+  if (numeric === undefined) return undefined;
+  return Math.round(numeric) - 8;
+};
+
+const normalizeName = (name: string): string =>
+  name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const uniqueNames = (names: string[]): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const name of names) {
+    const normalized = normalizeName(name);
+    if (normalized.length === 0 || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(name.trim());
+  }
+  return result;
+};
+
+const sanitizeEmbeddedDocuments = (docs: unknown): JsonRecord[] => {
+  if (!Array.isArray(docs)) return [];
+  return docs
+    .filter((entry): entry is JsonRecord => isRecord(entry))
+    .map((entry) => {
+      const cloned = { ...entry };
+      delete cloned._id;
+      delete cloned.folder;
+      delete cloned.sort;
+      return cloned;
+    });
+};
+
+const addItemOverride = (
+  itemOverrides: Record<string, ItemOverride>,
+  sourceName: string,
+  next: Partial<ItemOverride>
+): void => {
+  const normalized = normalizeName(sourceName);
+  if (normalized.length === 0) return;
+  const current = itemOverrides[normalized] ?? { sourceName };
+  itemOverrides[normalized] = {
+    ...current,
+    ...next,
+    sourceName: current.sourceName ?? sourceName,
+  };
+};
+
+const collectTalentOverrides = (
+  source: unknown,
+  itemOverrides: Record<string, ItemOverride>
+): void => {
+  if (!Array.isArray(source)) return;
+  for (const entry of source) {
+    if (!isRecord(entry)) continue;
+    const name = toStringValue(entry.name);
+    const talentValue = toNumber(entry.talentwert);
+    if (!name || talentValue === undefined) continue;
+    addItemOverride(itemOverrides, name, { talentValue });
+  }
+};
+
+const collectQuantityOverrides = (
+  source: unknown,
+  itemOverrides: Record<string, ItemOverride>
+): void => {
+  if (!Array.isArray(source)) return;
+  for (const entry of source) {
+    if (!isRecord(entry)) continue;
+    const name = toStringValue(entry.name);
+    const quantity = toNumber(getByKeys(entry, ['anzahl', 'menge', 'quantity']));
+    if (!name || quantity === undefined) continue;
+    addItemOverride(itemOverrides, name, { quantity: Math.max(0, Math.round(quantity)) });
+  }
+};
+
+export const applyResolvedItemOverrides = (
+  items: JsonRecord[],
+  itemOverrides: Record<string, ItemOverride>
+): { appliedCount: number; unappliedSourceNames: string[] } => {
+  if (items.length === 0 || Object.keys(itemOverrides).length === 0) {
+    return { appliedCount: 0, unappliedSourceNames: [] };
+  }
+
+  const matched = new Set<string>();
+  let appliedCount = 0;
+
+  for (const item of items) {
+    const itemName = toStringValue(item.name);
+    if (!itemName) continue;
+    const normalized = normalizeName(itemName);
+    const override = itemOverrides[normalized];
+    if (!override) continue;
+
+    if (!isRecord(item.system)) {
+      item.system = {};
+    }
+
+    let touched = false;
+
+    if (override.talentValue !== undefined) {
+      const talentValue = isRecord((item.system as JsonRecord).talentValue)
+        ? { ...((item.system as JsonRecord).talentValue as JsonRecord) }
+        : {};
+      talentValue.value = Math.round(override.talentValue);
+      (item.system as JsonRecord).talentValue = talentValue;
+      touched = true;
+    }
+
+    if (override.quantity !== undefined) {
+      const quantity = isRecord((item.system as JsonRecord).quantity)
+        ? { ...((item.system as JsonRecord).quantity as JsonRecord) }
+        : {};
+      quantity.value = Math.max(0, Math.round(override.quantity));
+      (item.system as JsonRecord).quantity = quantity;
+      touched = true;
+    }
+
+    if (touched) {
+      matched.add(normalized);
+      appliedCount += 1;
+    }
+  }
+
+  const unappliedSourceNames = Object.entries(itemOverrides)
+    .filter(([normalized]) => !matched.has(normalized))
+    .map(([, override]) => override.sourceName);
+
+  return {
+    appliedCount,
+    unappliedSourceNames: uniqueNames(unappliedSourceNames),
+  };
+};
+
+const getSearchCandidates = (name: string): string[] => {
+  const candidates = [
+    name,
+    name.replace(/\s*-\s*[ivx]+$/i, ''),
+    name.replace(/\s+[ivx]+$/i, ''),
+    name.replace(/\s*\([^)]*\)\s*/g, ' ').trim(),
+  ]
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0);
+
+  return uniqueNames(candidates);
+};
+
+export const detectDSA5ImportFormat = (payload: JsonRecord): DSA5ImportFormat => {
+  const normalizedPayload = normalizeInputKeys(payload);
+
+  if (isRecord(normalizedPayload.system) && typeof normalizedPayload.type === 'string') {
+    return 'raw_foundry';
+  }
+
+  const attr = normalizedPayload.attr;
+  const optolithLike = isRecord(attr) && Array.isArray(attr.values);
+  if (optolithLike) return 'optolith_like';
+
+  const customLike =
+    isRecord(normalizedPayload.attribute) ||
+    Array.isArray(normalizedPayload.vorteile) ||
+    Array.isArray(normalizedPayload.talente) ||
+    Array.isArray(normalizedPayload.kampftechniken);
+  if (customLike) return 'custom_dsa5';
+
+  return 'unknown';
+};
+
+export const validateImportPayload = (
+  payload: JsonRecord
+): {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+  detectedFormat: DSA5ImportFormat;
+  missingCriticalFields: string[];
+  availableTopLevelKeys: string[];
+} => {
+  const normalizedPayload = normalizeInputKeys(payload);
+  const detectedFormat = detectDSA5ImportFormat(normalizedPayload);
+  const availableTopLevelKeys = Object.keys(normalizedPayload);
+  const missingCriticalFields: string[] = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (detectedFormat === 'raw_foundry') {
+    if (typeof normalizedPayload.type !== 'string') {
+      missingCriticalFields.push('type');
+    }
+    if (!isRecord(normalizedPayload.system)) {
+      missingCriticalFields.push('system');
+    }
+    if (missingCriticalFields.length > 0) {
+      errors.push(`raw_foundry: Pflichtfelder fehlen (${missingCriticalFields.join(', ')}).`);
+    }
+  }
+
+  if (detectedFormat === 'optolith_like') {
+    if (!toStringValue(normalizedPayload.name)) {
+      missingCriticalFields.push('name');
+    }
+
+    const attr = isRecord(normalizedPayload.attr) ? normalizedPayload.attr : undefined;
+    const values = attr && Array.isArray(attr.values) ? attr.values : [];
+    if (values.length === 0) {
+      missingCriticalFields.push('attr.values');
+    }
+
+    if (missingCriticalFields.length > 0) {
+      errors.push(`optolith_like: Pflichtfelder fehlen (${missingCriticalFields.join(', ')}).`);
+    }
+
+    const hasR = Boolean(toStringValue(normalizedPayload.r));
+    const hasC = Boolean(toStringValue(normalizedPayload.c));
+    const hasP = Boolean(toStringValue(normalizedPayload.p));
+    if (!hasR || !hasC || !hasP) {
+      warnings.push('Spezies/Kultur/Profession fehlen');
+    }
+    if (!isRecord(normalizedPayload.talents) || Object.keys(normalizedPayload.talents).length === 0) {
+      warnings.push('Keine Talente gefunden');
+    }
+  }
+
+  if (detectedFormat === 'custom_dsa5') {
+    if (!toStringValue(normalizedPayload.name)) {
+      missingCriticalFields.push('name');
+    }
+
+    const attribute = isRecord(normalizedPayload.attribute) ? normalizedPayload.attribute : undefined;
+    const knownAttributeKeys = [
+      'mut',
+      'klugheit',
+      'intuition',
+      'charisma',
+      'fingerfertigkeit',
+      'gewandheit',
+      'konstitution',
+      'körperkraft',
+      'koerperkraft',
+    ];
+    const hasKnownAttribute =
+      attribute !== undefined && knownAttributeKeys.some((key) => key in attribute);
+    if (!hasKnownAttribute) {
+      missingCriticalFields.push('attribute');
+    }
+
+    if (missingCriticalFields.length > 0) {
+      errors.push(`custom_dsa5: Pflichtfelder fehlen (${missingCriticalFields.join(', ')}).`);
+    }
+
+    if (!isRecord(normalizedPayload.energien)) {
+      warnings.push('Energien (Lebensenergie etc.) fehlen');
+    }
+
+    const hasTalente = Array.isArray(normalizedPayload.talente) && normalizedPayload.talente.length > 0;
+    const hasVorteile = Array.isArray(normalizedPayload.vorteile) && normalizedPayload.vorteile.length > 0;
+    const hasKampftechniken =
+      Array.isArray(normalizedPayload.kampftechniken) && normalizedPayload.kampftechniken.length > 0;
+    if (!hasTalente && !hasVorteile && !hasKampftechniken) {
+      warnings.push('Keine Items');
+    }
+  }
+
+  if (detectedFormat === 'unknown') {
+    const keyList = availableTopLevelKeys.length > 0 ? availableTopLevelKeys.join(', ') : '(keine)';
+    errors.push(
+      `Format nicht erkannt. Erkannte Felder: [${keyList}]. ` +
+      `Unterstützte Formate: custom_dsa5, optolith_like, raw_foundry. ` +
+      `Für custom_dsa5 wird mindestens 'name' + 'attribute' benötigt. ` +
+      `Für optolith_like wird mindestens 'name' + 'attr.values' benötigt.`
+    );
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+    detectedFormat,
+    missingCriticalFields,
+    availableTopLevelKeys,
+  };
+};
+
+export const mapCustomDsa5Payload = (payload: JsonRecord): MappingResult => {
+  const attribute = isRecord(payload.attribute) ? payload.attribute : {};
+  const energien = isRecord(payload.energien) ? payload.energien : {};
+  const itemOverrides: Record<string, ItemOverride> = {};
+
+  const species = toStringValue(payload.spezies);
+  const culture = toStringValue(payload.kultur);
+  const profession = toStringValue(payload.profession);
+  const socialStatus = toStringValue(payload.sozialstatus);
+  const koValue = toNumber(attribute.konstitution);
+  const lifeEnergy = toNumber(energien.lebensenergie);
+  const derivedWoundsInitial =
+    lifeEnergy !== undefined && koValue !== undefined
+      ? Math.max(0, Math.round(lifeEnergy - koValue * 2))
+      : undefined;
+
+  const actorData: JsonRecord = {
+    name: toStringValue(payload.name) ?? 'Imported DSA5 Character',
+    type: 'character',
+    system: {
+      characteristics: {
+        mu: { advances: characteristicAdvance(attribute.mut) ?? 0 },
+        kl: { advances: characteristicAdvance(attribute.klugheit) ?? 0 },
+        in: { advances: characteristicAdvance(attribute.intuition) ?? 0 },
+        ch: { advances: characteristicAdvance(attribute.charisma) ?? 0 },
+        ff: { advances: characteristicAdvance(attribute.fingerfertigkeit) ?? 0 },
+        ge: { advances: characteristicAdvance(attribute.gewandheit) ?? 0 },
+        ko: { advances: characteristicAdvance(attribute.konstitution) ?? 0 },
+        kk: {
+          advances:
+            characteristicAdvance(getByKeys(attribute, ['körperkraft', 'koerperkraft'])) ?? 0,
+        },
+      },
+      status: {
+        wounds: {
+          // DSA5 computes max LeP from wounds.initial + KO*2 (+modifiers).
+          // Keep initial aligned with imported lifeEnergy to avoid 27/22 mismatches.
+          initial: derivedWoundsInitial ?? 0,
+          value: lifeEnergy ?? 0,
+          max: lifeEnergy ?? 0,
+        },
+        astralenergy: {
+          value: toNumber(energien.astralenergie) ?? 0,
+          max: toNumber(energien.astralenergie) ?? 0,
+        },
+        karmaenergy: {
+          value: toNumber(energien.karmaenergie) ?? 0,
+          max: toNumber(energien.karmaenergie) ?? 0,
+        },
+        fatePoints: {
+          value: toNumber(energien.schicksalspunkte) ?? 0,
+          max: toNumber(energien.schicksalspunkte) ?? 0,
+        },
+      },
+      details: {
+        species: { value: species ?? '' },
+        culture: { value: culture ?? '' },
+        career: { value: profession ?? '' },
+        socialstate: { value: socialStatus ?? '' },
+        experience: {
+          total: toNumber(payload.abenteuerpunkteGesammelt) ?? 0,
+          spent: toNumber(payload.abenteuerpunkteAusgegeben) ?? 0,
+          available: toNumber(payload.abenteuerpunkteGesamt) ?? 0,
+        },
+      },
+    },
+  };
+
+  const nameBuckets: string[] = [];
+  if (species) nameBuckets.push(species);
+  if (culture) nameBuckets.push(culture);
+  if (profession) nameBuckets.push(profession);
+
+  const pushNames = (value: unknown) => {
+    if (!Array.isArray(value)) return;
+    for (const entry of value) {
+      if (isRecord(entry)) {
+        const entryName = toStringValue(entry.name);
+        if (entryName) nameBuckets.push(entryName);
+      } else if (typeof entry === 'string' && entry.trim().length > 0) {
+        nameBuckets.push(entry.trim());
+      }
+    }
+  };
+
+  pushNames(payload.vorteile);
+  pushNames(payload.nachteile);
+  pushNames(payload.sonderfertigkeiten);
+  pushNames(payload.talente);
+  pushNames(payload.kampftechniken);
+  pushNames(payload.zauberUndLiturgien);
+  pushNames(payload.nahkampfwaffen);
+  pushNames(payload.fernkampfwaffen);
+  pushNames(payload.gegenstände);
+  pushNames(payload.sprachen);
+  pushNames(payload.schriften);
+
+  collectTalentOverrides(payload.talente, itemOverrides);
+  collectTalentOverrides(payload.kampftechniken, itemOverrides);
+  collectTalentOverrides(payload.zauberUndLiturgien, itemOverrides);
+  collectQuantityOverrides(payload.nahkampfwaffen, itemOverrides);
+  collectQuantityOverrides(payload.fernkampfwaffen, itemOverrides);
+  collectQuantityOverrides(payload.gegenstände, itemOverrides);
+
+  const warnings: string[] = [];
+  if (!species) warnings.push('No species in payload; actor will be created with empty species field.');
+  if (!culture) warnings.push('No culture in payload; actor will be created with empty culture field.');
+  if (!profession) warnings.push('No profession in payload; actor will be created with empty profession field.');
+
+  const knownRoots = new Set([
+    'uid',
+    'grösse',
+    'größe',
+    'grÃ¶sse',
+    'name',
+    'geschlecht',
+    'spezies',
+    'region',
+    'kultur',
+    'kulturpaket',
+    'profession',
+    'sozialstatus',
+    'abenteuerpunkteGesammelt',
+    'abenteuerpunkteAusgegeben',
+    'abenteuerpunkteGesamt',
+    'hintergrund',
+    'attribute',
+    'abgeleiteteWerte',
+    'energien',
+    'vorteile',
+    'nachteile',
+    'sonderfertigkeiten',
+    'berufsgeheimnisse',
+    'sprachen',
+    'schriften',
+    'talente',
+    'kampftechniken',
+    'zauberUndLiturgien',
+    'objektrituale',
+    'rüstungen',
+    'nahkampfwaffen',
+    'fernkampfwaffen',
+    'gegenstände',
+  ]);
+
+  const unmappedFields = Object.keys(payload).filter((key) => !knownRoots.has(key));
+
+  return {
+    actorData,
+    candidateItemNames: uniqueNames(nameBuckets),
+    itemOverrides,
+    warnings,
+    unmappedFields,
+  };
+};
+
+export const mapOptolithLikePayload = (payload: JsonRecord): MappingResult => {
+  const attr = isRecord(payload.attr) ? payload.attr : {};
+  const details = isRecord(payload.pers) ? payload.pers : {};
+  const itemOverrides: Record<string, ItemOverride> = {};
+  const candidateItemNames: string[] = [];
+  const warnings: string[] = [];
+
+  const characteristics: Record<string, { advances: number }> = {
+    mu: { advances: 0 },
+    kl: { advances: 0 },
+    in: { advances: 0 },
+    ch: { advances: 0 },
+    ff: { advances: 0 },
+    ge: { advances: 0 },
+    ko: { advances: 0 },
+    kk: { advances: 0 },
+  };
+
+  const attrValues = Array.isArray(attr.values) ? attr.values : [];
+  const attrToCharacteristic: Record<string, keyof typeof characteristics> = {
+    ATTR_1: 'mu',
+    ATTR_2: 'kl',
+    ATTR_3: 'in',
+    ATTR_4: 'ch',
+    ATTR_5: 'ff',
+    ATTR_6: 'ge',
+    ATTR_7: 'ko',
+    ATTR_8: 'kk',
+  };
+  for (const entry of attrValues) {
+    if (!isRecord(entry)) continue;
+    const idRaw = toStringValue(entry.id);
+    const value = toNumber(entry.value);
+    if (!idRaw || value === undefined) continue;
+    const characteristicKey = attrToCharacteristic[idRaw];
+    if (characteristicKey) {
+      characteristics[characteristicKey] = { advances: Math.round(value) - 8 };
+    }
+  }
+
+  const speciesId = toStringValue(payload.r);
+  const cultureId = toStringValue(payload.c);
+  const professionId = toStringValue(payload.p);
+  if (speciesId) candidateItemNames.push(speciesId);
+  if (cultureId) candidateItemNames.push(cultureId);
+  if (professionId) candidateItemNames.push(professionId);
+  if (speciesId || cultureId || professionId) {
+    warnings.push('Spezies/Kultur/Profession sind als IDs gespeichert - Compendium-Suche kann davon abweichen.');
+  }
+
+  const addIdBasedTalentValues = (source: unknown): boolean => {
+    if (!isRecord(source)) return false;
+    let detected = false;
+    for (const [id, value] of Object.entries(source)) {
+      const numeric = toNumber(value);
+      if (numeric === undefined) continue;
+      candidateItemNames.push(id);
+      addItemOverride(itemOverrides, id, { talentValue: Math.round(numeric) });
+      detected = true;
+    }
+    return detected;
+  };
+
+  const hasTalentIds = [
+    addIdBasedTalentValues(payload.talents),
+    addIdBasedTalentValues(payload.ct),
+    addIdBasedTalentValues(payload.spells),
+    addIdBasedTalentValues(payload.liturgies),
+  ].some(Boolean);
+  if (hasTalentIds) {
+    warnings.push('Talent-IDs (TAL_x) wurden übergeben - Compendium-Treffer hängen vom DSA5-System-Modul ab.');
+  }
+
+  const pushArrayNames = (source: unknown) => {
+    if (!Array.isArray(source)) return;
+    for (const entry of source) {
+      const name = toStringValue(entry);
+      if (name) candidateItemNames.push(name);
+    }
+  };
+  pushArrayNames(payload.cantrips);
+  pushArrayNames(payload.blessings);
+
+  if (isRecord(payload.activatable)) {
+    for (const [id] of Object.entries(payload.activatable)) {
+      candidateItemNames.push(id);
+    }
+  }
+
+  const belongings = isRecord(payload.belongings) ? payload.belongings : {};
+  const belongingsItems = isRecord(belongings.items) ? belongings.items : {};
+  for (const [, itemData] of Object.entries(belongingsItems)) {
+    if (!isRecord(itemData)) continue;
+    const itemName = toStringValue(itemData.name);
+    if (!itemName) continue;
+    candidateItemNames.push(itemName);
+    const amount = toNumber(itemData.amount);
+    if (amount !== undefined) {
+      addItemOverride(itemOverrides, itemName, { quantity: Math.max(0, Math.round(amount)) });
+    }
+  }
+
+  const actorData: JsonRecord = {
+    name: toStringValue(payload.name) ?? 'Imported Optolith Character',
+    type: 'character',
+    system: {
+      characteristics,
+      status: {
+        wounds: {
+          advances: toNumber(attr.lp) ?? 0,
+        },
+        astralenergy: {
+          advances: toNumber(attr.ae) ?? 0,
+          permanentLoss: toNumber(getNested(attr, 'permanentAE.lost')) ?? 0,
+          rebuy: toNumber(getNested(attr, 'permanentAE.redeemed')) ?? 0,
+        },
+        karmaenergy: {
+          advances: toNumber(attr.kp) ?? 0,
+          permanentLoss: toNumber(getNested(attr, 'permanentKP.lost')) ?? 0,
+          rebuy: toNumber(getNested(attr, 'permanentKP.redeemed')) ?? 0,
+        },
+      },
+      details: {
+        species: { value: speciesId ?? '' },
+        culture: { value: cultureId ?? '' },
+        career: { value: professionId ?? '' },
+        socialstate: { value: toStringValue(details.socialstatus) ?? '' },
+        age: { value: toStringValue(details.age) ?? '' },
+        gender: { value: toStringValue(payload.sex) ?? '' },
+        home: { value: toStringValue(details.placeofbirth) ?? '' },
+        family: { value: toStringValue(details.family) ?? '' },
+        haircolor: { value: toStringValue(details.haircolor) ?? '' },
+        eyecolor: { value: toStringValue(details.eyecolor) ?? '' },
+        height: { value: toStringValue(details.height) ?? '' },
+        weight: { value: toStringValue(details.weight) ?? '' },
+        characteristics: { value: toStringValue(details.characteristics) ?? '' },
+        experience: {
+          total: toNumber((isRecord(payload.ap) ? payload.ap.total : undefined)) ?? 0,
+        },
+      },
+    },
+  };
+
+  return {
+    actorData,
+    candidateItemNames: uniqueNames(candidateItemNames),
+    itemOverrides,
+    warnings,
+    unmappedFields: [],
+  };
+};
+
+const sanitizeActorPayload = (payload: JsonRecord): JsonRecord => {
+  const actorData: JsonRecord = { ...payload };
+
+  delete actorData._id;
+  delete actorData.folder;
+  delete actorData.sort;
+
+  actorData.items = sanitizeEmbeddedDocuments(actorData.items);
+  actorData.effects = sanitizeEmbeddedDocuments(actorData.effects);
+
+  if (!actorData.name || typeof actorData.name !== 'string') {
+    actorData.name = 'Imported Actor';
+  }
+
+  if (!actorData.type || typeof actorData.type !== 'string') {
+    actorData.type = 'character';
+  }
+
+  if (!isRecord(actorData.system)) {
+    actorData.system = {};
+  }
+
+  const prototypeToken = isRecord(actorData.prototypeToken) ? actorData.prototypeToken : undefined;
+  const texture = prototypeToken && isRecord(prototypeToken.texture) ? prototypeToken.texture : undefined;
+  const src = texture && typeof texture.src === 'string' ? texture.src : undefined;
+  if (src && src.startsWith('http')) {
+    texture!.src = null;
+  }
+
+  return actorData;
+};
+
+const extractPayload = async (jsonPayload: unknown, filePath: string | undefined): Promise<JsonRecord> => {
+  let parsed: unknown = jsonPayload;
+
+  if (!parsed && filePath) {
+    const content = await fs.readFile(filePath, 'utf8');
+    parsed = JSON.parse(content);
+  }
+
+  if (typeof parsed === 'string') {
+    parsed = JSON.parse(parsed);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('Payload must resolve to a JSON object.');
+  }
+
+  return parsed;
+};
+
+interface ResolvedItemsResult {
+  items: JsonRecord[];
+  unresolvedNames: string[];
+  resolvedCount: number;
+}
+
+export class DSA5JsonActorImporter {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+  private errorHandler: ErrorHandler;
+
+  constructor({ foundryClient, logger }: DSA5JsonActorImporterOptions) {
+    this.foundryClient = foundryClient;
+    this.logger = logger.child({ component: 'DSA5JsonActorImporter' });
+    this.errorHandler = new ErrorHandler(this.logger);
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'import-dsa5-actor-from-json',
+        description:
+          'Import a custom DSA5 actor JSON using multiple strategies (auto/custom_dsa5/optolith_like/raw_foundry). Supports file path or inline JSON payload. Best-effort item resolution is performed via compendium name lookup and unresolved entries are returned as warnings.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            jsonPayload: {
+              oneOf: [
+                { type: 'string' },
+                { type: 'object' },
+              ],
+              description:
+                'Inline JSON content as object or string. Optional if filePath is provided.',
+            },
+            filePath: {
+              type: 'string',
+              description:
+                'Local file path to a JSON file readable by the MCP server process. Optional if jsonPayload is provided.',
+            },
+            strategy: {
+              type: 'string',
+              enum: ['auto', 'custom_dsa5', 'optolith_like', 'raw_foundry'],
+              default: 'auto',
+              description:
+                'Import strategy. auto detects format and chooses mapping path.',
+            },
+            resolveItems: {
+              type: 'boolean',
+              default: true,
+              description:
+                'Try resolving item-like entries by name from compendiums and embed them into the created actor.',
+            },
+            addToScene: {
+              type: 'boolean',
+              default: false,
+              description: 'Add created actor to active scene as token.',
+            },
+            updateExisting: {
+              type: 'boolean',
+              default: true,
+              description:
+                'If true, update an existing actor (same name by default) instead of creating a duplicate.',
+            },
+            existingActorIdentifier: {
+              type: 'string',
+              description:
+                'Optional actor ID or exact name used when updateExisting is true. Defaults to imported name.',
+            },
+            strict: {
+              type: 'boolean',
+              default: false,
+              description:
+                'If true, unresolved item names abort the import instead of returning warnings.',
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  async handleImportActorFromJson(args: unknown): Promise<Record<string, unknown>> {
+    const schema = z
+      .object({
+        jsonPayload: z.union([z.string(), z.record(z.unknown())]).optional(),
+        filePath: z.string().optional(),
+        strategy: z.enum(['auto', 'custom_dsa5', 'optolith_like', 'raw_foundry']).default('auto'),
+        resolveItems: z.boolean().default(true),
+        addToScene: z.boolean().default(false),
+        updateExisting: z.boolean().default(true),
+        existingActorIdentifier: z.string().optional(),
+        strict: z.boolean().default(false),
+      })
+      .refine((value) => Boolean(value.jsonPayload) || Boolean(value.filePath), {
+        message: 'Either jsonPayload or filePath is required.',
+      });
+
+    const {
+      jsonPayload,
+      filePath,
+      strategy,
+      resolveItems,
+      addToScene,
+      updateExisting,
+      existingActorIdentifier,
+      strict,
+    } = schema.parse(args);
+
+    try {
+      await this.assertDsa5World();
+
+      const payload = await extractPayload(jsonPayload, filePath);
+      const normalizedPayload = normalizeInputKeys(payload);
+      const validation = validateImportPayload(normalizedPayload);
+
+      const detectedFormat = validation.detectedFormat;
+      const selectedFormat = strategy === 'auto' ? detectedFormat : strategy;
+
+      if (strategy === 'auto' && validation.errors.length > 0) {
+        return {
+          success: false,
+          error: validation.errors.join(' | '),
+          detectedFormat: validation.detectedFormat,
+          availableTopLevelKeys: validation.availableTopLevelKeys,
+        };
+      }
+
+      let mappingResult: MappingResult;
+      switch (selectedFormat) {
+        case 'raw_foundry':
+          mappingResult = {
+            actorData: sanitizeActorPayload(normalizedPayload),
+            candidateItemNames: [],
+            itemOverrides: {},
+            warnings: [],
+            unmappedFields: [],
+          };
+          break;
+        case 'optolith_like':
+          mappingResult = mapOptolithLikePayload(normalizedPayload);
+          break;
+        case 'custom_dsa5':
+          mappingResult = mapCustomDsa5Payload(normalizedPayload);
+          break;
+        default:
+          throw new Error(
+            `Could not detect supported JSON format. Detected format: ${detectedFormat}. Use strategy override if needed.`
+          );
+      }
+
+      const warnings = Array.from(new Set([...validation.warnings, ...mappingResult.warnings]));
+      const unresolvedItemNames: string[] = [];
+      let appliedItemOverrides = 0;
+      let unappliedItemOverrideNames: string[] = [];
+
+      if (resolveItems && mappingResult.candidateItemNames.length > 0) {
+        const resolved = await this.resolveItemsByName(mappingResult.candidateItemNames);
+        unresolvedItemNames.push(...resolved.unresolvedNames);
+        if (resolved.items.length > 0) {
+          const existingItems = Array.isArray(mappingResult.actorData.items)
+            ? sanitizeEmbeddedDocuments(mappingResult.actorData.items)
+            : [];
+          mappingResult.actorData.items = [...existingItems, ...resolved.items];
+        }
+
+        if (resolved.unresolvedNames.length > 0) {
+          warnings.push(
+            `Unresolved item names (${resolved.unresolvedNames.length}): ${resolved.unresolvedNames.join(', ')}`
+          );
+        }
+      }
+
+      const actorItems = Array.isArray(mappingResult.actorData.items)
+        ? sanitizeEmbeddedDocuments(mappingResult.actorData.items)
+        : [];
+      if (actorItems.length > 0 && Object.keys(mappingResult.itemOverrides).length > 0) {
+        const overrideResult = applyResolvedItemOverrides(actorItems, mappingResult.itemOverrides);
+        appliedItemOverrides = overrideResult.appliedCount;
+        unappliedItemOverrideNames = overrideResult.unappliedSourceNames;
+        mappingResult.actorData.items = actorItems;
+
+        if (overrideResult.unappliedSourceNames.length > 0) {
+          warnings.push(
+            `Unapplied value overrides (${overrideResult.unappliedSourceNames.length}): ${overrideResult.unappliedSourceNames.join(', ')}`
+          );
+        }
+      }
+
+      if (strict && unresolvedItemNames.length > 0) {
+        throw new Error(
+          `Strict import aborted because ${unresolvedItemNames.length} item names could not be resolved.`
+        );
+      }
+
+      const creationResult = await this.foundryClient.query('foundry-mcp-bridge.createActorFromData', {
+        actorData: sanitizeActorPayload(mappingResult.actorData),
+        addToScene,
+        updateExisting,
+        existingActorIdentifier: existingActorIdentifier ?? String(mappingResult.actorData.name ?? ''),
+        ...(updateExisting ? { preserveItemTypes: ['species', 'culture', 'career'] } : {}),
+      });
+
+      const actor = isRecord(creationResult) && isRecord(creationResult.actor)
+        ? creationResult.actor
+        : {};
+
+      return {
+        success: true,
+        summary: `Imported actor "${String(actor.name ?? mappingResult.actorData.name)}" using ${selectedFormat}.`,
+        import: {
+          selectedFormat,
+          detectedFormat,
+          strategy,
+          resolveItems,
+          updateExisting,
+          existingActorIdentifier,
+          strict,
+          source: filePath ? `file:${filePath}` : 'jsonPayload',
+        },
+        actor,
+        warnings,
+        unmappedFields: mappingResult.unmappedFields,
+        unresolvedItemNames,
+        valueOverrides: {
+          total: Object.keys(mappingResult.itemOverrides).length,
+          applied: appliedItemOverrides,
+          unapplied: unappliedItemOverrideNames.length,
+          unappliedNames: unappliedItemOverrideNames,
+        },
+        message:
+          `Import completed via ${selectedFormat}.\n` +
+          `Warnings: ${warnings.length}\n` +
+          `Unmapped root fields: ${mappingResult.unmappedFields.length}`,
+      };
+    } catch (error) {
+      this.errorHandler.handleToolError(error, 'import-dsa5-actor-from-json', 'JSON import');
+    }
+  }
+
+  private async assertDsa5World(): Promise<void> {
+    const worldInfo = await this.foundryClient.query('foundry-mcp-bridge.getWorldInfo');
+    const systemIdRaw =
+      isRecord(worldInfo) && typeof worldInfo.system === 'string' ? worldInfo.system : undefined;
+    const systemId = systemIdRaw?.toLowerCase();
+
+    if (systemId && systemId !== 'dsa5') {
+      throw new Error(
+        `import-dsa5-actor-from-json supports only DSA5 worlds. Detected system: ${systemIdRaw}.`
+      );
+    }
+  }
+
+  private async resolveItemsByName(itemNames: string[]): Promise<ResolvedItemsResult> {
+    const unique = uniqueNames(itemNames).slice(0, 120);
+    const resolvedItems: JsonRecord[] = [];
+    const unresolved: string[] = [];
+
+    for (const candidateName of unique) {
+      try {
+        const searchCandidates = getSearchCandidates(candidateName);
+        let selected: unknown;
+
+        for (const searchName of searchCandidates) {
+          const searchResponse = await this.foundryClient.query('foundry-mcp-bridge.searchCompendium', {
+            query: searchName,
+            packType: 'Item',
+          });
+
+          if (!Array.isArray(searchResponse) || searchResponse.length === 0) {
+            continue;
+          }
+
+          const exact = searchResponse.find((entry: unknown) => {
+            if (!isRecord(entry)) return false;
+            const name = toStringValue(entry.name);
+            if (!name) return false;
+            const normalizedItemName = normalizeName(name);
+            return (
+              normalizedItemName === normalizeName(candidateName) ||
+              normalizedItemName === normalizeName(searchName)
+            );
+          });
+
+          // Avoid false positives like mapping "Piken" -> "Pikenwall".
+          // Only accept normalized exact matches and treat all other hits as unresolved.
+          selected = exact;
+          if (selected) break;
+        }
+
+        if (!isRecord(selected)) {
+          unresolved.push(candidateName);
+          continue;
+        }
+
+        const packId = toStringValue(selected.pack);
+        const itemId = toStringValue(selected.id);
+        if (!packId || !itemId) {
+          unresolved.push(candidateName);
+          continue;
+        }
+
+        const full = await this.foundryClient.query('foundry-mcp-bridge.getCompendiumDocumentFull', {
+          packId,
+          documentId: itemId,
+        });
+
+        if (!isRecord(full) || !isRecord(full.fullData)) {
+          unresolved.push(candidateName);
+          continue;
+        }
+
+        const itemData = sanitizeEmbeddedDocuments([full.fullData])[0];
+        if (!itemData) {
+          unresolved.push(candidateName);
+          continue;
+        }
+
+        resolvedItems.push(itemData);
+      } catch (error) {
+        this.logger.warn('Item resolution failed during import', {
+          candidateName,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        unresolved.push(candidateName);
+      }
+    }
+
+    return {
+      items: resolvedItems,
+      unresolvedNames: unresolved,
+      resolvedCount: resolvedItems.length,
+    };
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/shared",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Shared TypeScript types and constants for Foundry MCP Integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

This PR adds a native HTTP transport to the MCP backend, letting local LLM clients like LM Studio connect alongside Claude Desktop — no Docker, no translation layer, no internet tunnel.

**This branch also includes the DSA5 JSON actor importer from [PR #34](https://github.com/adambdooley/foundry-vtt-mcp/pull/34)** so testers can exercise both features from a single installer. PR #34 should be reviewed/merged first; this PR's HTTP-specific changes are in the second commit.

Replaces the HTTP bridge / Docker approach proposed in @frankyh75's PR #23 with a simpler native implementation per his clarification (local LLM only, no ChatGPT).

## What's in this PR

### DSA5 JSON actor importer (from PR #34)
See [PR #34](https://github.com/adambdooley/foundry-vtt-mcp/pull/34) for details. New tool \`import-dsa5-actor-from-json\` plus core additions (\`getPackIndex\`, \`createActorFromData\`).

### Native HTTP transport (new in this PR)
Optional HTTP endpoint gated by \`MCP_HTTP_ENABLED=true\`. Extracts the tool dispatch logic into a shared \`dispatchTool()\` function called by both the existing TCP socket (for Claude Desktop via stdio wrapper) and the new HTTP handler.

**Configuration (environment variables):**
| Variable | Default | Purpose |
|---|---|---|
| \`MCP_HTTP_ENABLED\` | \`false\` | Enable HTTP transport |
| \`MCP_HTTP_HOST\` | \`127.0.0.1\` | Bind address (localhost only by default) |
| \`MCP_HTTP_PORT\` | \`3333\` | Listen port |
| \`MCP_HTTP_AUTH_TOKEN\` | _unset_ | Optional bearer token — required on every request when set |

**Endpoints:**
- \`GET /health\` — returns \`{"status":"ok","toolCount":N}\`
- \`POST /mcp\` — JSON-RPC 2.0 (\`tools/list\`, \`tools/call\`)

## Security model (local LLM only — NOT internet-facing)

Three defences:

1. **Binds to 127.0.0.1 by default** — not reachable from the network. Users must deliberately change \`MCP_HTTP_HOST\` to expose it, and doing so without a token is strongly discouraged.
2. **Origin check** — only requests with an Origin of \`localhost\`, \`127.0.0.1\`, \`::1\`, or no Origin header (curl, native clients) are accepted. Blocks drive-by browser attacks from malicious webpages.
3. **Optional bearer token** — if \`MCP_HTTP_AUTH_TOKEN\` is set, required on every request via \`Authorization: Bearer <token>\`.

Designed for localhost LM Studio / Ollama bridge scenarios, not for ChatGPT or remote exposure. Exposing to the internet requires OAuth and is explicitly out of scope.

## LM Studio configuration

In LM Studio's \`mcp.json\` (at \`%USERPROFILE%/.lmstudio/mcp.json\` on Windows, \`~/.lmstudio/mcp.json\` on Mac/Linux):

\`\`\`json
{
  "mcpServers": {
    "foundry-mcp": {
      "url": "http://127.0.0.1:3333/mcp"
    }
  }
}
\`\`\`

Claude Desktop continues to work unchanged via stdio — both clients can run simultaneously against the same backend/Foundry connection.

## Test plan

- [x] Manual: \`/health\` returns tool count
- [x] Manual: \`tools/list\` returns full tool list
- [x] Manual: Origin header check rejects \`https://evil.com\` with 403
- [x] Manual: Missing/wrong bearer token → 401; correct token → 200
- [x] TypeScript build passes
- [ ] Manual: End-to-end with LM Studio calling a tool
- [ ] Manual: Claude Desktop and LM Studio running simultaneously

## Not included (separate PRs)
- Web UI for enabling/configuring HTTP in the Foundry module settings (env vars only for now)
- NSIS/Mac installer UI for HTTP configuration
- OAuth / internet exposure (different threat model — explicit non-goal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)