### PR TITLE
v0.8.0: Foundry v14 support and Mac installer fixes

### DIFF
--- a/.github/workflows/build-complete-release.yml
+++ b/.github/workflows/build-complete-release.yml
@@ -450,7 +450,9 @@ jobs:
 
           Complete multi-platform distribution for Foundry MCP Server - AI-powered campaign management for Foundry VTT using Claude Desktop.
 
-          ### 📦 Installation Options
+          **Compatible with Foundry VTT v13 and v14.**
+
+          ### Installation Options
 
           **Windows Users:**
           - Download `FoundryMCPServer-Setup-${{ github.ref_name }}.exe`
@@ -473,14 +475,14 @@ jobs:
           - Install directly from Foundry's module browser
           - Or use manifest: `https://raw.githubusercontent.com/adambdooley/foundry-vtt-mcp/master/packages/foundry-module/module.json`
 
-          ### 🚀 Quick Start
+          ### Quick Start
           1. Choose your installation method above
           2. Install MCP Bridge module in Foundry VTT
           3. Restart Claude Desktop
           4. Start creating AI-powered campaigns!
 
-          ### 📋 Features
-          - 25 MCP tools for comprehensive Foundry VTT integration
+          ### Features
+          - 36 MCP tools for comprehensive Foundry VTT integration
           - Actor creation with natural language processing
           - Quest management with HTML generation and updates
           - Campaign system with multi-part structure and progress tracking

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -27,7 +27,7 @@ This guide covers the complete installation of the Foundry VTT AI Model Integrat
 ### Option 2: Manual Installation
 
 #### Install the Foundry Module
-1. Open Foundry VTT v13
+1. Open Foundry VTT (v13 or v14)
 2. Select install module in the Foundry Add-ons menu
 2. At the bottom of the window, add the Manifest URL as: https://github.com/adambdooley/foundry-vtt-mcp/blob/master/packages/foundry-module/module.json and click install
 3. Enable "Foundry MCP Bridge" in Module Management

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project was built with the assistance of Claude Code. If you like this proj
 
 ### Prerequisites
 
-- **Foundry VTT v13** 
+- **Foundry VTT v13 or v14**
 - **Claude Desktop** with MCP support
 - **Windows** (for automated installer) or **Node.js 18+** for manual installation
 
@@ -51,7 +51,7 @@ This project was built with the assistance of Claude Code. If you like this proj
 ### Option 3: Manual Installation
 
 #### Install the Foundry Module
-1. Open Foundry VTT v13
+1. Open Foundry VTT (v13 or v14)
 2. Select install module in the Foundry Add-ons menu
 2. At the bottom of the window, add the Manifest URL as: https://github.com/adambdooley/foundry-vtt-mcp/blob/master/packages/foundry-module/module.json and click install
 3. Enable "Foundry MCP Bridge" in Module Management

--- a/installer/Uninstall.tool
+++ b/installer/Uninstall.tool
@@ -263,9 +263,9 @@ fi
 echo "🗑️  Removing package receipts..."
 
 PKG_IDS=(
-    "com.foundry-mcp.server.core"
-    "com.foundry-mcp.server.foundry-module"
-    "com.foundry-mcp.server.comfyui"
+    "com.foundry-mcp.core"
+    "com.foundry-mcp.foundry-module"
+    "com.foundry-mcp.comfyui"
 )
 
 REMOVED_PKG_COUNT=0

--- a/installer/mac/setup-comfyui-headless.js
+++ b/installer/mac/setup-comfyui-headless.js
@@ -116,7 +116,7 @@ function downloadFile(url, dest, displayName) {
     log(`📥 Downloading ${displayName}...`);
     log(`   URL: ${url}`);
 
-    const curlCommand = `curl -L -o "${dest}" "${url}" --fail --max-time 600`;
+    const curlCommand = `curl -L -o "${dest}" "${url}" --fail --connect-timeout 30 --speed-time 60 --speed-limit 10240`;
 
     try {
       log(`   Starting download...`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundry-mcp-integration",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "MCP server that bridges Foundry VTT game data with Claude Desktop",
   "private": true,
   "workspaces": [

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -2,11 +2,11 @@
   "id": "foundry-mcp-bridge",
   "title": "Foundry MCP Bridge",
   "description": "Connect Foundry VTT to AI models through MCP protocol. Enable AI-powered actor creation, intelligent compendium search, campaign analysis, and interactive dice roll coordination. Supports Claude, local LLMs, and future AI models with comprehensive GM-only security.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {

--- a/packages/foundry-module/package.json
+++ b/packages/foundry-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/module",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Foundry VTT module for MCP bridge integration",
   "type": "module",
   "scripts": {

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -1165,19 +1165,24 @@ export class FoundryDataAccess {
           system: this.sanitizeData(item.system),
         };
       }),
-      effects: actor.effects.map(effect => ({
-        id: effect.id,
-        name: (effect as any).name || (effect as any).label || 'Unknown Effect',
-        ...((effect as any).icon ? { icon: (effect as any).icon } : {}),
-        disabled: (effect as any).disabled,
-        ...(((effect as any).duration) ? {
-          duration: {
-            type: (effect as any).duration.type || 'none',
-            duration: (effect as any).duration.duration,
-            remaining: (effect as any).duration.remaining,
-          }
-        } : {}),
-      })),
+      effects: actor.effects.map(effect => {
+        const eff = effect as any;
+        const dur = eff.duration;
+        const durRaw = eff._source?.duration;
+        return {
+          id: effect.id,
+          name: eff.name || eff.label || 'Unknown Effect',
+          ...(eff.icon ? { icon: eff.icon } : {}),
+          disabled: eff.disabled,
+          ...(dur ? {
+            duration: {
+              type: dur.units ?? durRaw?.type ?? 'none',
+              duration: dur.seconds ?? durRaw?.duration,
+              remaining: dur.remaining,
+            }
+          } : {}),
+        };
+      }),
     };
 
     // Add PF2e-specific data if available
@@ -1367,7 +1372,8 @@ export class FoundryDataAccess {
       // Spell-specific fields
       if (item.type === 'spell') {
         result.level = itemSystem?.level?.value ?? itemSystem?.level ?? itemSystem?.rank ?? 0;
-        result.prepared = itemSystem?.preparation?.prepared ?? itemSystem?.location?.prepared;
+        const itemRaw = (item as any)._source?.system;
+        result.prepared = itemSystem?.prepared ?? itemRaw?.preparation?.prepared ?? itemSystem?.location?.prepared;
         result.expended = itemSystem?.location?.expended;
 
         // Get targeting info
@@ -1642,7 +1648,11 @@ export class FoundryDataAccess {
 
       for (const spell of spellItems) {
         const spellSystem = spell.system as any;
-        const sourceClass = spellSystem?.sourceClass || 'general';
+        const spellRaw = (spell as any)._source?.system || spellSystem;
+        const sourceItem = spellSystem?.sourceItem;
+        const sourceClass = (sourceItem
+          ? (typeof sourceItem === 'string' ? sourceItem : (sourceItem.identifier || sourceItem.id))
+          : spellRaw?.sourceClass) || 'general';
 
         if (!spellsByClass[sourceClass]) {
           spellsByClass[sourceClass] = [];
@@ -1653,7 +1663,7 @@ export class FoundryDataAccess {
           id: spell.id || '',
           name: spell.name || '',
           level: spellSystem?.level || 0,
-          prepared: spellSystem?.preparation?.prepared ?? true,
+          prepared: spellSystem?.prepared ?? spellRaw?.preparation?.prepared ?? true,
           traits: [], // D&D 5e doesn't use traits the same way
           actionCost: spellSystem?.activation?.type || undefined,
           range: targeting.range,
@@ -2823,7 +2833,7 @@ export class FoundryDataAccess {
       id: scene.id,
       name: scene.name,
       img: scene.img || undefined,
-      background: scene.background?.src || undefined,
+      background: scene._source?.background?.src || undefined,
       width: scene.width,
       height: scene.height,
       padding: scene.padding,
@@ -2947,20 +2957,37 @@ export class FoundryDataAccess {
 
       // Create a new sanitized object
       const sanitized: any = {};
-      
-      for (const [key, value] of Object.entries(obj)) {
+
+      // Use Object.keys (does not invoke getters) so we can filter deprecated
+      // accessor properties before reading their values.
+      const keys = Object.keys(obj);
+
+      // dnd5e 5.3 moved senses.darkvision/blindsight/tremorsense/truesight to
+      // senses.ranges.*. The legacy keys remain as deprecated getters that
+      // log a warning when read. Detect this shape and skip the legacy keys.
+      const DEPRECATED_DND5E_SENSE_KEYS = ['darkvision', 'blindsight', 'tremorsense', 'truesight'];
+      const isDnd5eSensesShape = keys.includes('ranges') &&
+        keys.some(k => DEPRECATED_DND5E_SENSE_KEYS.includes(k));
+
+      for (const key of keys) {
         // Skip sensitive and problematic fields entirely
         if (this.isSensitiveOrProblematicField(key)) {
           continue;
         }
 
-        // Skip most private properties except essential ones
-        if (key.startsWith('_') && !['_id', '_stats', '_source'].includes(key)) {
+        // Skip most private properties except essential ones.
+        // _stats (Foundry document audit metadata) and _source (raw stored data
+        // duplicate) are bloat in tool output; we keep only _id.
+        if (key.startsWith('_') && key !== '_id') {
           continue;
         }
 
-        // Recursively sanitize the value
-        sanitized[key] = this.removeSensitiveFields(value, visited, depth + 1);
+        if (isDnd5eSensesShape && DEPRECATED_DND5E_SENSE_KEYS.includes(key)) {
+          continue;
+        }
+
+        // Recursively sanitize the value (read only after filter to avoid getter-triggered warnings)
+        sanitized[key] = this.removeSensitiveFields((obj as any)[key], visited, depth + 1);
       }
 
       return sanitized;
@@ -2982,7 +3009,10 @@ export class FoundryDataAccess {
 
     const problematicKeys = [
       'parent', '_parent', 'collection', 'apps', 'document', '_document',
-      'constructor', 'prototype', '__proto__', 'valueOf', 'toString'
+      'constructor', 'prototype', '__proto__', 'valueOf', 'toString',
+      // dnd5e item leveling metadata; full of cycles back to the actor and other items.
+      // Not gameplay-relevant for LLM consumers.
+      'advancement'
     ];
 
     // Skip deprecated ability save properties that trigger warnings
@@ -5027,7 +5057,7 @@ export class FoundryDataAccess {
           height: scene.dimensions?.height || (scene as any).height || 0
         },
         gridSize: scene.grid?.size || 100,
-        background: scene.background?.src || scene.img || '',
+        background: scene._source?.background?.src || scene.img || '',
         walls: scene.walls?.size || 0,
         tokens: scene.tokens?.size || 0,
         lighting: scene.lights?.size || 0,

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "MCP server for Foundry VTT integration with Claude Desktop",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -558,10 +558,19 @@ export class CharacterTools {
     }
 
     // Race/ancestry information
+    // dnd5e 4.x+ stores race as an embedded item document; collapse to just the
+    // identifying name to avoid dumping the full item (HTML description, advancement,
+    // circular refs). Older data may store a plain string, which we pass through.
     if (system.details?.race) {
-      basicInfo.race = system.details.race;
+      const race = system.details.race;
+      basicInfo.race = typeof race === 'string'
+        ? race
+        : (race.name || race.identifier || race._id || 'Unknown');
     } else if (system.details?.ancestry) {
-      basicInfo.ancestry = system.details.ancestry;
+      const ancestry = system.details.ancestry;
+      basicInfo.ancestry = typeof ancestry === 'string'
+        ? ancestry
+        : (ancestry.name || ancestry.identifier || ancestry._id || 'Unknown');
     }
 
     return basicInfo;

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/shared",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Shared TypeScript types and constants for Foundry MCP Integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- **Foundry v14 compatibility**: bump module compatibility to v14, fix `Scene#background`, `SpellData` (sourceClass/preparation), `ActiveEffectDuration` (units/seconds), and dnd5e senses deprecations
- **Reduce get-character bloat**: strip `_stats` and `advancement` from sanitized output, collapse race/ancestry to identifying name
- **Fix Mac installer version stamping**: pass VERSION env to build scripts so PKGs aren't built with stale package.json default — this was the root cause of the v0.7.0 install issue (macOS skipped ComfyUI postinstall because the package version hadn't changed)
- **Fix Uninstall.tool package identifiers** so receipts are properly cleared on uninstall
- **Replace curl --max-time 600** with `--connect-timeout`/`--speed-time`/`--speed-limit` so the 6.5GB model downloads aren't capped at 10 minutes
- **Docs**: README and INSTALLATION now mention v13/v14 compatibility; release-notes template tool count fixed (25 → 36)

## Test plan
- [ ] CI Mac DMG build succeeds
- [ ] CI Windows EXE build succeeds
- [ ] Download Mac DMG artifact, install with ComfyUI selected — verify ComfyUI postinstall runs (download takes 20-30 min)
- [ ] Verify Foundry module loads in v14, no deprecation warnings on get-character / list-scenes / search-character-items
- [ ] Verify get-character returns derived values (AC, HP, ability modifiers) and lean response shape