### PR TITLE
chore: Fix broken ESLint config (PR #42 consolidated)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,13 +4,13 @@
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module",
-    "project": ["./tsconfig.json", "./packages/*/tsconfig.json", "./shared/tsconfig.json"]
+    "project": ["./tsconfig.eslint.json"]
   },
   "plugins": ["@typescript-eslint", "prettier"],
   "extends": [
     "eslint:recommended",
-    "@typescript-eslint/recommended",
-    "@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "prettier"
   ],
   "rules": {
@@ -18,7 +18,14 @@
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/explicit-function-return-type": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/no-unsafe-member-access": "warn",
+    "@typescript-eslint/no-unsafe-assignment": "warn",
+    "@typescript-eslint/no-unsafe-call": "warn",
+    "@typescript-eslint/no-unsafe-argument": "warn",
+    "@typescript-eslint/no-unsafe-return": "warn",
+    "@typescript-eslint/require-await": "warn",
+    "@typescript-eslint/restrict-template-expressions": "warn",
+    "@typescript-eslint/prefer-nullish-coalescing": "warn",
     "@typescript-eslint/prefer-optional-chain": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/await-thenable": "error",
@@ -32,5 +39,5 @@
     "node": true,
     "es2022": true
   },
-  "ignorePatterns": ["dist/", "build/", "node_modules/", "*.js"]
+  "ignorePatterns": ["dist/", "build/", "node_modules/", "*.js", "**/*.d.ts"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["./shared/*"],
+      "@foundry-module/*": ["./packages/foundry-module/*"],
+      "@mcp-server/*": ["./packages/mcp-server/src/*"],
+      "@foundry-mcp/shared": ["./shared/src"]
+    },
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["packages/**/*.ts", "shared/**/*.ts"],
+  "exclude": ["node_modules", "**/dist", "**/build"]
+}


### PR DESCRIPTION
Applies @Andrew12000's ESLint config fix from #42, cleanly onto current master.

## Why consolidated instead of merging #42 directly
The original PR #42 branch carried a stale `package-lock.json` (–314 lines, predating the husky/lint-staged deps added in #39). Cherry-picking just the two intended config files onto current master avoids any lockfile drift. Diff is exactly the intended 41/5.

## Problem fixed
`npm run lint` was completely broken — it crashed before running:
- `@typescript-eslint/parser` can't handle the root tsconfig's project references
- the deprecated short-form `extends: "@typescript-eslint/recommended"` no longer resolves

## Changes
- New flat `tsconfig.eslint.json` (no project references) for the parser
- Modern `plugin:@typescript-eslint/...` extends syntax
- New rules at `warn` (non-blocking): `no-unsafe-*` family, `require-await`, `restrict-template-expressions`
- `prefer-nullish-coalescing` downgraded `error` → `warn`
- Ignore `**/*.d.ts`

## Impact
- `npm run lint` now **runs** instead of crashing. It surfaces ~237 pre-existing errors / 7393 warnings — these were always there, just hidden by the crash. Not introduced by this PR.
- **No CI impact** — lint is not referenced in any GitHub workflow (build pipeline only).

## Verification
- [x] `npm run build` passes (all workspaces)
- [x] `npm run format:check` passes
- [x] `npm run lint` runs to completion (exit reflects pre-existing debt, non-blocking)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)