### PR TITLE
feat: add cosmere rpg system support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3432,6 +3432,305 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.46.2",
       "cpu": [
@@ -3576,16 +3875,6 @@
         "@types/deep-eql": "*"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "dev": true,
@@ -3614,13 +3903,6 @@
       "version": "7.0.15",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/node": {
       "version": "20.19.10",
@@ -6550,6 +6832,21 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -114,8 +114,38 @@ interface PF2eCreatureIndex {
   img?: string;
 }
 
-// Union type for both systems
-type EnhancedCreatureIndex = DnD5eCreatureIndex | PF2eCreatureIndex;
+// Cosmere RPG (Plotweaver) Enhanced Creature Index
+//
+// Plotweaver categorises adversaries by `tier` (1-4) and `role`
+// (minion/rival/boss) rather than CR or level — those are the primary
+// encounter-design dials. Defenses are split into phy/cog/spi instead
+// of a single AC, and Investiture is the Surge/Stormlight resource.
+interface CosmereRpgCreatureIndex {
+  id: string;
+  name: string;
+  type: string;                     // 'adversary' for compendium creatures
+  pack: string;
+  packLabel: string;
+  tier: number;                     // 1-4
+  role: string;                     // minion | rival | boss | (system-extended)
+  creatureType: string;             // humanoid | animal | spren | …
+  subtype: string;                  // free-form secondary type
+  size: string;
+  hitPoints: number;                // resources.hea.max (override-aware)
+  focus: number;                    // resources.foc.max
+  investiture: number;              // resources.inv.max — typically 0
+  hasInvestiture: boolean;
+  defensePhysical: number;
+  defenseCognitive: number;
+  defenseSpiritual: number;
+  deflect: number;
+  walkSpeed: number;
+  description?: string;
+  img?: string;
+}
+
+// Union type across all supported systems
+type EnhancedCreatureIndex = DnD5eCreatureIndex | PF2eCreatureIndex | CosmereRpgCreatureIndex;
 
 interface PersistentIndexMetadata {
   version: string;
@@ -571,9 +601,11 @@ class PersistentCreatureIndex {
       return await this.buildPF2eIndex(force);
     } else if (gameSystem === 'dnd5e') {
       return await this.buildDnD5eIndex(force);
+    } else if (gameSystem === 'cosmere-rpg') {
+      return await this.buildCosmereRpgIndex(force);
     } else {
       throw new Error(
-        `Enhanced creature index not supported for system: ${gameSystem}. Only D&D 5e and Pathfinder 2e are currently supported.`
+        `Enhanced creature index not supported for system: ${gameSystem}. Only D&D 5e, Pathfinder 2e, and Cosmere RPG are currently supported.`
       );
     }
   }
@@ -1175,6 +1207,260 @@ class PersistentCreatureIndex {
           armorClass: 10,
           hasSpells: false,
           alignment: 'N',
+          description: 'Data extraction failed',
+          img: doc.img || '',
+        },
+        errors: 1,
+      };
+    }
+  }
+
+  /**
+   * Build Cosmere RPG (Plotweaver) enhanced creature index.
+   *
+   * Indexes `adversary`-type actors. Player characters are excluded —
+   * they're individual sheets, not encounter material.
+   */
+  private async buildCosmereRpgIndex(_force = false): Promise<CosmereRpgCreatureIndex[]> {
+    this.buildInProgress = true;
+
+    const startTime = Date.now();
+    let progressNotification: any = null;
+    let totalErrors = 0;
+
+    try {
+      const actorPacks = Array.from(game.packs.values()).filter(pack => pack.metadata.type === 'Actor');
+      const enhancedCreatures: CosmereRpgCreatureIndex[] = [];
+      const packFingerprints = new Map<string, PackFingerprint>();
+
+      ui.notifications?.info(`Starting Cosmere RPG creature index build from ${actorPacks.length} packs...`);
+
+      for (let i = 0; i < actorPacks.length; i++) {
+        const pack = actorPacks[i];
+        const progressPercent = Math.round((i / actorPacks.length) * 100);
+
+        if (i % 3 === 0 || pack.metadata.label.toLowerCase().includes('adversar')) {
+          if (progressNotification) {
+            progressNotification.remove();
+          }
+          progressNotification = ui.notifications?.info(
+            `Building creature index... ${progressPercent}% (${i + 1}/${actorPacks.length}) Processing: ${pack.metadata.label}`
+          );
+        }
+
+        try {
+          if (!pack.indexed) {
+            await pack.getIndex({});
+          }
+
+          packFingerprints.set(pack.metadata.id, this.generatePackFingerprint(pack));
+
+          const packResult = await this.extractCosmereRpgDataFromPack(pack);
+          enhancedCreatures.push(...packResult.creatures);
+          totalErrors += packResult.errors;
+
+          if (i === 0 || (i + 1) % 5 === 0 || i === actorPacks.length - 1) {
+            const totalCreaturesSoFar = enhancedCreatures.length;
+            if (progressNotification) {
+              progressNotification.remove();
+            }
+            progressNotification = ui.notifications?.info(
+              `Index Progress: ${i + 1}/${actorPacks.length} packs complete, ${totalCreaturesSoFar} creatures indexed`
+            );
+          }
+        } catch (error) {
+          console.warn(`[${this.moduleId}] Failed to process pack ${pack.metadata.label}:`, error);
+          ui.notifications?.warn(`Warning: Failed to index pack "${pack.metadata.label}" - continuing with other packs`);
+        }
+      }
+
+      if (progressNotification) {
+        progressNotification.remove();
+      }
+      ui.notifications?.info(`Saving enhanced index to world database... (${enhancedCreatures.length} creatures)`);
+
+      const persistentIndex: PersistentEnhancedIndex = {
+        metadata: {
+          version: this.INDEX_VERSION,
+          timestamp: Date.now(),
+          packFingerprints,
+          totalCreatures: enhancedCreatures.length,
+          gameSystem: 'cosmere-rpg',
+        },
+        creatures: enhancedCreatures,
+      };
+
+      await this.savePersistedIndex(persistentIndex);
+
+      const buildTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+      const errorText = totalErrors > 0 ? ` (${totalErrors} extraction errors)` : '';
+      const successMessage = `Cosmere RPG creature index complete! ${enhancedCreatures.length} creatures indexed from ${actorPacks.length} packs in ${buildTimeSeconds}s${errorText}`;
+
+      ui.notifications?.info(successMessage);
+
+      return enhancedCreatures;
+    } catch (error) {
+      if (progressNotification) {
+        progressNotification.remove();
+      }
+
+      const errorMessage = `Failed to build Cosmere RPG creature index: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      console.error(`[${this.moduleId}] ${errorMessage}`);
+      ui.notifications?.error(errorMessage);
+
+      throw error;
+    } finally {
+      this.buildInProgress = false;
+      if (progressNotification) {
+        progressNotification.remove();
+      }
+    }
+  }
+
+  /**
+   * Extract Cosmere RPG creatures from a single pack.
+   */
+  private async extractCosmereRpgDataFromPack(
+    pack: any,
+  ): Promise<{ creatures: CosmereRpgCreatureIndex[]; errors: number }> {
+    const creatures: CosmereRpgCreatureIndex[] = [];
+    let errors = 0;
+
+    try {
+      const documents = await pack.getDocuments();
+
+      for (const doc of documents) {
+        try {
+          if (doc.type !== 'adversary') {
+            continue;
+          }
+
+          const result = this.extractCosmereRpgCreatureData(doc, pack);
+          if (result) {
+            creatures.push(result.creature);
+            errors += result.errors;
+          }
+        } catch (error) {
+          console.warn(
+            `[${this.moduleId}] Failed to extract Cosmere RPG data from ${doc.name} in ${pack.metadata.label}:`,
+            error,
+          );
+          errors++;
+        }
+      }
+    } catch (error) {
+      console.warn(`[${this.moduleId}] Failed to load documents from ${pack.metadata.label}:`, error);
+      errors++;
+    }
+
+    return { creatures, errors };
+  }
+
+  /**
+   * Resolve a Cosmere DerivedValueField (`{value, derived, override?, useOverride, bonus?}`).
+   * Honours `useOverride: true` so manually-typed values (like Investiture max
+   * on a sheet the system can't auto-derive) come through correctly.
+   */
+  private readDerived(field: any): number | undefined {
+    if (field == null) return undefined;
+    if (typeof field === 'number') return field;
+    if (typeof field === 'object') {
+      if (field.useOverride === true && typeof field.override === 'number') {
+        return field.override;
+      }
+      if (typeof field.value === 'number') return field.value;
+      if (typeof field.derived === 'number') return field.derived;
+    }
+    return undefined;
+  }
+
+  /**
+   * Extract a single Cosmere RPG adversary into the creature index format.
+   */
+  private extractCosmereRpgCreatureData(doc: any, pack: any): { creature: CosmereRpgCreatureIndex; errors: number } | null {
+    try {
+      const system = doc.system ?? {};
+
+      const tier = typeof system.tier === 'number' ? system.tier : 0;
+      const role =
+        typeof system.role === 'string' && system.role.length > 0
+          ? system.role.toLowerCase()
+          : 'unknown';
+
+      const size =
+        typeof system.size === 'string' && system.size.length > 0
+          ? system.size.toLowerCase()
+          : 'medium';
+
+      const creatureType =
+        typeof system.type?.id === 'string' && system.type.id.length > 0
+          ? system.type.id.toLowerCase()
+          : 'unknown';
+
+      const subtype =
+        typeof system.type?.subtype === 'string' && system.type.subtype.length > 0
+          ? system.type.subtype
+          : '';
+
+      const hitPoints = this.readDerived(system.resources?.hea?.max) ?? 0;
+      const focus = this.readDerived(system.resources?.foc?.max) ?? 0;
+      const investiture = this.readDerived(system.resources?.inv?.max) ?? 0;
+
+      const defensePhysical = this.readDerived(system.defenses?.phy) ?? 0;
+      const defenseCognitive = this.readDerived(system.defenses?.cog) ?? 0;
+      const defenseSpiritual = this.readDerived(system.defenses?.spi) ?? 0;
+
+      const deflect = this.readDerived(system.deflect) ?? 0;
+      const walkSpeed = this.readDerived(system.movement?.walk?.rate) ?? 0;
+
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          pack: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          tier,
+          role,
+          creatureType,
+          subtype,
+          size,
+          hitPoints,
+          focus,
+          investiture,
+          hasInvestiture: investiture > 0,
+          defensePhysical,
+          defenseCognitive,
+          defenseSpiritual,
+          deflect,
+          walkSpeed,
+          img: doc.img,
+        },
+        errors: 0,
+      };
+    } catch (error) {
+      console.warn(`[${this.moduleId}] Failed to extract Cosmere RPG data from ${doc.name}:`, error);
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          pack: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          tier: 0,
+          role: 'unknown',
+          creatureType: 'unknown',
+          subtype: '',
+          size: 'medium',
+          hitPoints: 0,
+          focus: 0,
+          investiture: 0,
+          hasInvestiture: false,
+          defensePhysical: 0,
+          defenseCognitive: 0,
+          defenseSpiritual: 0,
+          deflect: 0,
+          walkSpeed: 0,
           description: 'Data extraction failed',
           img: doc.img || '',
         },
@@ -2559,17 +2845,17 @@ export class FoundryDataAccess {
         this.passesEnhancedCriteria(creature, criteria)
       );
 
-      // Sort by Level/CR then name for consistent ordering (system-aware)
+      // Sort by power level then name for consistent ordering (system-aware).
+      // Power-level dial: tier (cosmere), level (pf2e), challengeRating (dnd5e).
+      const powerLevel = (c: EnhancedCreatureIndex): number => {
+        if ('tier' in c) return (c as CosmereRpgCreatureIndex).tier;
+        if ('level' in c) return (c as PF2eCreatureIndex).level;
+        return (c as DnD5eCreatureIndex).challengeRating;
+      };
       filteredCreatures.sort((a, b) => {
-        // Get power level (CR for D&D 5e, Level for PF2e)
-        const powerA =
-          'level' in a ? (a as PF2eCreatureIndex).level : (a as DnD5eCreatureIndex).challengeRating;
-        const powerB =
-          'level' in b ? (b as PF2eCreatureIndex).level : (b as DnD5eCreatureIndex).challengeRating;
-
-        if (powerA !== powerB) {
-          return powerA - powerB; // Lower power first
-        }
+        const powerA = powerLevel(a);
+        const powerB = powerLevel(b);
+        if (powerA !== powerB) return powerA - powerB;
         return a.name.localeCompare(b.name);
       });
 
@@ -2580,10 +2866,10 @@ export class FoundryDataAccess {
 
       // Convert enhanced creatures to result format (system-aware)
       const results = filteredCreatures.map(creature => {
-        // Type guard for result formatting
-        const isPF2e = 'level' in creature;
+        const isCosmere = 'tier' in creature;
+        const isPF2e = !isCosmere && 'level' in creature;
 
-        return {
+        const base = {
           id: creature.id,
           name: creature.name,
           type: creature.type,
@@ -2591,30 +2877,55 @@ export class FoundryDataAccess {
           packLabel: creature.packLabel,
           description: creature.description || '',
           hasImage: !!creature.img,
-
-          // System-aware summary
-          summary: isPF2e
-            ? `Level ${(creature as PF2eCreatureIndex).level} ${creature.creatureType} (${(creature as PF2eCreatureIndex).rarity}) from ${creature.packLabel}`
-            : `CR ${(creature as DnD5eCreatureIndex).challengeRating} ${creature.creatureType} from ${creature.packLabel}`,
-
-          // Include all creature data (conditional based on system)
-          ...(isPF2e
-            ? {
-                level: (creature as PF2eCreatureIndex).level,
-                traits: (creature as PF2eCreatureIndex).traits,
-                rarity: (creature as PF2eCreatureIndex).rarity,
-              }
-            : {
-                challengeRating: (creature as DnD5eCreatureIndex).challengeRating,
-                hasLegendaryActions: (creature as DnD5eCreatureIndex).hasLegendaryActions,
-              }),
-
           creatureType: creature.creatureType,
           size: creature.size,
           hitPoints: creature.hitPoints,
-          armorClass: creature.armorClass,
-          hasSpells: creature.hasSpells,
-          alignment: creature.alignment,
+        };
+
+        if (isCosmere) {
+          const c = creature as CosmereRpgCreatureIndex;
+          return {
+            ...base,
+            summary: `Tier ${c.tier} ${c.role} ${c.creatureType} from ${c.packLabel}`,
+            tier: c.tier,
+            role: c.role,
+            subtype: c.subtype,
+            focus: c.focus,
+            investiture: c.investiture,
+            hasInvestiture: c.hasInvestiture,
+            defenses: {
+              physical: c.defensePhysical,
+              cognitive: c.defenseCognitive,
+              spiritual: c.defenseSpiritual,
+            },
+            deflect: c.deflect,
+            walkSpeed: c.walkSpeed,
+          };
+        }
+
+        if (isPF2e) {
+          const p = creature as PF2eCreatureIndex;
+          return {
+            ...base,
+            armorClass: p.armorClass,
+            hasSpells: p.hasSpells,
+            alignment: p.alignment,
+            summary: `Level ${p.level} ${p.creatureType} (${p.rarity}) from ${p.packLabel}`,
+            level: p.level,
+            traits: p.traits,
+            rarity: p.rarity,
+          };
+        }
+
+        const d = creature as DnD5eCreatureIndex;
+        return {
+          ...base,
+          armorClass: d.armorClass,
+          hasSpells: d.hasSpells,
+          alignment: d.alignment,
+          summary: `CR ${d.challengeRating} ${d.creatureType} from ${d.packLabel}`,
+          challengeRating: d.challengeRating,
+          hasLegendaryActions: d.hasLegendaryActions,
         };
       });
 
@@ -2661,15 +2972,89 @@ export class FoundryDataAccess {
   }
 
   /**
-   * Check if enhanced creature passes all specified criteria (system-aware routing)
+   * Check if enhanced creature passes all specified criteria (system-aware routing).
+   *
+   * Discriminator order matters: cosmere-rpg has a `tier` field, pf2e has
+   * `level`, dnd5e has `challengeRating`. Check cosmere first (tier is the
+   * narrowest signal), then pf2e, then fall through to dnd5e.
    */
   private passesEnhancedCriteria(creature: EnhancedCreatureIndex, criteria: any): boolean {
-    // Type guard for PF2e creatures - check for level property
+    if ('tier' in creature) {
+      return this.passesCosmereRpgCriteria(creature as CosmereRpgCreatureIndex, criteria);
+    }
     if ('level' in creature) {
       return this.passesPF2eCriteria(creature as PF2eCreatureIndex, criteria);
-    } else {
-      return this.passesDnD5eCriteria(creature as DnD5eCreatureIndex, criteria);
     }
+    return this.passesDnD5eCriteria(creature as DnD5eCreatureIndex, criteria);
+  }
+
+  /**
+   * Cosmere RPG criteria filter — tier, role, creatureType, size,
+   * hasInvestiture, hitPoints range, defenses minimums, deflect minimum.
+   */
+  private passesCosmereRpgCriteria(creature: CosmereRpgCreatureIndex, criteria: {
+    tier?: number | { min?: number; max?: number };
+    role?: string;
+    creatureType?: string;
+    size?: string;
+    hasInvestiture?: boolean;
+    hitPoints?: number | { min?: number; max?: number };
+    health?: number | { min?: number; max?: number };
+    defensesMin?: { phy?: number; cog?: number; spi?: number };
+    deflectMin?: number;
+  }): boolean {
+    if (criteria.tier !== undefined) {
+      if (typeof criteria.tier === 'number') {
+        if (creature.tier !== criteria.tier) return false;
+      } else {
+        const { min, max } = criteria.tier;
+        if (min !== undefined && creature.tier < min) return false;
+        if (max !== undefined && creature.tier > max) return false;
+      }
+    }
+
+    if (criteria.role && creature.role.toLowerCase() !== criteria.role.toLowerCase()) {
+      return false;
+    }
+
+    if (criteria.creatureType && creature.creatureType.toLowerCase() !== criteria.creatureType.toLowerCase()) {
+      return false;
+    }
+
+    if (criteria.size && creature.size.toLowerCase() !== criteria.size.toLowerCase()) {
+      return false;
+    }
+
+    if (criteria.hasInvestiture !== undefined && creature.hasInvestiture !== criteria.hasInvestiture) {
+      return false;
+    }
+
+    // Accept either `hitPoints` or `health` from callers — they're synonyms
+    // here (hitPoints is the cross-system convention; health is the cosmere-
+    // native term).
+    const hpRange = criteria.hitPoints ?? criteria.health;
+    if (hpRange !== undefined) {
+      if (typeof hpRange === 'number') {
+        if (creature.hitPoints !== hpRange) return false;
+      } else {
+        const { min, max } = hpRange;
+        if (min !== undefined && creature.hitPoints < min) return false;
+        if (max !== undefined && creature.hitPoints > max) return false;
+      }
+    }
+
+    if (criteria.defensesMin) {
+      const { phy, cog, spi } = criteria.defensesMin;
+      if (phy !== undefined && creature.defensePhysical < phy) return false;
+      if (cog !== undefined && creature.defenseCognitive < cog) return false;
+      if (spi !== undefined && creature.defenseSpiritual < spi) return false;
+    }
+
+    if (criteria.deflectMin !== undefined && creature.deflect < criteria.deflectMin) {
+      return false;
+    }
+
+    return true;
   }
 
   /**

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4293,6 +4293,105 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Add one or more freshly-authored Item documents to an existing Actor.
+   *
+   * Unlike `createActorFromCompendium*`, the items here are constructed from
+   * caller-supplied data — no compendium lookup. This is the path used to
+   * push planner-authored content (talents, actions, powers, custom gear)
+   * onto a PC or NPC sheet.
+   *
+   * Validation is intentionally light: name + type are required, and the
+   * type is checked against the active system's declared Item document
+   * types when available. Everything else (system schema validation,
+   * required sub-fields) is delegated to Foundry's DataModel layer, which
+   * will fill defaults or throw a meaningful error.
+   */
+  async addActorItems(params: {
+    actorIdentifier: string;
+    items: Array<{
+      name: string;
+      type: string;
+      img?: string;
+      system?: Record<string, any>;
+    }>;
+  }): Promise<{
+    actorId: string;
+    actorName: string;
+    created: Array<{ id: string; name: string; type: string }>;
+  }> {
+    this.validateFoundryState();
+
+    const { actorIdentifier, items } = params;
+
+    if (!actorIdentifier) {
+      throw new Error('actorIdentifier is required');
+    }
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new Error('items array is required and must contain at least one entry');
+    }
+
+    const actor = this.findActorByIdentifier(actorIdentifier);
+    if (!actor) {
+      throw new Error(`Actor not found: ${actorIdentifier}`);
+    }
+
+    // Discover the active system's declared Item types so we can give a
+    // useful error before sending the doc to Foundry's DataModel layer.
+    const itemDocTypes = (game as any).system?.documentTypes?.Item;
+    const validTypes: string[] | null =
+      itemDocTypes && typeof itemDocTypes === 'object' ? Object.keys(itemDocTypes) : null;
+
+    const payload = items.map((it, idx) => {
+      if (!it || typeof it.name !== 'string' || it.name.trim().length === 0) {
+        throw new Error(`items[${idx}]: "name" is required and must be a non-empty string`);
+      }
+      if (typeof it.type !== 'string' || it.type.trim().length === 0) {
+        throw new Error(`items[${idx}] ("${it.name}"): "type" is required`);
+      }
+      if (validTypes && !validTypes.includes(it.type)) {
+        throw new Error(
+          `items[${idx}] ("${it.name}"): unknown type "${it.type}" for system "${(game.system as any)?.id}". ` +
+            `Valid Item types: ${validTypes.join(', ')}`
+        );
+      }
+
+      const doc: Record<string, any> = { name: it.name, type: it.type };
+      if (it.img) doc.img = it.img;
+      if (it.system && typeof it.system === 'object') doc.system = it.system;
+      return doc;
+    });
+
+    try {
+      const created = await actor.createEmbeddedDocuments('Item', payload);
+
+      const result = {
+        actorId: actor.id,
+        actorName: actor.name,
+        created: (created || []).map((doc: any) => ({
+          id: doc.id,
+          name: doc.name,
+          type: doc.type,
+        })),
+      };
+
+      this.auditLog(
+        'addActorItems',
+        { actorIdentifier, actorId: actor.id, count: payload.length },
+        'success'
+      );
+      return result;
+    } catch (error) {
+      this.auditLog(
+        'addActorItems',
+        { actorIdentifier, actorId: actor.id, count: payload.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Get full compendium document with all embedded data
    */
   async getCompendiumDocumentFull(

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4186,7 +4186,8 @@ export class FoundryDataAccess {
       }
 
       // Validate actor type - support all common actor types including DSA5 creatures
-      const validActorTypes = ['character', 'npc', 'creature'];
+      // and Cosmere RPG adversaries.
+      const validActorTypes = ['character', 'npc', 'creature', 'adversary'];
       if (!validActorTypes.includes(sourceDocument.type)) {
         throw new Error(
           `Document "${itemId}" has unsupported actor type: ${sourceDocument.type}. Supported types: ${validActorTypes.join(', ')}`

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -111,6 +111,9 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.searchCharacterItems`] =
       this.handleSearchCharacterItems.bind(this);
 
+    // Item authoring on actor sheets
+    CONFIG.queries[`${modulePrefix}.addActorItems`] = this.handleAddActorItems.bind(this);
+
     // Phase 7: Token manipulation queries
     CONFIG.queries[`${modulePrefix}.move-token`] = this.handleMoveToken.bind(this);
     CONFIG.queries[`${modulePrefix}.update-token`] = this.handleUpdateToken.bind(this);
@@ -1463,4 +1466,41 @@ export class QueryHandlers {
       );
     }
   }
+
+
+  private async handleAddActorItems(data: {
+    actorIdentifier: string;
+    items: Array<{
+      name: string;
+      type: string;
+      img?: string;
+      system?: Record<string, any>;
+    }>;
+  }): Promise<any> {
+    try {
+      // SECURITY: Silent GM validation - writes to actor sheets are GM-only
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data?.actorIdentifier) {
+        throw new Error('actorIdentifier is required');
+      }
+      if (!Array.isArray(data?.items) || data.items.length === 0) {
+        throw new Error('items array is required and must contain at least one entry');
+      }
+
+      return await this.dataAccess.addActorItems({
+        actorIdentifier: data.actorIdentifier,
+        items: data.items,
+      });
+    } catch (error) {
+      throw new Error(`Failed to add actor items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+
 }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1145,11 +1145,13 @@ async function startBackend(): Promise<void> {
   const { DnD5eAdapter } = await import('./systems/dnd5e/adapter.js');
   const { PF2eAdapter } = await import('./systems/pf2e/adapter.js');
   const { DSA5Adapter } = await import('./systems/dsa5/adapter.js');
+  const { CosmereRpgAdapter } = await import('./systems/cosmere-rpg/adapter.js');
 
   const systemRegistry = getSystemRegistry(logger);
   systemRegistry.register(new DnD5eAdapter());
   systemRegistry.register(new PF2eAdapter());
   systemRegistry.register(new DSA5Adapter());
+  systemRegistry.register(new CosmereRpgAdapter());
 
   logger.info('System registry initialized', {
     supportedSystems: systemRegistry.getSupportedSystems(),

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1487,6 +1487,12 @@ async function startBackend(): Promise<void> {
 
                   break;
 
+                case 'add-actor-items':
+
+                  result = await characterTools.handleAddActorItems(args);
+
+                  break;
+
                 // Compendium tools
 
                 case 'search-compendium':

--- a/packages/mcp-server/src/systems/cosmere-rpg/adapter.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/adapter.ts
@@ -7,10 +7,11 @@
  * Scope of this adapter:
  *   - extractBasicInfo: level, tier, health/focus/investiture (current+max+bonus), deflect
  *   - extractCharacterStats: attributes (with pre→prs remap), defenses, skills (rank+mod)
- *   - extractCreatureData: delegates to CosmereRpgIndexBuilder so the
- *     server- and browser-side indexing paths share a single extractor
  *   - Filters: tier / role / creatureType / size / hasInvestiture / health
  *     / defensesMin / deflectMin (see ./filters.ts)
+ *
+ * Index extraction lives in `./index-builder.ts` (browser-context).
+ * `extractCreatureData` here throws to match the dnd5e/pf2e/dsa5 convention.
  */
 
 import type {
@@ -31,23 +32,8 @@ import {
   COSMERE_RESOURCES,
   readDerived,
 } from './constants.js';
-import { CosmereRpgIndexBuilder } from './index-builder.js';
 
 export class CosmereRpgAdapter implements SystemAdapter {
-  /**
-   * Shared extractor used by both extractCreatureData (Node side) and
-   * the browser-side IndexBuilder. Constructed lazily so the adapter is
-   * cheap to instantiate when only character-stat methods are called.
-   */
-  private indexBuilder: CosmereRpgIndexBuilder | null = null;
-
-  private getIndexBuilder(): CosmereRpgIndexBuilder {
-    if (!this.indexBuilder) {
-      this.indexBuilder = new CosmereRpgIndexBuilder();
-    }
-    return this.indexBuilder;
-  }
-
   getMetadata(): SystemMetadata {
     return {
       id: 'cosmere-rpg',
@@ -73,12 +59,8 @@ export class CosmereRpgAdapter implements SystemAdapter {
     return systemId.toLowerCase() === 'cosmere-rpg';
   }
 
-  /**
-   * Delegate to the IndexBuilder so the same extraction logic powers both
-   * the Node-side adapter call and the browser-side index build.
-   */
-  extractCreatureData(doc: any, pack: any): { creature: SystemCreatureIndex; errors: number } | null {
-    return this.getIndexBuilder().extractCreatureData(doc, pack);
+  extractCreatureData(_doc: any, _pack: any): { creature: SystemCreatureIndex; errors: number } | null {
+    throw new Error('extractCreatureData should be called from CosmereRpgIndexBuilder, not the adapter');
   }
 
   getFilterSchema() {

--- a/packages/mcp-server/src/systems/cosmere-rpg/adapter.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/adapter.ts
@@ -1,0 +1,236 @@
+/**
+ * Cosmere RPG System Adapter
+ *
+ * Implements SystemAdapter for the Cosmere RPG Foundry system
+ * (https://github.com/the-metalworks/cosmere-rpg).
+ *
+ * Scope of this adapter:
+ *   - extractBasicInfo: level, tier, health/focus/investiture (current+max+bonus), deflect
+ *   - extractCharacterStats: attributes (with pre→prs remap), defenses, skills (rank+mod)
+ *   - extractCreatureData: delegates to CosmereRpgIndexBuilder so the
+ *     server- and browser-side indexing paths share a single extractor
+ *   - Filters: tier / role / creatureType / size / hasInvestiture / health
+ *     / defensesMin / deflectMin (see ./filters.ts)
+ */
+
+import type {
+  SystemAdapter,
+  SystemMetadata,
+  SystemCreatureIndex,
+  CosmereRpgCreatureIndex,
+} from '../types.js';
+import {
+  CosmereRpgFiltersSchema,
+  matchesCosmereRpgFilters,
+  describeCosmereRpgFilters,
+  type CosmereRpgFilters,
+} from './filters.js';
+import {
+  COSMERE_ATTR_KEYS,
+  COSMERE_DEFENSE_KEYS,
+  COSMERE_RESOURCES,
+  readDerived,
+} from './constants.js';
+import { CosmereRpgIndexBuilder } from './index-builder.js';
+
+export class CosmereRpgAdapter implements SystemAdapter {
+  /**
+   * Shared extractor used by both extractCreatureData (Node side) and
+   * the browser-side IndexBuilder. Constructed lazily so the adapter is
+   * cheap to instantiate when only character-stat methods are called.
+   */
+  private indexBuilder: CosmereRpgIndexBuilder | null = null;
+
+  private getIndexBuilder(): CosmereRpgIndexBuilder {
+    if (!this.indexBuilder) {
+      this.indexBuilder = new CosmereRpgIndexBuilder();
+    }
+    return this.indexBuilder;
+  }
+
+  getMetadata(): SystemMetadata {
+    return {
+      id: 'cosmere-rpg',
+      name: 'cosmere-rpg',
+      displayName: 'Cosmere RPG',
+      version: '1.0.0',
+      description:
+        'Support for the Cosmere RPG (Plotweaver) system: levels/tiers, ' +
+        'attributes (str/spd/int/wil/awa/pre), defenses (phy/cog/spi), ' +
+        'resources (health/focus/investiture), deflect, and skills (rank+mod). ' +
+        'Adversary indexing covers tier, role, creature type, size, defenses, ' +
+        'deflect, and Investiture pool.',
+      supportedFeatures: {
+        creatureIndex: true,
+        characterStats: true,
+        spellcasting: false,  // Surges are modelled as items, not a spellcasting feature
+        powerLevel: true,     // Uses adversary tier (1-4) or character level
+      },
+    };
+  }
+
+  canHandle(systemId: string): boolean {
+    return systemId.toLowerCase() === 'cosmere-rpg';
+  }
+
+  /**
+   * Delegate to the IndexBuilder so the same extraction logic powers both
+   * the Node-side adapter call and the browser-side index build.
+   */
+  extractCreatureData(doc: any, pack: any): { creature: SystemCreatureIndex; errors: number } | null {
+    return this.getIndexBuilder().extractCreatureData(doc, pack);
+  }
+
+  getFilterSchema() {
+    return CosmereRpgFiltersSchema;
+  }
+
+  matchesFilters(creature: SystemCreatureIndex, filters: Record<string, any>): boolean {
+    const validated = CosmereRpgFiltersSchema.safeParse(filters);
+    if (!validated.success) return false;
+    return matchesCosmereRpgFilters(creature as CosmereRpgCreatureIndex, validated.data as CosmereRpgFilters);
+  }
+
+  getDataPaths(): Record<string, string | null> {
+    return {
+      level: 'system.level',
+      tier: 'system.tier',
+      // Cosmere RPG doesn't use D&D-style class/race; leaving null.
+      challengeRating: null,
+      creatureType: 'system.type.id',
+      size: 'system.size',
+      alignment: null,
+      // Resource maxes (DerivedValueFields — read .value)
+      hitPoints: 'system.resources.hea.max.value',
+      armorClass: null, // Defenses replace AC; cosmere splits phys/cog/spi
+      // Cosmere-specific
+      attributes: 'system.attributes',
+      defenses: 'system.defenses',
+      resources: 'system.resources',
+      skills: 'system.skills',
+      deflect: 'system.deflect.value',
+    };
+  }
+
+  formatCreatureForList(creature: SystemCreatureIndex): any {
+    const c = creature as CosmereRpgCreatureIndex;
+    const formatted: any = {
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      pack: { id: c.packName, label: c.packLabel },
+    };
+    if (c.systemData) {
+      const stats: any = {};
+      if (c.systemData.tier !== undefined) stats.tier = c.systemData.tier;
+      if (c.systemData.role) stats.role = c.systemData.role;
+      if (c.systemData.level !== undefined) stats.level = c.systemData.level;
+      if (c.systemData.creatureType) stats.creatureType = c.systemData.creatureType;
+      if (c.systemData.size) stats.size = c.systemData.size;
+      if (c.systemData.health !== undefined) stats.health = c.systemData.health;
+      if (c.systemData.deflect !== undefined) stats.deflect = c.systemData.deflect;
+      if (c.systemData.hasInvestiture) stats.hasInvestiture = true;
+      if (Object.keys(stats).length > 0) formatted.stats = stats;
+    }
+    if (c.img) formatted.hasImage = true;
+    return formatted;
+  }
+
+  formatCreatureForDetails(creature: SystemCreatureIndex): any {
+    const c = creature as CosmereRpgCreatureIndex;
+    const formatted = this.formatCreatureForList(creature);
+    if (c.systemData) {
+      formatted.detailedStats = { ...c.systemData };
+    }
+    if (c.img) formatted.img = c.img;
+    return formatted;
+  }
+
+  describeFilters(filters: Record<string, any>): string {
+    const validated = CosmereRpgFiltersSchema.safeParse(filters);
+    if (!validated.success) return 'invalid filters';
+    return describeCosmereRpgFilters(validated.data as CosmereRpgFilters);
+  }
+
+  getPowerLevel(creature: SystemCreatureIndex): number | undefined {
+    // Cosmere's primary encounter-design dial is tier (1-4) for adversaries.
+    // Player-character level is exposed if present but adversaries don't
+    // carry one — fall back to tier first, level second.
+    const c = creature as CosmereRpgCreatureIndex;
+    return c.systemData?.tier ?? c.systemData?.level;
+  }
+
+  /**
+   * Extract Cosmere-specific basic info: level, tier, resource maxes,
+   * deflect. Returned object is merged into the get-character response's
+   * `basicInfo` block.
+   */
+  extractBasicInfo(actorData: any): any {
+    const system = actorData?.system || {};
+    const out: any = {};
+
+    if (typeof system.level === 'number') out.level = system.level;
+    if (typeof system.tier === 'number') out.tier = system.tier;
+
+    if (system.resources) {
+      for (const [key, name] of Object.entries(COSMERE_RESOURCES)) {
+        const r = system.resources[key];
+        if (r) {
+          out[name] = {
+            current: typeof r.value === 'number' ? r.value : 0,
+            max: readDerived(r.max) ?? 0,
+            bonus: typeof r.bonus === 'number' ? r.bonus : 0,
+          };
+        }
+      }
+    }
+
+    const deflect = readDerived(system.deflect);
+    if (deflect !== undefined) out.deflect = deflect;
+
+    return out;
+  }
+
+  /**
+   * Extract Cosmere-specific stats: attributes (with pre→prs remap),
+   * defenses (final values), skills (rank + mod).
+   */
+  extractCharacterStats(actorData: any): any {
+    const system = actorData?.system || {};
+    const stats: any = {};
+
+    if (system.attributes) {
+      stats.attributes = {};
+      for (const key of COSMERE_ATTR_KEYS) {
+        const a = system.attributes[key];
+        if (a && typeof a.value === 'number') {
+          stats.attributes[key] = a.value;
+        }
+      }
+    }
+
+    if (system.defenses) {
+      stats.defenses = {};
+      for (const key of COSMERE_DEFENSE_KEYS) {
+        const v = readDerived(system.defenses[key]);
+        if (v !== undefined) stats.defenses[key] = v;
+      }
+    }
+
+    if (system.skills) {
+      stats.skills = {};
+      for (const [key, skill] of Object.entries(system.skills)) {
+        if (typeof skill === 'object' && skill !== null) {
+          const rank = (skill as any).rank;
+          const mod = readDerived((skill as any).mod);
+          stats.skills[key] = {
+            rank: typeof rank === 'number' ? rank : 0,
+            mod: mod ?? 0,
+          };
+        }
+      }
+    }
+
+    return stats;
+  }
+}

--- a/packages/mcp-server/src/systems/cosmere-rpg/constants.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/constants.ts
@@ -1,0 +1,55 @@
+/**
+ * Cosmere RPG Schema Constants
+ *
+ * Field paths and key sets for the Cosmere RPG Foundry system.
+ * Schema reference: https://github.com/the-metalworks/cosmere-rpg
+ *
+ * Notable shape characteristics:
+ *   - `system.level` (number, top-level for character)
+ *   - `system.tier` (number)
+ *   - `system.attributes.<key>.{value, bonus}` — keys: str/spd/int/wil/awa/pre
+ *   - `system.defenses.<key>` — DerivedValueField; read `.value` for final
+ *   - `system.resources.<key>.{value, max, bonus}` — keys: hea/foc/inv;
+ *      `.max` is itself a DerivedValueField (read `.value`)
+ *   - `system.skills.<key>.{rank, mod}` — `.mod` is a DerivedValueField
+ *   - `system.deflect` — DerivedValueField; read `.value`
+ */
+
+/** Attribute keys as Foundry stores them. */
+export const COSMERE_ATTR_KEYS = ['str', 'spd', 'int', 'wil', 'awa', 'pre'] as const;
+export type CosmereAttrKey = typeof COSMERE_ATTR_KEYS[number];
+
+/** Defense keys (attribute groups). */
+export const COSMERE_DEFENSE_KEYS = ['phy', 'cog', 'spi'] as const;
+export type CosmereDefenseKey = typeof COSMERE_DEFENSE_KEYS[number];
+
+/** Resource keys mapped to friendly names used in the get-character response. */
+export const COSMERE_RESOURCES: Record<string, 'health' | 'focus' | 'investiture'> = {
+  hea: 'health',
+  foc: 'focus',
+  inv: 'investiture',
+};
+
+/**
+ * Normalise a Cosmere DerivedValueField. The shape is:
+ *   { value: T, derived: T, override?: T, useOverride: boolean, base?, bonus? }
+ *
+ * Resolution order:
+ *   1. If `useOverride` is true and `override` is a number, return `override`.
+ *      (The actor sheet honours this; e.g. Investiture max where the system
+ *      can't auto-derive a value and the GM/player has typed one in.)
+ *   2. Otherwise prefer `value` (the final post-bonus result on most fields).
+ *   3. Fall back to `derived` (raw computed pre-bonus).
+ */
+export function readDerived(field: any): number | undefined {
+  if (field == null) return undefined;
+  if (typeof field === 'number') return field;
+  if (typeof field === 'object') {
+    if (field.useOverride === true && typeof field.override === 'number') {
+      return field.override;
+    }
+    if (typeof field.value === 'number') return field.value;
+    if (typeof field.derived === 'number') return field.derived;
+  }
+  return undefined;
+}

--- a/packages/mcp-server/src/systems/cosmere-rpg/filters.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/filters.ts
@@ -1,0 +1,170 @@
+/**
+ * Cosmere RPG Filter Schema
+ *
+ * Filters for `search-compendium` and `list-creatures-by-criteria`.
+ *
+ * Cosmere RPG uses tiers (1-4) and adversary roles (minion/rival/boss/…)
+ * rather than CR or level, so the filter surface is intentionally distinct
+ * from the dnd5e/pf2e schemas.
+ */
+
+import { z } from 'zod';
+import type { CosmereRpgCreatureIndex } from '../types.js';
+
+/** Range filter: either an exact value or an inclusive {min?, max?} window. */
+const NumberRange = z.union([
+  z.number(),
+  z
+    .object({
+      min: z.number().optional(),
+      max: z.number().optional(),
+    })
+    .strict(),
+]);
+
+/**
+ * Adversary role values seen in the official Stormlight compendia.
+ * Treated as a free-form string downstream (system may add roles).
+ */
+export const COSMERE_ROLES = ['minion', 'rival', 'boss'] as const;
+export type CosmereRole = (typeof COSMERE_ROLES)[number];
+
+/**
+ * Common cosmere creature types observed in compendium content.
+ * Matched against `system.type.id` (lowercased).
+ */
+export const COSMERE_CREATURE_TYPES = [
+  'humanoid',
+  'animal',
+  'spren',
+  'parshendi',
+  'singer',
+  'voidbringer',
+  'fabrial',
+  'unknown',
+] as const;
+export type CosmereCreatureType = (typeof COSMERE_CREATURE_TYPES)[number];
+
+export const COSMERE_SIZES = [
+  'tiny',
+  'small',
+  'medium',
+  'large',
+  'huge',
+  'gargantuan',
+] as const;
+
+export const CosmereRpgFiltersSchema = z
+  .object({
+    /** Tier filter — exact value or {min, max}. */
+    tier: NumberRange.optional(),
+    /** Adversary role (minion/rival/boss/…). Case-insensitive match. */
+    role: z.string().min(1).optional(),
+    /** Creature type — matches `system.type.id`. Case-insensitive. */
+    creatureType: z.string().min(1).optional(),
+    /** Size category. */
+    size: z.enum(COSMERE_SIZES).optional(),
+    /** Filter for Surge/Investiture-using adversaries. */
+    hasInvestiture: z.boolean().optional(),
+    /** Health max range. */
+    health: NumberRange.optional(),
+    /** Minimum defense thresholds — pass any subset. */
+    defensesMin: z
+      .object({
+        phy: z.number().optional(),
+        cog: z.number().optional(),
+        spi: z.number().optional(),
+      })
+      .strict()
+      .optional(),
+    /** Minimum deflect rating. */
+    deflectMin: z.number().optional(),
+  })
+  .strict();
+
+export type CosmereRpgFilters = z.infer<typeof CosmereRpgFiltersSchema>;
+
+type RangeInput = number | { min?: number | undefined; max?: number | undefined };
+
+/** Resolve a NumberRange against a candidate value. */
+function inRange(value: number | undefined, range: RangeInput): boolean {
+  if (value === undefined) return false;
+  if (typeof range === 'number') return value === range;
+  if (range.min !== undefined && value < range.min) return false;
+  if (range.max !== undefined && value > range.max) return false;
+  return true;
+}
+
+export function matchesCosmereRpgFilters(
+  creature: CosmereRpgCreatureIndex,
+  filters: CosmereRpgFilters,
+): boolean {
+  const data = creature.systemData ?? ({} as CosmereRpgCreatureIndex['systemData']);
+
+  if (filters.tier !== undefined && !inRange(data.tier, filters.tier)) {
+    return false;
+  }
+  if (filters.role !== undefined) {
+    const role = (data.role ?? '').toLowerCase();
+    if (role !== filters.role.toLowerCase()) return false;
+  }
+  if (filters.creatureType !== undefined) {
+    const ct = (data.creatureType ?? '').toLowerCase();
+    if (ct !== filters.creatureType.toLowerCase()) return false;
+  }
+  if (filters.size !== undefined) {
+    const size = (data.size ?? '').toLowerCase();
+    if (size !== filters.size) return false;
+  }
+  if (filters.hasInvestiture !== undefined) {
+    const has = data.hasInvestiture ?? (data.investiture ?? 0) > 0;
+    if (has !== filters.hasInvestiture) return false;
+  }
+  if (filters.health !== undefined && !inRange(data.health, filters.health)) {
+    return false;
+  }
+  if (filters.defensesMin !== undefined) {
+    const def = data.defenses ?? {};
+    const { phy, cog, spi } = filters.defensesMin;
+    if (phy !== undefined && (def.phy ?? -Infinity) < phy) return false;
+    if (cog !== undefined && (def.cog ?? -Infinity) < cog) return false;
+    if (spi !== undefined && (def.spi ?? -Infinity) < spi) return false;
+  }
+  if (filters.deflectMin !== undefined) {
+    if ((data.deflect ?? -Infinity) < filters.deflectMin) return false;
+  }
+  return true;
+}
+
+export function describeCosmereRpgFilters(filters: CosmereRpgFilters): string {
+  const parts: string[] = [];
+
+  if (filters.tier !== undefined) {
+    parts.push(typeof filters.tier === 'number' ? `tier ${filters.tier}` : describeRange('tier', filters.tier));
+  }
+  if (filters.role) parts.push(`role=${filters.role.toLowerCase()}`);
+  if (filters.creatureType) parts.push(`type=${filters.creatureType.toLowerCase()}`);
+  if (filters.size) parts.push(`size=${filters.size}`);
+  if (filters.hasInvestiture !== undefined) {
+    parts.push(filters.hasInvestiture ? 'has Investiture' : 'no Investiture');
+  }
+  if (filters.health !== undefined) {
+    parts.push(typeof filters.health === 'number' ? `hp=${filters.health}` : describeRange('hp', filters.health));
+  }
+  if (filters.defensesMin) {
+    const { phy, cog, spi } = filters.defensesMin;
+    if (phy !== undefined) parts.push(`phy>=${phy}`);
+    if (cog !== undefined) parts.push(`cog>=${cog}`);
+    if (spi !== undefined) parts.push(`spi>=${spi}`);
+  }
+  if (filters.deflectMin !== undefined) parts.push(`deflect>=${filters.deflectMin}`);
+
+  return parts.length > 0 ? parts.join(', ') : 'no filters';
+}
+
+function describeRange(label: string, range: { min?: number | undefined; max?: number | undefined }): string {
+  if (range.min !== undefined && range.max !== undefined) return `${label} ${range.min}-${range.max}`;
+  if (range.min !== undefined) return `${label}>=${range.min}`;
+  if (range.max !== undefined) return `${label}<=${range.max}`;
+  return `${label} (any)`;
+}

--- a/packages/mcp-server/src/systems/cosmere-rpg/index-builder.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/index-builder.ts
@@ -4,13 +4,16 @@
  * Builds the enhanced creature index from Foundry compendium packs.
  *
  * Runs in Foundry's browser context (foundry-module side); does NOT execute
- * on the Node MCP server. The mcp-server-side `CosmereRpgAdapter` re-uses
- * `extractCreatureData` for any places it needs the same logic on already-
- * loaded actor data.
+ * on the Node MCP server. Mirrors the dnd5e/pf2e/dsa5 IndexBuilder pattern.
  *
  * Schema reference: github.com/the-metalworks/cosmere-rpg
  *   - Adversary actors expose `system.tier`, `system.role`, defenses,
  *     resources, etc. — see ../filters.ts for the indexed field list.
+ *
+ * Note: today the foundry-module's data-access.ts contains a parallel
+ * inline extractor that's the actual runtime path. This file mirrors that
+ * behavior so the two paths produce equivalent shapes if the registry is
+ * ever wired up — same tech-debt situation as dnd5e/pf2e.
  */
 
 import type { IndexBuilder, CosmereRpgCreatureIndex } from '../types.js';
@@ -178,69 +181,67 @@ export class CosmereRpgIndexBuilder implements IndexBuilder {
    * Reads the live (post-derive) `doc.system` block. DerivedValueField
    * fields (resources.*.max, defenses.*, deflect, movement.*.rate) are
    * resolved via `readDerived`, which honours `useOverride`.
+   *
+   * Defaults (tier=0, role='unknown', etc.) match the browser-side extractor
+   * in foundry-module's data-access.ts so both paths produce equivalent
+   * shapes. "0" / "unknown" mean "field not set on the actor"; consumers
+   * filtering by tier/role typically use ranges that exclude these.
    */
   extractCreatureData(doc: any, pack: any): CosmereExtractionResult | null {
     try {
       const system = doc.system ?? {};
 
-      const tier = typeof system.tier === 'number' ? system.tier : undefined;
+      const tier = typeof system.tier === 'number' ? system.tier : 0;
       const level = typeof system.level === 'number' ? system.level : undefined;
 
       const role =
         typeof system.role === 'string' && system.role.length > 0
           ? system.role.toLowerCase()
-          : undefined;
+          : 'unknown';
 
       const size =
         typeof system.size === 'string' && system.size.length > 0
           ? system.size.toLowerCase()
-          : undefined;
+          : 'medium';
 
       const creatureType =
         typeof system.type?.id === 'string' && system.type.id.length > 0
           ? system.type.id.toLowerCase()
-          : undefined;
+          : 'unknown';
 
       const subtype =
         typeof system.type?.subtype === 'string' && system.type.subtype.length > 0
           ? system.type.subtype
-          : undefined;
+          : '';
 
-      const health = readDerived(system.resources?.hea?.max);
-      const focus = readDerived(system.resources?.foc?.max);
+      const health = readDerived(system.resources?.hea?.max) ?? 0;
+      const focus = readDerived(system.resources?.foc?.max) ?? 0;
       const investiture = readDerived(system.resources?.inv?.max) ?? 0;
 
-      let defenses: { phy?: number; cog?: number; spi?: number } | undefined;
-      if (system.defenses) {
-        defenses = {};
-        const phy = readDerived(system.defenses.phy);
-        const cog = readDerived(system.defenses.cog);
-        const spi = readDerived(system.defenses.spi);
-        if (phy !== undefined) defenses.phy = phy;
-        if (cog !== undefined) defenses.cog = cog;
-        if (spi !== undefined) defenses.spi = spi;
-      }
+      const defenses = {
+        phy: readDerived(system.defenses?.phy) ?? 0,
+        cog: readDerived(system.defenses?.cog) ?? 0,
+        spi: readDerived(system.defenses?.spi) ?? 0,
+      };
 
-      const deflect = readDerived(system.deflect);
-      const walkSpeed = readDerived(system.movement?.walk?.rate);
+      const deflect = readDerived(system.deflect) ?? 0;
+      const walkSpeed = readDerived(system.movement?.walk?.rate) ?? 0;
 
-      // Build systemData incrementally so undefined fields stay omitted
-      // (the type uses `exactOptionalPropertyTypes`).
       const systemData: CosmereRpgCreatureIndex['systemData'] = {
-        hasInvestiture: investiture > 0,
+        tier,
+        role,
+        size,
+        creatureType,
+        subtype,
+        health,
+        focus,
         investiture,
+        hasInvestiture: investiture > 0,
+        defenses,
+        deflect,
+        walkSpeed,
       };
       if (level !== undefined) systemData.level = level;
-      if (tier !== undefined) systemData.tier = tier;
-      if (role !== undefined) systemData.role = role;
-      if (size !== undefined) systemData.size = size;
-      if (creatureType !== undefined) systemData.creatureType = creatureType;
-      if (subtype !== undefined) systemData.subtype = subtype;
-      if (health !== undefined) systemData.health = health;
-      if (focus !== undefined) systemData.focus = focus;
-      if (defenses !== undefined) systemData.defenses = defenses;
-      if (deflect !== undefined) systemData.deflect = deflect;
-      if (walkSpeed !== undefined) systemData.walkSpeed = walkSpeed;
 
       return {
         creature: {
@@ -272,8 +273,18 @@ export class CosmereRpgIndexBuilder implements IndexBuilder {
           img: doc.img,
           system: 'cosmere-rpg',
           systemData: {
+            tier: 0,
+            role: 'unknown',
+            size: 'medium',
+            creatureType: 'unknown',
+            subtype: '',
+            health: 0,
+            focus: 0,
             investiture: 0,
             hasInvestiture: false,
+            defenses: { phy: 0, cog: 0, spi: 0 },
+            deflect: 0,
+            walkSpeed: 0,
           },
         },
         errors: 1,

--- a/packages/mcp-server/src/systems/cosmere-rpg/index-builder.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/index-builder.ts
@@ -1,0 +1,283 @@
+/**
+ * Cosmere RPG Index Builder
+ *
+ * Builds the enhanced creature index from Foundry compendium packs.
+ *
+ * Runs in Foundry's browser context (foundry-module side); does NOT execute
+ * on the Node MCP server. The mcp-server-side `CosmereRpgAdapter` re-uses
+ * `extractCreatureData` for any places it needs the same logic on already-
+ * loaded actor data.
+ *
+ * Schema reference: github.com/the-metalworks/cosmere-rpg
+ *   - Adversary actors expose `system.tier`, `system.role`, defenses,
+ *     resources, etc. — see ../filters.ts for the indexed field list.
+ */
+
+import type { IndexBuilder, CosmereRpgCreatureIndex } from '../types.js';
+import { readDerived } from './constants.js';
+
+declare const ui: any;
+
+interface CosmereExtractionResult {
+  creature: CosmereRpgCreatureIndex;
+  errors: number;
+}
+
+export class CosmereRpgIndexBuilder implements IndexBuilder {
+  private moduleId: string;
+
+  constructor(moduleId: string = 'foundry-mcp-bridge') {
+    this.moduleId = moduleId;
+  }
+
+  getSystemId() {
+    return 'cosmere-rpg' as const;
+  }
+
+  async buildIndex(packs: any[], _force = false): Promise<CosmereRpgCreatureIndex[]> {
+    const startTime = Date.now();
+    let progressNotification: any = null;
+    let totalErrors = 0;
+
+    try {
+      const actorPacks = packs.filter((pack) => pack.metadata.type === 'Actor');
+      const enhancedCreatures: CosmereRpgCreatureIndex[] = [];
+
+      console.log(
+        `[${this.moduleId}] Starting Cosmere RPG creature index build from ${actorPacks.length} packs...`,
+      );
+      if (typeof ui !== 'undefined' && ui.notifications) {
+        ui.notifications.info(
+          `Starting Cosmere RPG creature index build from ${actorPacks.length} packs...`,
+        );
+      }
+
+      for (let i = 0; i < actorPacks.length; i++) {
+        const pack = actorPacks[i];
+        const progressPercent = Math.round((i / actorPacks.length) * 100);
+
+        if (i % 3 === 0 || pack.metadata.label.toLowerCase().includes('adversar')) {
+          if (progressNotification && typeof ui !== 'undefined') {
+            progressNotification.remove();
+          }
+          if (typeof ui !== 'undefined' && ui.notifications) {
+            progressNotification = ui.notifications.info(
+              `Building creature index... ${progressPercent}% (${i + 1}/${actorPacks.length}) Processing: ${pack.metadata.label}`,
+            );
+          }
+        }
+
+        try {
+          if (!pack.indexed) {
+            await pack.getIndex({});
+          }
+
+          const packResult = await this.extractDataFromPack(pack);
+          enhancedCreatures.push(...packResult.creatures);
+          totalErrors += packResult.errors;
+
+          if (i === 0 || (i + 1) % 5 === 0 || i === actorPacks.length - 1) {
+            const totalCreaturesSoFar = enhancedCreatures.length;
+            if (progressNotification && typeof ui !== 'undefined') {
+              progressNotification.remove();
+            }
+            if (typeof ui !== 'undefined' && ui.notifications) {
+              progressNotification = ui.notifications.info(
+                `Index Progress: ${i + 1}/${actorPacks.length} packs complete, ${totalCreaturesSoFar} creatures indexed`,
+              );
+            }
+          }
+        } catch (error) {
+          console.warn(
+            `[${this.moduleId}] Failed to process pack ${pack.metadata.label}:`,
+            error,
+          );
+          if (typeof ui !== 'undefined' && ui.notifications) {
+            ui.notifications.warn(
+              `Warning: Failed to index pack "${pack.metadata.label}" - continuing with other packs`,
+            );
+          }
+        }
+      }
+
+      if (progressNotification && typeof ui !== 'undefined') {
+        progressNotification.remove();
+      }
+
+      const buildTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+      const errorText = totalErrors > 0 ? ` (${totalErrors} extraction errors)` : '';
+      const successMessage = `Cosmere RPG creature index complete! ${enhancedCreatures.length} creatures indexed from ${actorPacks.length} packs in ${buildTimeSeconds}s${errorText}`;
+
+      console.log(`[${this.moduleId}] ${successMessage}`);
+      if (typeof ui !== 'undefined' && ui.notifications) {
+        ui.notifications.info(successMessage);
+      }
+
+      return enhancedCreatures;
+    } catch (error) {
+      if (progressNotification && typeof ui !== 'undefined') {
+        progressNotification.remove();
+      }
+
+      const errorMessage = `Failed to build Cosmere RPG creature index: ${
+        error instanceof Error ? error.message : 'Unknown error'
+      }`;
+      console.error(`[${this.moduleId}] ${errorMessage}`);
+      if (typeof ui !== 'undefined' && ui.notifications) {
+        ui.notifications.error(errorMessage);
+      }
+      throw error;
+    }
+  }
+
+  async extractDataFromPack(
+    pack: any,
+  ): Promise<{ creatures: CosmereRpgCreatureIndex[]; errors: number }> {
+    const creatures: CosmereRpgCreatureIndex[] = [];
+    let errors = 0;
+
+    try {
+      const documents = await pack.getDocuments();
+
+      for (const doc of documents) {
+        try {
+          // Cosmere-rpg compendium creatures are `adversary`-typed. Player
+          // characters (`character`) are excluded from the creature index
+          // — they're individual sheets, not encounter material.
+          if (doc.type !== 'adversary') {
+            continue;
+          }
+
+          const result = this.extractCreatureData(doc, pack);
+          if (result) {
+            creatures.push(result.creature);
+            errors += result.errors;
+          }
+        } catch (error) {
+          console.warn(
+            `[${this.moduleId}] Failed to extract Cosmere RPG data from ${doc.name} in ${pack.metadata.label}:`,
+            error,
+          );
+          errors++;
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `[${this.moduleId}] Failed to load documents from ${pack.metadata.label}:`,
+        error,
+      );
+      errors++;
+    }
+
+    return { creatures, errors };
+  }
+
+  /**
+   * Extract a single Cosmere RPG creature.
+   *
+   * Reads the live (post-derive) `doc.system` block. DerivedValueField
+   * fields (resources.*.max, defenses.*, deflect, movement.*.rate) are
+   * resolved via `readDerived`, which honours `useOverride`.
+   */
+  extractCreatureData(doc: any, pack: any): CosmereExtractionResult | null {
+    try {
+      const system = doc.system ?? {};
+
+      const tier = typeof system.tier === 'number' ? system.tier : undefined;
+      const level = typeof system.level === 'number' ? system.level : undefined;
+
+      const role =
+        typeof system.role === 'string' && system.role.length > 0
+          ? system.role.toLowerCase()
+          : undefined;
+
+      const size =
+        typeof system.size === 'string' && system.size.length > 0
+          ? system.size.toLowerCase()
+          : undefined;
+
+      const creatureType =
+        typeof system.type?.id === 'string' && system.type.id.length > 0
+          ? system.type.id.toLowerCase()
+          : undefined;
+
+      const subtype =
+        typeof system.type?.subtype === 'string' && system.type.subtype.length > 0
+          ? system.type.subtype
+          : undefined;
+
+      const health = readDerived(system.resources?.hea?.max);
+      const focus = readDerived(system.resources?.foc?.max);
+      const investiture = readDerived(system.resources?.inv?.max) ?? 0;
+
+      let defenses: { phy?: number; cog?: number; spi?: number } | undefined;
+      if (system.defenses) {
+        defenses = {};
+        const phy = readDerived(system.defenses.phy);
+        const cog = readDerived(system.defenses.cog);
+        const spi = readDerived(system.defenses.spi);
+        if (phy !== undefined) defenses.phy = phy;
+        if (cog !== undefined) defenses.cog = cog;
+        if (spi !== undefined) defenses.spi = spi;
+      }
+
+      const deflect = readDerived(system.deflect);
+      const walkSpeed = readDerived(system.movement?.walk?.rate);
+
+      // Build systemData incrementally so undefined fields stay omitted
+      // (the type uses `exactOptionalPropertyTypes`).
+      const systemData: CosmereRpgCreatureIndex['systemData'] = {
+        hasInvestiture: investiture > 0,
+        investiture,
+      };
+      if (level !== undefined) systemData.level = level;
+      if (tier !== undefined) systemData.tier = tier;
+      if (role !== undefined) systemData.role = role;
+      if (size !== undefined) systemData.size = size;
+      if (creatureType !== undefined) systemData.creatureType = creatureType;
+      if (subtype !== undefined) systemData.subtype = subtype;
+      if (health !== undefined) systemData.health = health;
+      if (focus !== undefined) systemData.focus = focus;
+      if (defenses !== undefined) systemData.defenses = defenses;
+      if (deflect !== undefined) systemData.deflect = deflect;
+      if (walkSpeed !== undefined) systemData.walkSpeed = walkSpeed;
+
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          packName: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          img: doc.img,
+          system: 'cosmere-rpg',
+          systemData,
+        },
+        errors: 0,
+      };
+    } catch (error) {
+      console.warn(
+        `[${this.moduleId}] Failed to extract Cosmere RPG data from ${doc.name}:`,
+        error,
+      );
+
+      // Minimal fallback so the index isn't gappy on a single bad doc.
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          packName: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          img: doc.img,
+          system: 'cosmere-rpg',
+          systemData: {
+            investiture: 0,
+            hasInvestiture: false,
+          },
+        },
+        errors: 1,
+      };
+    }
+  }
+}

--- a/packages/mcp-server/src/systems/cosmere-rpg/index.ts
+++ b/packages/mcp-server/src/systems/cosmere-rpg/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Cosmere RPG System Module
+ *
+ * Re-exports for the Cosmere RPG adapter and index builder.
+ *
+ * Register `CosmereRpgAdapter` with the system registry in backend.ts (Node)
+ * and `CosmereRpgIndexBuilder` with the IndexBuilderRegistry in the foundry
+ * module's main.ts (browser) to enable creature indexing end-to-end.
+ */
+
+// Type definitions (from central types.ts)
+export type { CosmereRpgCreatureIndex } from '../types.js';
+
+// Index builder (runs in Foundry browser context)
+export { CosmereRpgIndexBuilder } from './index-builder.js';
+
+// System adapter (runs in MCP server Node.js context)
+export { CosmereRpgAdapter } from './adapter.js';
+
+// Filter system
+export {
+  CosmereRpgFiltersSchema,
+  matchesCosmereRpgFilters,
+  describeCosmereRpgFilters,
+  COSMERE_ROLES,
+  COSMERE_CREATURE_TYPES,
+  COSMERE_SIZES,
+  type CosmereRpgFilters,
+  type CosmereRole,
+  type CosmereCreatureType,
+} from './filters.js';
+
+// Constants
+export {
+  COSMERE_ATTR_KEYS,
+  COSMERE_DEFENSE_KEYS,
+  COSMERE_RESOURCES,
+  readDerived,
+} from './constants.js';

--- a/packages/mcp-server/src/systems/types.ts
+++ b/packages/mcp-server/src/systems/types.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
  * Supported game system identifiers
  * Extend this type when adding new systems
  */
-export type SystemId = 'dnd5e' | 'pf2e' | 'dsa5' | 'other';
+export type SystemId = 'dnd5e' | 'pf2e' | 'dsa5' | 'cosmere-rpg' | 'other';
 
 /**
  * System metadata returned by adapters
@@ -130,6 +130,19 @@ export interface SystemAdapter {
    * @param actorData - Raw Foundry actor data
    */
   extractCharacterStats(actorData: any): any;
+
+  /**
+   * Extract system-specific "basic info" from actor data
+   * (e.g. resources/HP, AC, level, deflect — anything that belongs in
+   * the top-level `basicInfo` block of the get-character response).
+   *
+   * Optional: if not implemented, the get-character tool falls back
+   * to its built-in cross-system extractor (which works for dnd5e/pf2e).
+   *
+   * @param actorData - Raw Foundry actor data
+   * @returns Object merged into the get-character response's basicInfo
+   */
+  extractBasicInfo?(actorData: any): any;
 }
 
 /**
@@ -222,6 +235,52 @@ export interface DSA5CreatureIndex extends SystemCreatureIndex {
 }
 
 /**
+ * Cosmere RPG specific creature index structure
+ *
+ * Schema reference: github.com/the-metalworks/cosmere-rpg
+ *
+ * Most cosmere-rpg compendium creatures are `adversary`-type actors. The
+ * fields below are extracted from the live (post-derive) `system.*` block
+ * so DerivedValueField overrides (e.g. health max set via the sheet) are
+ * resolved before indexing — see `readDerived` in ./cosmere-rpg/constants.ts.
+ */
+export interface CosmereRpgCreatureIndex extends SystemCreatureIndex {
+  system: 'cosmere-rpg';
+  systemData: {
+    /** Player-character level (rare in compendium adversaries). */
+    level?: number;
+    /** Adversary tier — 1 (minion-tier) to 4 (legendary). Primary power-level proxy. */
+    tier?: number;
+    /** Adversary role — `minion` | `rival` | `boss` (and any system-defined extension). */
+    role?: string;
+    /** Size category (tiny/small/medium/large/huge/gargantuan). */
+    size?: string;
+    /** Primary creature type (`humanoid`, `animal`, `spren`, `parshendi`, ...). */
+    creatureType?: string;
+    /** Free-form subtype (e.g. specific singer form, beast variant). */
+    subtype?: string;
+    /** Health max (resources.hea.max, override-aware). */
+    health?: number;
+    /** Focus max (resources.foc.max, override-aware). */
+    focus?: number;
+    /** Investiture max (resources.inv.max, override-aware) — usually 0 for non-Surge-users. */
+    investiture?: number;
+    /** Convenience flag: `investiture > 0`. */
+    hasInvestiture?: boolean;
+    /** Final defense values (post-derive). */
+    defenses?: {
+      phy?: number;
+      cog?: number;
+      spi?: number;
+    };
+    /** Deflect rating. */
+    deflect?: number;
+    /** Walk speed in feet (movement.walk.rate, override-aware). */
+    walkSpeed?: number;
+  };
+}
+
+/**
  * Generic creature index for unsupported systems
  */
 export interface GenericCreatureIndex extends SystemCreatureIndex {
@@ -236,4 +295,5 @@ export type AnyCreatureIndex =
   | DnD5eCreatureIndex
   | PF2eCreatureIndex
   | DSA5CreatureIndex
+  | CosmereRpgCreatureIndex
   | GenericCreatureIndex;

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 import { FoundryClient } from '../foundry-client.js';
 import { Logger } from '../logger.js';
 import { SystemRegistry } from '../systems/system-registry.js';
-import { detectGameSystem, type GameSystem } from '../utils/system-detection.js';
+import { detectGameSystem, getCachedSystemId, type GameSystem } from '../utils/system-detection.js';
+import type { SystemAdapter } from '../systems/types.js';
 
 export interface CharacterToolsOptions {
   foundryClient: FoundryClient;
@@ -30,6 +31,25 @@ export class CharacterTools {
       this.cachedGameSystem = await detectGameSystem(this.foundryClient, this.logger);
     }
     return this.cachedGameSystem;
+  }
+
+  /**
+   * Resolve the active SystemAdapter, if any. Looks up by the raw
+   * Foundry system id first (so adapters whose id isn't part of the
+   * narrow `GameSystem` enum — e.g. 'dsa5', 'cosmere-rpg' — still
+   * resolve), then falls back to the normalised GameSystem.
+   */
+  private async getAdapter(): Promise<SystemAdapter | null> {
+    if (!this.systemRegistry) return null;
+    // Ensure detection has populated the cached id (it's set as a side
+    // effect of detectGameSystem, which getGameSystem wraps).
+    await this.getGameSystem();
+    const rawId = getCachedSystemId();
+    if (rawId) {
+      const byRaw = this.systemRegistry.getAdapter(rawId);
+      if (byRaw) return byRaw;
+    }
+    return this.systemRegistry.getAdapter(this.cachedGameSystem ?? 'other');
   }
 
   /**
@@ -427,7 +447,7 @@ export class CharacterTools {
       id: characterData.id,
       name: characterData.name,
       type: characterData.type,
-      basicInfo: this.extractBasicInfo(characterData),
+      basicInfo: await this.extractBasicInfo(characterData),
       stats: await this.extractStats(characterData),
       items: this.formatItems(characterData.items || []),
       effects: this.formatEffects(characterData.effects || []),
@@ -556,31 +576,48 @@ export class CharacterTools {
     });
   }
 
-  private extractBasicInfo(characterData: any): any {
-    const system = characterData.system || {};
-
+  private async extractBasicInfo(characterData: any): Promise<any> {
     // Extract common fields that exist across different game systems
     const basicInfo: any = {};
 
-    // D&D 5e / PF2e common fields
+    // Let the active SystemAdapter (if it exposes extractBasicInfo) seed
+    // system-specific fields first. Anything it returns wins; the legacy
+    // cross-system extractor below only fills gaps.
+    try {
+      const adapter = await this.getAdapter();
+      if (adapter && typeof adapter.extractBasicInfo === 'function') {
+        const fromAdapter = adapter.extractBasicInfo(characterData);
+        if (fromAdapter && typeof fromAdapter === 'object') {
+          Object.assign(basicInfo, fromAdapter);
+        }
+      }
+    } catch (error) {
+      this.logger.warn('System adapter extractBasicInfo failed; falling back to legacy', { error });
+    }
+
+    const system = characterData.system || {};
+
+    // D&D 5e / PF2e common fields (only fill if adapter didn't already)
     if (system.attributes) {
-      if (system.attributes.hp) {
+      if (system.attributes.hp && basicInfo.hitPoints === undefined) {
         basicInfo.hitPoints = {
           current: system.attributes.hp.value,
           max: system.attributes.hp.max,
           temp: system.attributes.hp.temp || 0,
         };
       }
-      if (system.attributes.ac) {
+      if (system.attributes.ac && basicInfo.armorClass === undefined) {
         basicInfo.armorClass = system.attributes.ac.value;
       }
     }
 
-    // Level information
-    if (system.details?.level?.value) {
-      basicInfo.level = system.details.level.value;
-    } else if (system.level) {
-      basicInfo.level = system.level;
+    // Level information (only if adapter didn't set it)
+    if (basicInfo.level === undefined) {
+      if (system.details?.level?.value) {
+        basicInfo.level = system.details.level.value;
+      } else if (typeof system.level === 'number') {
+        basicInfo.level = system.level;
+      }
     }
 
     // Class information
@@ -608,23 +645,19 @@ export class CharacterTools {
   }
 
   private async extractStats(characterData: any): Promise<any> {
-    // Try using system adapter if available
-    if (this.systemRegistry) {
-      try {
-        const gameSystem = await this.getGameSystem();
-        const adapter = this.systemRegistry.getAdapter(gameSystem);
-
-        if (adapter) {
-          this.logger.debug('Using system adapter for character stats extraction', {
-            system: gameSystem,
-          });
-          return adapter.extractCharacterStats(characterData);
-        }
-      } catch (error) {
-        this.logger.warn('Failed to use system adapter, falling back to legacy extraction', {
-          error,
+    // Try using system adapter if available. Lookup uses the raw Foundry
+    // system id first so adapters whose id isn't part of the narrow
+    // GameSystem enum (e.g. 'dsa5', 'cosmere-rpg') resolve correctly.
+    try {
+      const adapter = await this.getAdapter();
+      if (adapter) {
+        this.logger.debug('Using system adapter for character stats extraction', {
+          system: adapter.getMetadata().id,
         });
+        return adapter.extractCharacterStats(characterData);
       }
+    } catch (error) {
+      this.logger.warn('Failed to use system adapter, falling back to legacy extraction', { error });
     }
 
     // Legacy extraction (backwards compatibility)

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -140,6 +140,48 @@ export class CharacterTools {
         },
       },
       {
+        name: 'add-actor-items',
+        description: 'Add one or more freshly-authored Item documents (talents, actions, powers, equipment, etc.) to an existing actor. Items are constructed from the supplied data — no compendium lookup is performed. Each item requires a non-empty "name" and a "type" valid for the active game system (e.g. Cosmere RPG: "action", "talent", "power", "weapon", "armor", "equipment", "loot", "ancestry", "culture", "path", "specialty", "trait", "injury", "connection", "goal", "talent_tree"). Pass system-specific data via the optional "system" object — Foundry\'s DataModel layer fills defaults and validates required sub-fields. GM-only. Returns the created item IDs so callers can update or roll them next.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actorIdentifier: {
+              type: 'string',
+              description: 'Actor name or ID to receive the items',
+            },
+            items: {
+              type: 'array',
+              minItems: 1,
+              description: 'One or more items to create on the actor sheet',
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: 'Display name of the item',
+                  },
+                  type: {
+                    type: 'string',
+                    description: 'Item type valid for the active system (e.g. "action", "talent", "weapon")',
+                  },
+                  img: {
+                    type: 'string',
+                    description: 'Optional icon path (e.g. "icons/svg/explosion.svg" or a system-bundled path)',
+                  },
+                  system: {
+                    type: 'object',
+                    description: 'System-specific data (free-form). For Cosmere actions: { activation: { type: "utility", cost: { value: 1, type: "act" }, consume: [{ type: "resource", resource: "foc", value: { min: 2, max: 2 } }] }, description: { value: "<p>HTML</p>" } }',
+                    additionalProperties: true,
+                  },
+                },
+                required: ['name', 'type'],
+              },
+            },
+          },
+          required: ['actorIdentifier', 'items'],
+        },
+      },
+      {
         name: 'search-character-items',
         description:
           "Search within a character's items, spells, actions, and effects. More token-efficient than get-character when you need specific items. Supports text search (name/description) and type filtering. Returns matching items with full details including targeting info for spells. Use this to find specific spells, equipment, feats, or abilities without loading the entire character.",
@@ -397,6 +439,46 @@ export class CharacterTools {
       throw new Error(
         `Failed to use item "${itemIdentifier}": ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  async handleAddActorItems(args: any): Promise<any> {
+    const itemSchema = z.object({
+      name: z.string().min(1, 'Item name cannot be empty'),
+      type: z.string().min(1, 'Item type cannot be empty'),
+      img: z.string().optional(),
+      system: z.record(z.any()).optional(),
+    });
+
+    const schema = z.object({
+      actorIdentifier: z.string().min(1, 'Actor identifier cannot be empty'),
+      items: z.array(itemSchema).min(1, 'At least one item is required'),
+    });
+
+    const { actorIdentifier, items } = schema.parse(args);
+
+    this.logger.info('Adding items to actor', {
+      actorIdentifier,
+      count: items.length,
+      types: items.map(i => i.type),
+    });
+
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.addActorItems', {
+        actorIdentifier,
+        items,
+      });
+
+      this.logger.debug('Successfully added actor items', {
+        actorName: result.actorName,
+        created: result.created?.length ?? 0,
+      });
+
+      return result;
+
+    } catch (error) {
+      this.logger.error('Failed to add actor items', error);
+      throw new Error(`Failed to add items to "${actorIdentifier}": ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/packages/mcp-server/src/tools/compendium.ts
+++ b/packages/mcp-server/src/tools/compendium.ts
@@ -16,6 +16,7 @@ import {
   describeFilters,
   type GenericFilters,
 } from '../utils/compendium-filters.js';
+import { readDerived } from '../systems/cosmere-rpg/constants.js';
 
 export interface CompendiumToolsOptions {
   foundryClient: FoundryClient;
@@ -803,12 +804,45 @@ export class CompendiumTools {
       summary: this.createItemSummary(item),
     };
 
-    // Add key stats for actors/creatures to reduce need for detail calls
-    if (item.type === 'npc' || item.type === 'character') {
+    // Add key stats for actors/creatures to reduce need for detail calls.
+    // `adversary` is Cosmere RPG's NPC equivalent.
+    if (item.type === 'npc' || item.type === 'character' || item.type === 'adversary') {
       const stats: any = {};
 
       // Use system detection utilities for accurate stat extraction
-      if (gameSystem) {
+      if (gameSystem === 'cosmere-rpg') {
+        const system = item.system || {};
+
+        if (typeof system.tier === 'number') stats.tier = system.tier;
+        if (typeof system.level === 'number') stats.level = system.level;
+        if (typeof system.role === 'string' && system.role) stats.role = system.role.toLowerCase();
+        if (typeof system.type?.id === 'string' && system.type.id) {
+          stats.creatureType = system.type.id.toLowerCase();
+        }
+        if (typeof system.type?.subtype === 'string' && system.type.subtype) {
+          stats.subtype = system.type.subtype;
+        }
+        if (typeof system.size === 'string' && system.size) stats.size = system.size.toLowerCase();
+
+        const hpCurrent = typeof system.resources?.hea?.value === 'number' ? system.resources.hea.value : undefined;
+        const hpMax = readDerived(system.resources?.hea?.max);
+        if (hpCurrent !== undefined || hpMax !== undefined) {
+          stats.hitPoints = { current: hpCurrent, max: hpMax };
+        }
+
+        const phy = readDerived(system.defenses?.phy);
+        const cog = readDerived(system.defenses?.cog);
+        const spi = readDerived(system.defenses?.spi);
+        if (phy !== undefined || cog !== undefined || spi !== undefined) {
+          stats.defenses = { phy, cog, spi };
+        }
+
+        const deflect = readDerived(system.deflect);
+        if (deflect !== undefined) stats.deflect = deflect;
+
+        const investitureMax = readDerived(system.resources?.inv?.max) ?? 0;
+        if (investitureMax > 0) stats.hasInvestiture = true;
+      } else if (gameSystem) {
         // Level/CR (system-specific)
         const level = getCreatureLevel(item, gameSystem);
         if (level !== undefined) {

--- a/packages/mcp-server/src/tools/compendium.ts
+++ b/packages/mcp-server/src/tools/compendium.ts
@@ -191,7 +191,7 @@ export class CompendiumTools {
       {
         name: 'list-creatures-by-criteria',
         description:
-          'MULTI-SYSTEM CREATURE DISCOVERY: Get a comprehensive list of creatures matching specific criteria. Supports D&D 5e (Challenge Rating) and Pathfinder 2e (Level) with automatic system detection. Perfect for encounter building - returns minimal data so Claude can use built-in monster knowledge to identify suitable creatures by name, then pull full details only for final selections. Features intelligent pack prioritization and high result limits for complete surveys.',
+          'MULTI-SYSTEM CREATURE DISCOVERY: Get a comprehensive list of creatures matching specific criteria. Supports D&D 5e (Challenge Rating), Pathfinder 2e (Level), and Cosmere RPG (Tier/Role/Investiture) with automatic system detection. Perfect for encounter building - returns minimal data so Claude can use built-in monster knowledge to identify suitable creatures by name, then pull full details only for final selections. Features intelligent pack prioritization and high result limits for complete surveys.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -269,6 +269,57 @@ export class CompendiumTools {
               type: 'string',
               enum: ['common', 'uncommon', 'rare', 'unique'],
               description: 'Filter by rarity (Pathfinder 2e)',
+            },
+            // Cosmere RPG specific filters
+            tier: {
+              oneOf: [
+                { type: 'number', description: 'Exact tier value (1-4)' },
+                {
+                  type: 'object',
+                  properties: {
+                    min: { type: 'number', description: 'Minimum tier (1-4)' },
+                    max: { type: 'number', description: 'Maximum tier (1-4)' }
+                  },
+                  description: 'Tier range object (e.g., {"min": 2, "max": 3})'
+                }
+              ],
+              description: 'Filter by adversary Tier (Cosmere RPG, 1-4). Cosmere\'s primary encounter-design dial.'
+            },
+            role: {
+              type: 'string',
+              description: 'Filter by adversary role (Cosmere RPG). Common values: "minion", "rival", "boss". Case-insensitive.'
+            },
+            hasInvestiture: {
+              type: 'boolean',
+              description: 'Filter for Surge/Investiture-using adversaries (Cosmere RPG)'
+            },
+            hitPoints: {
+              oneOf: [
+                { type: 'number', description: 'Exact health/HP value' },
+                {
+                  type: 'object',
+                  properties: {
+                    min: { type: 'number' },
+                    max: { type: 'number' }
+                  },
+                  description: 'Health/HP range object (e.g., {"min": 30, "max": 80})'
+                }
+              ],
+              description: 'Filter by max health/HP (Cosmere RPG; cross-system field)'
+            },
+            defensesMin: {
+              type: 'object',
+              properties: {
+                phy: { type: 'number', description: 'Minimum Physical defense' },
+                cog: { type: 'number', description: 'Minimum Cognitive defense' },
+                spi: { type: 'number', description: 'Minimum Spiritual defense' }
+              },
+              additionalProperties: false,
+              description: 'Minimum defense thresholds (Cosmere RPG). Pass any subset of phy/cog/spi.'
+            },
+            deflectMin: {
+              type: 'number',
+              description: 'Minimum Deflect rating (Cosmere RPG)'
             },
             limit: {
               type: 'number',
@@ -536,6 +587,64 @@ export class CompendiumTools {
       traits: z.array(z.string()).optional(),
       rarity: z.enum(['common', 'uncommon', 'rare', 'unique']).optional(),
 
+      // Cosmere RPG specific
+      tier: z.union([
+        z.object({
+          min: z.number().optional(),
+          max: z.number().optional(),
+        }),
+        z.string().refine((val) => {
+          try {
+            const parsed = JSON.parse(val);
+            return typeof parsed === 'object' && parsed !== null &&
+                   (typeof parsed.min === 'number' || typeof parsed.max === 'number');
+          } catch {
+            return false;
+          }
+        }, { message: 'Tier range must be valid JSON object with min/max numbers' })
+          .transform((val) => JSON.parse(val) as { min?: number; max?: number }),
+        z.number(),
+        z.string().refine((val) => !isNaN(parseFloat(val)), {
+          message: 'Tier must be a valid number'
+        }).transform((val) => parseFloat(val)),
+      ]).optional(),
+      role: z.string().optional(),
+      hasInvestiture: z.union([
+        z.boolean(),
+        z.string().refine((v) => ['true', 'false'].includes(v.toLowerCase())).transform((v) => v.toLowerCase() === 'true'),
+      ]).optional(),
+      hitPoints: z.union([
+        z.object({
+          min: z.number().optional(),
+          max: z.number().optional(),
+        }),
+        z.string().refine((val) => {
+          try {
+            const parsed = JSON.parse(val);
+            return typeof parsed === 'object' && parsed !== null &&
+                   (typeof parsed.min === 'number' || typeof parsed.max === 'number');
+          } catch {
+            return false;
+          }
+        }, { message: 'hitPoints range must be valid JSON object with min/max numbers' })
+          .transform((val) => JSON.parse(val) as { min?: number; max?: number }),
+        z.number(),
+        z.string().refine((val) => !isNaN(parseFloat(val)), {
+          message: 'hitPoints must be a valid number'
+        }).transform((val) => parseFloat(val)),
+      ]).optional(),
+      defensesMin: z.object({
+        phy: z.number().optional(),
+        cog: z.number().optional(),
+        spi: z.number().optional(),
+      }).optional(),
+      deflectMin: z.union([
+        z.number(),
+        z.string().refine((val) => !isNaN(parseFloat(val)), {
+          message: 'deflectMin must be a valid number'
+        }).transform((val) => parseFloat(val)),
+      ]).optional(),
+
       // Spellcasting flags (different names per system)
       hasSpells: z
         .union([
@@ -626,7 +735,7 @@ export class CompendiumTools {
         criteria: params,
         searchSummary: {
           ...searchSummary,
-          searchStrategy: `Prioritized pack search - ${gameSystem === 'pf2e' ? 'PF2e' : 'D&D 5e'} content first, then modules, then campaign-specific`,
+          searchStrategy: `Prioritized pack search - ${gameSystem === 'pf2e' ? 'PF2e' : gameSystem === 'cosmere-rpg' ? 'Cosmere RPG' : 'D&D 5e'} content first, then modules, then campaign-specific`,
           note: 'Packs searched in priority order to find most relevant creatures first',
         },
         optimizationNote:
@@ -882,6 +991,24 @@ export class CompendiumTools {
       pack: { id: creature.pack, label: creature.packLabel },
     };
 
+    if (gameSystem === 'cosmere-rpg') {
+      // Cosmere fields come pre-flattened from data-access.ts; pass them through.
+      if (creature.tier !== undefined) formatted.tier = creature.tier;
+      if (creature.role) formatted.role = creature.role;
+      if (creature.subtype) formatted.subtype = creature.subtype;
+      if (creature.creatureType) formatted.creatureType = creature.creatureType;
+      if (creature.size) formatted.size = creature.size;
+      if (creature.hitPoints !== undefined) formatted.hitPoints = creature.hitPoints;
+      if (creature.focus !== undefined) formatted.focus = creature.focus;
+      if (creature.investiture !== undefined) formatted.investiture = creature.investiture;
+      if (creature.hasInvestiture !== undefined) formatted.hasInvestiture = creature.hasInvestiture;
+      if (creature.defenses) formatted.defenses = creature.defenses;
+      if (creature.deflect !== undefined) formatted.deflect = creature.deflect;
+      if (creature.walkSpeed !== undefined) formatted.walkSpeed = creature.walkSpeed;
+      if (creature.summary) formatted.summary = creature.summary;
+      return formatted;
+    }
+
     if (gameSystem) {
       // System-specific extraction using detection utilities
       const level = getCreatureLevel(creature, gameSystem);
@@ -1016,6 +1143,38 @@ export class CompendiumTools {
           parts.push(`Level ${min}-${max}`);
         }
       }
+    } else if (gameSystem === 'cosmere-rpg') {
+      if (params.tier !== undefined) {
+        if (typeof params.tier === 'number') {
+          parts.push(`Tier ${params.tier}`);
+        } else if (typeof params.tier === 'object') {
+          const min = params.tier.min ?? 1;
+          const max = params.tier.max ?? 4;
+          parts.push(`Tier ${min}-${max}`);
+        }
+      }
+      if (params.role) parts.push(`role=${String(params.role).toLowerCase()}`);
+      if (params.hasInvestiture !== undefined) {
+        parts.push(params.hasInvestiture ? 'has Investiture' : 'no Investiture');
+      }
+      if (params.hitPoints !== undefined) {
+        if (typeof params.hitPoints === 'number') {
+          parts.push(`hp=${params.hitPoints}`);
+        } else if (typeof params.hitPoints === 'object') {
+          const min = params.hitPoints.min;
+          const max = params.hitPoints.max;
+          if (min !== undefined && max !== undefined) parts.push(`hp ${min}-${max}`);
+          else if (min !== undefined) parts.push(`hp>=${min}`);
+          else if (max !== undefined) parts.push(`hp<=${max}`);
+        }
+      }
+      if (params.defensesMin) {
+        const { phy, cog, spi } = params.defensesMin;
+        if (phy !== undefined) parts.push(`phy>=${phy}`);
+        if (cog !== undefined) parts.push(`cog>=${cog}`);
+        if (spi !== undefined) parts.push(`spi>=${spi}`);
+      }
+      if (params.deflectMin !== undefined) parts.push(`deflect>=${params.deflectMin}`);
     }
 
     if (params.creatureType) parts.push(params.creatureType);

--- a/packages/mcp-server/src/utils/system-detection.ts
+++ b/packages/mcp-server/src/utils/system-detection.ts
@@ -11,7 +11,7 @@ import { Logger } from '../logger.js';
 /**
  * Supported game systems
  */
-export type GameSystem = 'dnd5e' | 'pf2e' | 'other';
+export type GameSystem = 'dnd5e' | 'pf2e' | 'cosmere-rpg' | 'other';
 
 /**
  * Cache for system detection (avoid repeated queries)
@@ -33,7 +33,12 @@ export async function detectGameSystem(
 
   try {
     const worldInfo = await foundryClient.query('foundry-mcp-bridge.getWorldInfo');
-    const systemId = worldInfo.system?.toLowerCase() || '';
+    // Foundry's getWorldInfo can return `system` as either a string (legacy)
+    // or an object `{ id, version }` (current). Accept both.
+    const rawSystem: any = worldInfo.system;
+    const systemId = (typeof rawSystem === 'string'
+      ? rawSystem
+      : rawSystem?.id ?? '').toLowerCase();
 
     cachedSystemId = systemId;
 
@@ -41,6 +46,8 @@ export async function detectGameSystem(
       cachedSystem = 'dnd5e';
     } else if (systemId === 'pf2e') {
       cachedSystem = 'pf2e';
+    } else if (systemId === 'cosmere-rpg') {
+      cachedSystem = 'cosmere-rpg';
     } else {
       cachedSystem = 'other';
     }

--- a/packages/mcp-server/src/utils/system-detection.ts
+++ b/packages/mcp-server/src/utils/system-detection.ts
@@ -33,12 +33,7 @@ export async function detectGameSystem(
 
   try {
     const worldInfo = await foundryClient.query('foundry-mcp-bridge.getWorldInfo');
-    // Foundry's getWorldInfo can return `system` as either a string (legacy)
-    // or an object `{ id, version }` (current). Accept both.
-    const rawSystem: any = worldInfo.system;
-    const systemId = (typeof rawSystem === 'string'
-      ? rawSystem
-      : rawSystem?.id ?? '').toLowerCase();
+    const systemId = (worldInfo.system ?? '').toLowerCase();
 
     cachedSystemId = systemId;
 
@@ -121,7 +116,11 @@ export const SystemPaths = {
 } as const;
 
 /**
- * Get system-specific data paths based on detected system
+ * Get system-specific data paths based on detected system.
+ *
+ * Returns null for systems without registered paths (cosmere-rpg, dsa5, other).
+ * Callers must branch on `system` for those — falling back to dnd5e paths
+ * silently produces wrong values when called against a non-dnd5e actor.
  */
 export function getSystemPaths(system: GameSystem) {
   if (system === 'dnd5e') {
@@ -129,8 +128,7 @@ export function getSystemPaths(system: GameSystem) {
   } else if (system === 'pf2e') {
     return SystemPaths.pf2e;
   }
-  // Default to dnd5e paths for unknown systems (best effort)
-  return SystemPaths.dnd5e;
+  return null;
 }
 
 /**
@@ -157,22 +155,27 @@ export function extractSystemValue(data: any, path: string | null): any {
 
 /**
  * Get creature level/CR based on system
- * Returns a normalized level value for both D&D 5e and PF2e
+ * Returns a normalized level value for D&D 5e, PF2e, and Cosmere RPG.
  */
 export function getCreatureLevel(actorData: any, system: GameSystem): number | undefined {
-  const paths = getSystemPaths(system);
-
   if (system === 'dnd5e') {
     // D&D 5e: Try CR first, then level
-    const cr = extractSystemValue(actorData, paths.challengeRating);
+    const cr = extractSystemValue(actorData, SystemPaths.dnd5e.challengeRating);
     if (cr !== undefined) return Number(cr);
 
-    const level = extractSystemValue(actorData, paths.level);
+    const level = extractSystemValue(actorData, SystemPaths.dnd5e.level);
     if (level !== undefined) return Number(level);
   } else if (system === 'pf2e') {
     // PF2e: Level is the primary metric
-    const level = extractSystemValue(actorData, paths.level);
+    const level = extractSystemValue(actorData, SystemPaths.pf2e.level);
     if (level !== undefined) return Number(level);
+  } else if (system === 'cosmere-rpg') {
+    // Cosmere: tier (1-4) for adversaries, level for player characters
+    const tier = extractSystemValue(actorData, 'system.tier');
+    if (typeof tier === 'number') return tier;
+
+    const level = extractSystemValue(actorData, 'system.level');
+    if (typeof level === 'number') return level;
   }
 
   return undefined;

--- a/scripts/mcp-schema-smoke-test.mjs
+++ b/scripts/mcp-schema-smoke-test.mjs
@@ -23,7 +23,7 @@ const importDist = async (relativePath) =>
 const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { CompendiumTools }, { SceneTools },
   { ActorCreationTools }, { QuestCreationTools }, { DiceRollTools }, { CampaignManagementTools },
   { OwnershipTools }, { TokenManipulationTools }, { MapGenerationTools }, { getSystemRegistry },
-  { DnD5eAdapter }, { PF2eAdapter }, { DSA5Adapter }] = await Promise.all([
+  { DnD5eAdapter }, { PF2eAdapter }, { DSA5Adapter }, { CosmereRpgAdapter }] = await Promise.all([
   importDist('config.js'),
   importDist('logger.js'),
   importDist('foundry-client.js'),
@@ -41,6 +41,7 @@ const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { Compendi
   importDist('systems/dnd5e/adapter.js'),
   importDist('systems/pf2e/adapter.js'),
   importDist('systems/dsa5/adapter.js'),
+  importDist('systems/cosmere-rpg/adapter.js'),
 ]);
 
 const logger = new Logger({ level: 'error', enableConsole: false, enableFile: false });
@@ -50,6 +51,7 @@ const systemRegistry = getSystemRegistry(logger);
 systemRegistry.register(new DnD5eAdapter());
 systemRegistry.register(new PF2eAdapter());
 systemRegistry.register(new DSA5Adapter());
+systemRegistry.register(new CosmereRpgAdapter());
 
 const tools = [
   ...new CharacterTools({ foundryClient, logger, systemRegistry }).getToolDefinitions(),


### PR DESCRIPTION
Adds support for the https://foundryvtt.com/packages/cosmere-rpg Foundry system:                                                                                                                                                                      
  - New cosmere-rpg system module under packages/mcp-server/src/systems/cosmere-rpg/ — adapter, browser-side index builder, filter schema, and system constants (attributes, defenses,
  resources, roles, creature types, sizes).                                                                                                                                                     
  - Registers CosmereRpgAdapter in backend.ts and extends the GameSystem union in utils/system-detection.ts to recognize cosmere-rpg.
  - Compendium and character tools (tools/compendium.ts, tools/character.ts) and data-access.ts updated to surface Cosmere-specific creature/character data (roles, tier, derived stats,        
  defenses, resources).                                                                                                                                                                         
  - Drive-by fix in detectGameSystem: handle worldInfo.system returning either a legacy string or the current { id, version } object so detection works on newer Foundry versions.              
                                                                                                                                                                                                
Test plan                                                                                                                                                                                     
  - Connect against a Foundry world running the Cosmere RPG system and confirm the system is detected as cosmere-rpg.
  - Verify creature/character search and compendium queries return Cosmere-shaped results with filters (role, type, size, tier) applied.