### PR TITLE
feat: world items CRUD and actor item authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Once connected, ask Claude Desktop:
 - **Character Management**: Access stats, abilities, inventory, and detailed entity information
 - **Token Manipulation**: Move, update, delete tokens and manage status conditions
 - **Enhanced Compendium Search**: Instant filtering by CR, type, abilities, and more
-- **Content Creation**: Generate actors, NPCs, and quest journals
+- **Content Creation**: Generate actors, NPCs, and quest journals (with optional folder organisation)
+- **World Item Management**: Create, list, and update world-level Items; attach items directly to actors
 - **Campaign Management**: Multi-part quest tracking with progress dashboards
 - **Interactive Dice System**: Send different dice roll requests to players from Claude
 - **Actor Ownership**: Manage player permissions for characters and tokens
@@ -166,7 +167,7 @@ Once connected, ask Claude Desktop:
 - **34** list-dsa5-archetypes (DSA5 Only)
 - **35** create-dsa5-character-from-archetype (DSA5 Only)
 - **36** create-campaign-dashboard
-- **37** add-actor-items
+- **37** manage-world-items (create / list / update world items, add items to actor)
 
 ## Settings
 

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4418,6 +4418,105 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Add one or more freshly-authored Item documents to an existing Actor.
+   *
+   * Unlike `createActorFromCompendium*`, the items here are constructed from
+   * caller-supplied data — no compendium lookup. This is the path used to
+   * push planner-authored content (talents, actions, powers, custom gear)
+   * onto a PC or NPC sheet.
+   *
+   * Validation is intentionally light: name + type are required, and the
+   * type is checked against the active system's declared Item document
+   * types when available. Everything else (system schema validation,
+   * required sub-fields) is delegated to Foundry's DataModel layer, which
+   * will fill defaults or throw a meaningful error.
+   */
+  async addActorItems(params: {
+    actorIdentifier: string;
+    items: Array<{
+      name: string;
+      type: string;
+      img?: string;
+      system?: Record<string, any>;
+    }>;
+  }): Promise<{
+    actorId: string;
+    actorName: string;
+    created: Array<{ id: string; name: string; type: string }>;
+  }> {
+    this.validateFoundryState();
+
+    const { actorIdentifier, items } = params;
+
+    if (!actorIdentifier) {
+      throw new Error('actorIdentifier is required');
+    }
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new Error('items array is required and must contain at least one entry');
+    }
+
+    const actor = this.findActorByIdentifier(actorIdentifier);
+    if (!actor) {
+      throw new Error(`Actor not found: ${actorIdentifier}`);
+    }
+
+    // Discover the active system's declared Item types so we can give a
+    // useful error before sending the doc to Foundry's DataModel layer.
+    const itemDocTypes = (game as any).system?.documentTypes?.Item;
+    const validTypes: string[] | null =
+      itemDocTypes && typeof itemDocTypes === 'object' ? Object.keys(itemDocTypes) : null;
+
+    const payload = items.map((it, idx) => {
+      if (!it || typeof it.name !== 'string' || it.name.trim().length === 0) {
+        throw new Error(`items[${idx}]: "name" is required and must be a non-empty string`);
+      }
+      if (typeof it.type !== 'string' || it.type.trim().length === 0) {
+        throw new Error(`items[${idx}] ("${it.name}"): "type" is required`);
+      }
+      if (validTypes && !validTypes.includes(it.type)) {
+        throw new Error(
+          `items[${idx}] ("${it.name}"): unknown type "${it.type}" for system "${(game.system as any)?.id}". ` +
+            `Valid Item types: ${validTypes.join(', ')}`
+        );
+      }
+
+      const doc: Record<string, any> = { name: it.name, type: it.type };
+      if (it.img) doc.img = it.img;
+      if (it.system && typeof it.system === 'object') doc.system = it.system;
+      return doc;
+    });
+
+    try {
+      const created = await actor.createEmbeddedDocuments('Item', payload);
+
+      const result = {
+        actorId: actor.id,
+        actorName: actor.name,
+        created: (created || []).map((doc: any) => ({
+          id: doc.id,
+          name: doc.name,
+          type: doc.type,
+        })),
+      };
+
+      this.auditLog(
+        'addActorItems',
+        { actorIdentifier, actorId: actor.id, count: payload.length },
+        'success'
+      );
+      return result;
+    } catch (error) {
+      this.auditLog(
+        'addActorItems',
+        { actorIdentifier, actorId: actor.id, count: payload.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Get full compendium document with all embedded data
    */
   async getCompendiumDocumentFull(

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4517,6 +4517,159 @@ export class FoundryDataAccess {
   }
 
   /**
+   * List world-level Item documents from the Items sidebar.
+   * Optionally filters by type, folder (name or id), or a case-insensitive name substring.
+   */
+  async listWorldItems(params: {
+    type?: string;
+    folder?: string;
+    nameFilter?: string;
+  }): Promise<Array<{
+    id: string;
+    name: string;
+    type: string;
+    img?: string;
+    folderId: string | null;
+    folderName: string | null;
+  }>> {
+    this.validateFoundryState();
+
+    const { type, folder, nameFilter } = params;
+    const nameLower = nameFilter ? nameFilter.toLowerCase() : null;
+
+    // Resolve folder filter to an id if a name/id was provided
+    let folderId: string | null = null;
+    if (folder && folder.trim().length > 0) {
+      const folderTrimmed = folder.trim();
+      const folderDoc = (game as any).folders?.find(
+        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+      ) ?? null;
+      if (!folderDoc) {
+        return [];
+      }
+      folderId = folderDoc.id;
+    }
+
+    const result: Array<{
+      id: string;
+      name: string;
+      type: string;
+      img?: string;
+      folderId: string | null;
+      folderName: string | null;
+    }> = [];
+
+    for (const item of (game as any).items) {
+      if (type && item.type !== type) continue;
+      if (folderId && item.folder?.id !== folderId) continue;
+      if (nameLower && !(item.name ?? '').toLowerCase().includes(nameLower)) continue;
+
+      result.push({
+        id: item.id ?? '',
+        name: item.name ?? '',
+        type: item.type,
+        ...(item.img ? { img: item.img } : {}),
+        folderId: item.folder?.id ?? null,
+        folderName: item.folder?.name ?? null,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Update one or more existing world-level Item documents.
+   *
+   * Each entry must supply an `id` plus at least one field to change (name,
+   * img, system, folder). Uses Item.updateDocuments() for a single batched
+   * write. Folder may be supplied as a name or id; if a name is given that
+   * does not exist, it is created automatically (same behaviour as
+   * createWorldItems).
+   */
+  async updateWorldItems(params: {
+    updates: Array<{
+      id: string;
+      name?: string;
+      img?: string;
+      system?: Record<string, any>;
+      folder?: string;
+    }>;
+  }): Promise<{
+    updated: Array<{ id: string; name: string; type: string }>;
+  }> {
+    this.validateFoundryState();
+
+    const { updates } = params;
+
+    if (!Array.isArray(updates) || updates.length === 0) {
+      throw new Error('updates array is required and must contain at least one entry');
+    }
+
+    // Cache folder resolutions so we only look up / create each folder once
+    const folderCache = new Map<string, string>(); // folder param → folder id
+
+    const resolveFolderId = async (folder: string): Promise<string> => {
+      if (folderCache.has(folder)) return folderCache.get(folder)!;
+      const folderTrimmed = folder.trim();
+      let folderDoc = (game as any).folders?.find(
+        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+      ) ?? null;
+      if (!folderDoc) {
+        folderDoc = await (Folder as any).create({ name: folderTrimmed, type: 'Item', parent: null });
+      }
+      folderCache.set(folder, folderDoc.id);
+      return folderDoc.id;
+    };
+
+    const payload: Array<Record<string, any>> = [];
+
+    for (let idx = 0; idx < updates.length; idx++) {
+      const upd = updates[idx];
+      if (!upd || typeof upd.id !== 'string' || upd.id.trim().length === 0) {
+        throw new Error(`updates[${idx}]: "id" is required and must be a non-empty string`);
+      }
+
+      const item = (game as any).items?.get(upd.id);
+      if (!item) {
+        throw new Error(`updates[${idx}]: Item "${upd.id}" not found in world`);
+      }
+
+      const patch: Record<string, any> = { _id: upd.id };
+      if (upd.name !== undefined) patch.name = upd.name;
+      if (upd.img !== undefined) patch.img = upd.img;
+      if (upd.system !== undefined) patch.system = upd.system;
+      if (upd.folder !== undefined && upd.folder.trim().length > 0) {
+        patch.folder = await resolveFolderId(upd.folder.trim());
+      }
+
+      payload.push(patch);
+    }
+
+    try {
+      const updated = await (Item as any).updateDocuments(payload);
+
+      const result = {
+        updated: (updated || []).map((doc: any) => ({
+          id: doc.id,
+          name: doc.name,
+          type: doc.type,
+        })),
+      };
+
+      this.auditLog('updateWorldItems', { count: payload.length }, 'success');
+      return result;
+    } catch (error) {
+      this.auditLog(
+        'updateWorldItems',
+        { count: payload.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Create one or more world-level Item documents (Items sidebar, not embedded on an actor).
    *
    * Uses Item.createDocuments() with no parent so items appear in the Foundry

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4418,120 +4418,19 @@ export class FoundryDataAccess {
   }
 
   /**
-   * Add one or more freshly-authored Item documents to an existing Actor.
-   *
-   * Unlike `createActorFromCompendium*`, the items here are constructed from
-   * caller-supplied data — no compendium lookup. This is the path used to
-   * push planner-authored content (talents, actions, powers, custom gear)
-   * onto a PC or NPC sheet.
-   *
-   * Validation is intentionally light: name + type are required, and the
-   * type is checked against the active system's declared Item document
-   * types when available. Everything else (system schema validation,
-   * required sub-fields) is delegated to Foundry's DataModel layer, which
-   * will fill defaults or throw a meaningful error.
-   */
-  async addActorItems(params: {
-    actorIdentifier: string;
-    items: Array<{
-      name: string;
-      type: string;
-      img?: string;
-      system?: Record<string, any>;
-    }>;
-  }): Promise<{
-    actorId: string;
-    actorName: string;
-    created: Array<{ id: string; name: string; type: string }>;
-  }> {
-    this.validateFoundryState();
-
-    const { actorIdentifier, items } = params;
-
-    if (!actorIdentifier) {
-      throw new Error('actorIdentifier is required');
-    }
-    if (!Array.isArray(items) || items.length === 0) {
-      throw new Error('items array is required and must contain at least one entry');
-    }
-
-    const actor = this.findActorByIdentifier(actorIdentifier);
-    if (!actor) {
-      throw new Error(`Actor not found: ${actorIdentifier}`);
-    }
-
-    // Discover the active system's declared Item types so we can give a
-    // useful error before sending the doc to Foundry's DataModel layer.
-    const itemDocTypes = (game as any).system?.documentTypes?.Item;
-    const validTypes: string[] | null =
-      itemDocTypes && typeof itemDocTypes === 'object' ? Object.keys(itemDocTypes) : null;
-
-    const payload = items.map((it, idx) => {
-      if (!it || typeof it.name !== 'string' || it.name.trim().length === 0) {
-        throw new Error(`items[${idx}]: "name" is required and must be a non-empty string`);
-      }
-      if (typeof it.type !== 'string' || it.type.trim().length === 0) {
-        throw new Error(`items[${idx}] ("${it.name}"): "type" is required`);
-      }
-      if (validTypes && !validTypes.includes(it.type)) {
-        throw new Error(
-          `items[${idx}] ("${it.name}"): unknown type "${it.type}" for system "${(game.system as any)?.id}". ` +
-            `Valid Item types: ${validTypes.join(', ')}`
-        );
-      }
-
-      const doc: Record<string, any> = { name: it.name, type: it.type };
-      if (it.img) doc.img = it.img;
-      if (it.system && typeof it.system === 'object') doc.system = it.system;
-      return doc;
-    });
-
-    try {
-      const created = await actor.createEmbeddedDocuments('Item', payload);
-
-      const result = {
-        actorId: actor.id,
-        actorName: actor.name,
-        created: (created || []).map((doc: any) => ({
-          id: doc.id,
-          name: doc.name,
-          type: doc.type,
-        })),
-      };
-
-      this.auditLog(
-        'addActorItems',
-        { actorIdentifier, actorId: actor.id, count: payload.length },
-        'success'
-      );
-      return result;
-    } catch (error) {
-      this.auditLog(
-        'addActorItems',
-        { actorIdentifier, actorId: actor.id, count: payload.length },
-        'failure',
-        error instanceof Error ? error.message : 'Unknown error'
-      );
-      throw error;
-    }
-  }
-
-  /**
    * List world-level Item documents from the Items sidebar.
    * Optionally filters by type, folder (name or id), or a case-insensitive name substring.
    */
-  async listWorldItems(params: {
-    type?: string;
-    folder?: string;
-    nameFilter?: string;
-  }): Promise<Array<{
-    id: string;
-    name: string;
-    type: string;
-    img?: string;
-    folderId: string | null;
-    folderName: string | null;
-  }>> {
+  async listWorldItems(params: { type?: string; folder?: string; nameFilter?: string }): Promise<
+    Array<{
+      id: string;
+      name: string;
+      type: string;
+      img?: string;
+      folderId: string | null;
+      folderName: string | null;
+    }>
+  > {
     this.validateFoundryState();
 
     const { type, folder, nameFilter } = params;
@@ -4541,9 +4440,10 @@ export class FoundryDataAccess {
     let folderId: string | null = null;
     if (folder && folder.trim().length > 0) {
       const folderTrimmed = folder.trim();
-      const folderDoc = (game as any).folders?.find(
-        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
-      ) ?? null;
+      const folderDoc =
+        (game as any).folders?.find(
+          (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+        ) ?? null;
       if (!folderDoc) {
         return [];
       }
@@ -4611,11 +4511,16 @@ export class FoundryDataAccess {
     const resolveFolderId = async (folder: string): Promise<string> => {
       if (folderCache.has(folder)) return folderCache.get(folder)!;
       const folderTrimmed = folder.trim();
-      let folderDoc = (game as any).folders?.find(
-        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
-      ) ?? null;
+      let folderDoc =
+        (game as any).folders?.find(
+          (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+        ) ?? null;
       if (!folderDoc) {
-        folderDoc = await (Folder as any).create({ name: folderTrimmed, type: 'Item', parent: null });
+        folderDoc = await (Folder as any).create({
+          name: folderTrimmed,
+          type: 'Item',
+          parent: null,
+        });
       }
       folderCache.set(folder, folderDoc.id);
       return folderDoc.id;
@@ -4725,12 +4630,17 @@ export class FoundryDataAccess {
     let folderDoc: any = null;
     if (folder && folder.trim().length > 0) {
       const folderTrimmed = folder.trim();
-      folderDoc = (game as any).folders?.find(
-        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
-      ) ?? null;
+      folderDoc =
+        (game as any).folders?.find(
+          (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+        ) ?? null;
 
       if (!folderDoc) {
-        folderDoc = await (Folder as any).create({ name: folderTrimmed, type: 'Item', parent: null });
+        folderDoc = await (Folder as any).create({
+          name: folderTrimmed,
+          type: 'Item',
+          parent: null,
+        });
       }
 
       for (const doc of payload) {

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4517,6 +4517,105 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Create one or more world-level Item documents (Items sidebar, not embedded on an actor).
+   *
+   * Uses Item.createDocuments() with no parent so items appear in the Foundry
+   * Items sidebar and can be dragged onto any actor sheet. Optionally places
+   * items inside a named/id-resolved folder, creating the folder if necessary.
+   */
+  async createWorldItems(params: {
+    items: Array<{
+      name: string;
+      type: string;
+      img?: string;
+      system?: Record<string, any>;
+    }>;
+    folder?: string;
+  }): Promise<{
+    folderId: string | null;
+    folderName: string | null;
+    created: Array<{ id: string; name: string; type: string }>;
+  }> {
+    this.validateFoundryState();
+
+    const { items, folder } = params;
+
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new Error('items array is required and must contain at least one entry');
+    }
+
+    const itemDocTypes = (game as any).system?.documentTypes?.Item;
+    const validTypes: string[] | null =
+      itemDocTypes && typeof itemDocTypes === 'object' ? Object.keys(itemDocTypes) : null;
+
+    const payload = items.map((it, idx) => {
+      if (!it || typeof it.name !== 'string' || it.name.trim().length === 0) {
+        throw new Error(`items[${idx}]: "name" is required and must be a non-empty string`);
+      }
+      if (typeof it.type !== 'string' || it.type.trim().length === 0) {
+        throw new Error(`items[${idx}] ("${it.name}"): "type" is required`);
+      }
+      if (validTypes && !validTypes.includes(it.type)) {
+        throw new Error(
+          `items[${idx}] ("${it.name}"): unknown type "${it.type}" for system "${(game.system as any)?.id}". ` +
+            `Valid Item types: ${validTypes.join(', ')}`
+        );
+      }
+
+      const doc: Record<string, any> = { name: it.name, type: it.type };
+      if (it.img) doc.img = it.img;
+      if (it.system && typeof it.system === 'object') doc.system = it.system;
+      return doc;
+    });
+
+    // Resolve or create the target folder
+    let folderDoc: any = null;
+    if (folder && folder.trim().length > 0) {
+      const folderTrimmed = folder.trim();
+      folderDoc = (game as any).folders?.find(
+        (f: any) => f.type === 'Item' && (f.name === folderTrimmed || f.id === folderTrimmed)
+      ) ?? null;
+
+      if (!folderDoc) {
+        folderDoc = await (Folder as any).create({ name: folderTrimmed, type: 'Item', parent: null });
+      }
+
+      for (const doc of payload) {
+        doc.folder = folderDoc.id;
+      }
+    }
+
+    try {
+      const created = await (Item as any).createDocuments(payload);
+
+      const result = {
+        folderId: folderDoc ? folderDoc.id : null,
+        folderName: folderDoc ? folderDoc.name : null,
+        created: (created || []).map((doc: any) => ({
+          id: doc.id,
+          name: doc.name,
+          type: doc.type,
+        })),
+      };
+
+      this.auditLog(
+        'createWorldItems',
+        { folder: folder ?? null, count: payload.length },
+        'success'
+      );
+      return result;
+    } catch (error) {
+      this.auditLog(
+        'createWorldItems',
+        { folder: folder ?? null, count: payload.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Get full compendium document with all embedded data
    */
   async getCompendiumDocumentFull(

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -114,8 +114,10 @@ export class QueryHandlers {
     // Item authoring on actor sheets
     CONFIG.queries[`${modulePrefix}.addActorItems`] = this.handleAddActorItems.bind(this);
 
-    // World-level item creation
+    // World-level item CRUD
     CONFIG.queries[`${modulePrefix}.createWorldItems`] = this.handleCreateWorldItems.bind(this);
+    CONFIG.queries[`${modulePrefix}.listWorldItems`] = this.handleListWorldItems.bind(this);
+    CONFIG.queries[`${modulePrefix}.updateWorldItems`] = this.handleUpdateWorldItems.bind(this);
 
     // Phase 7: Token manipulation queries
     CONFIG.queries[`${modulePrefix}.move-token`] = this.handleMoveToken.bind(this);
@@ -1503,6 +1505,56 @@ export class QueryHandlers {
       throw new Error(
         `Failed to add actor items: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  private async handleUpdateWorldItems(data: {
+    updates: Array<{
+      id: string;
+      name?: string;
+      img?: string;
+      system?: Record<string, any>;
+      folder?: string;
+    }>;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!Array.isArray(data?.updates) || data.updates.length === 0) {
+        throw new Error('updates array is required and must contain at least one entry');
+      }
+
+      return await this.dataAccess.updateWorldItems({ updates: data.updates });
+    } catch (error) {
+      throw new Error(`Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  private async handleListWorldItems(data: {
+    type?: string;
+    folder?: string;
+    nameFilter?: string;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      return await this.dataAccess.listWorldItems({
+        ...(data.type !== undefined ? { type: data.type } : {}),
+        ...(data.folder !== undefined ? { folder: data.folder } : {}),
+        ...(data.nameFilter !== undefined ? { nameFilter: data.nameFilter } : {}),
+      });
+    } catch (error) {
+      throw new Error(`Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -114,6 +114,9 @@ export class QueryHandlers {
     // Item authoring on actor sheets
     CONFIG.queries[`${modulePrefix}.addActorItems`] = this.handleAddActorItems.bind(this);
 
+    // World-level item creation
+    CONFIG.queries[`${modulePrefix}.createWorldItems`] = this.handleCreateWorldItems.bind(this);
+
     // Phase 7: Token manipulation queries
     CONFIG.queries[`${modulePrefix}.move-token`] = this.handleMoveToken.bind(this);
     CONFIG.queries[`${modulePrefix}.update-token`] = this.handleUpdateToken.bind(this);
@@ -1502,4 +1505,38 @@ export class QueryHandlers {
       );
     }
   }
+
+  private async handleCreateWorldItems(data: {
+    items: Array<{
+      name: string;
+      type: string;
+      img?: string;
+      system?: Record<string, any>;
+    }>;
+    folder?: string;
+  }): Promise<any> {
+    try {
+      // SECURITY: World item creation is GM-only
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!Array.isArray(data?.items) || data.items.length === 0) {
+        throw new Error('items array is required and must contain at least one entry');
+      }
+
+      return await this.dataAccess.createWorldItems({
+        items: data.items,
+        ...(data.folder !== undefined ? { folder: data.folder } : {}),
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to create world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
 }

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -547,6 +547,7 @@ export class QueryHandlers {
         name: data.name,
         content: data.content,
         additionalPages: data.additionalPages,
+        folderName: data.folderName,
       });
     } catch (error) {
       throw new Error(

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1487,26 +1487,8 @@ async function startBackend(): Promise<void> {
 
                   break;
 
-                case 'add-actor-items':
-                  result = await characterTools.handleAddActorItems(args);
-
-                  break;
-
-                case 'update-world-items':
-
-                  result = await characterTools.handleUpdateWorldItems(args);
-
-                  break;
-
-                case 'list-world-items':
-
-                  result = await characterTools.handleListWorldItems(args);
-
-                  break;
-
-                case 'create-world-items':
-
-                  result = await characterTools.handleCreateWorldItems(args);
+                case 'manage-world-items':
+                  result = await characterTools.handleManageWorldItems(args);
 
                   break;
 

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1492,6 +1492,18 @@ async function startBackend(): Promise<void> {
 
                   break;
 
+                case 'update-world-items':
+
+                  result = await characterTools.handleUpdateWorldItems(args);
+
+                  break;
+
+                case 'list-world-items':
+
+                  result = await characterTools.handleListWorldItems(args);
+
+                  break;
+
                 case 'create-world-items':
 
                   result = await characterTools.handleCreateWorldItems(args);

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1492,6 +1492,12 @@ async function startBackend(): Promise<void> {
 
                   break;
 
+                case 'create-world-items':
+
+                  result = await characterTools.handleCreateWorldItems(args);
+
+                  break;
+
                 // Compendium tools
 
                 case 'search-compendium':

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -140,76 +140,59 @@ export class CharacterTools {
         },
       },
       {
-        name: 'add-actor-items',
+        name: 'manage-world-items',
         description:
-          'Add one or more freshly-authored Item documents (talents, actions, powers, equipment, etc.) to an existing actor. Items are constructed from the supplied data — no compendium lookup is performed. Each item requires a non-empty "name" and a "type" valid for the active game system (e.g. Cosmere RPG: "action", "talent", "power", "weapon", "armor", "equipment", "loot", "ancestry", "culture", "path", "specialty", "trait", "injury", "connection", "goal", "talent_tree"). Pass system-specific data via the optional "system" object — Foundry\'s DataModel layer fills defaults and validates required sub-fields. GM-only. Returns the created item IDs so callers can update or roll them next.',
+          'Manage Item documents in Foundry VTT. Specify the operation with "action":\n' +
+          '- "create": Create world-level Items in the sidebar (not actor-attached). Good for reusable libraries. GM-only.\n' +
+          '- "list": List world-level Items with optional type/folder/name filters.\n' +
+          '- "update": Update existing world-level Items by ID. GM-only.\n' +
+          '- "add-to-actor": Create and attach Items directly to an existing actor. GM-only.',
         inputSchema: {
           type: 'object',
           properties: {
-            actorIdentifier: {
+            action: {
               type: 'string',
-              description: 'Actor name or ID to receive the items',
+              enum: ['create', 'list', 'update', 'add-to-actor'],
+              description:
+                'Operation to perform: "create" world items, "list" world items, "update" world items by id, or "add-to-actor" to attach items to an actor.',
             },
             items: {
               type: 'array',
               minItems: 1,
-              description: 'One or more items to create on the actor sheet',
+              description:
+                'Required for "create" and "add-to-actor". One or more items to create. Each item requires a name and a type valid for the active game system (e.g. "action", "talent", "weapon"). For Cosmere RPG add-to-actor, pass system-specific data via the "system" field.',
               items: {
                 type: 'object',
                 properties: {
-                  name: {
-                    type: 'string',
-                    description: 'Display name of the item',
-                  },
+                  name: { type: 'string', description: 'Display name of the item' },
                   type: {
                     type: 'string',
-                    description:
-                      'Item type valid for the active system (e.g. "action", "talent", "weapon")',
+                    description: 'Item type valid for the active system (e.g. "action", "talent", "weapon")',
                   },
                   img: {
                     type: 'string',
-                    description:
-                      'Optional icon path (e.g. "icons/svg/explosion.svg" or a system-bundled path)',
+                    description: 'Optional icon path (e.g. "icons/svg/explosion.svg")',
                   },
                   system: {
                     type: 'object',
-                    description:
-                      'System-specific data (free-form). For Cosmere actions: { activation: { type: "utility", cost: { value: 1, type: "act" }, consume: [{ type: "resource", resource: "foc", value: { min: 2, max: 2 } }] }, description: { value: "<p>HTML</p>" } }',
+                    description: 'System-specific data (free-form). Passed through to Foundry\'s DataModel layer.',
                     additionalProperties: true,
                   },
                 },
                 required: ['name', 'type'],
               },
             },
-          },
-          required: ['actorIdentifier', 'items'],
-        },
-      },
-      {
-        name: 'update-world-items',
-        description: 'Update one or more existing world-level Item documents in Foundry\'s Items sidebar. Accepts an array of patches — each entry must include the item\'s id and at least one field to change (name, img, system, folder). system data is merged at the top level by Foundry\'s DataModel. Folder may be a name or id; a missing folder is created automatically. GM-only. Use list-world-items first to obtain item IDs.',
-        inputSchema: {
-          type: 'object',
-          properties: {
             updates: {
               type: 'array',
               minItems: 1,
-              description: 'One or more item patches to apply',
+              description:
+                'Required for "update". One or more item patches. Each entry must include "id" plus at least one field to change (name, img, system, folder).',
               items: {
                 type: 'object',
                 properties: {
-                  id: {
-                    type: 'string',
-                    description: 'ID of the world Item to update',
-                  },
-                  name: {
-                    type: 'string',
-                    description: 'New display name',
-                  },
-                  img: {
-                    type: 'string',
-                    description: 'New icon path',
-                  },
+                  id: { type: 'string', description: 'ID of the world Item to update' },
+                  name: { type: 'string', description: 'New display name' },
+                  img: { type: 'string', description: 'New icon path' },
                   system: {
                     type: 'object',
                     description: 'System-specific fields to update (merged into existing system data)',
@@ -223,71 +206,25 @@ export class CharacterTools {
                 required: ['id'],
               },
             },
-          },
-          required: ['updates'],
-        },
-      },
-      {
-        name: 'list-world-items',
-        description: 'List world-level Item documents from Foundry\'s Items sidebar (not actor-embedded items). Supports optional filtering by item type, folder name/ID, or a case-insensitive name substring. Returns id, name, type, img, and folder info for each match. Useful for checking what library items already exist before calling create-world-items.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            type: {
-              type: 'string',
-              description: 'Filter by item type (e.g. "action", "talent", "weapon"). Omit to return all types.',
-            },
             folder: {
               type: 'string',
-              description: 'Filter to items inside this folder (name or ID). Returns empty array if the folder does not exist.',
+              description:
+                'For "create": folder name/ID to place items in (created if absent). For "list": filter to items inside this folder.',
+            },
+            type: {
+              type: 'string',
+              description: 'For "list": filter by item type (e.g. "action", "talent"). Omit to return all types.',
             },
             nameFilter: {
               type: 'string',
-              description: 'Case-insensitive substring match on item name.',
+              description: 'For "list": case-insensitive substring match on item name.',
             },
-          },
-        },
-      },
-      {
-        name: 'create-world-items',
-        description: 'Creates world-level Item documents in Foundry\'s Items sidebar. Items are NOT attached to any actor — the GM (or players, if owned) can drag-and-drop from the sidebar onto any actor sheet. Use this for reusable libraries (spell lists, action collections, gear catalogs). For items that should live on a specific actor, use add-actor-items instead. GM-only.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            items: {
-              type: 'array',
-              minItems: 1,
-              description: 'One or more items to create in the world Items sidebar',
-              items: {
-                type: 'object',
-                properties: {
-                  name: {
-                    type: 'string',
-                    description: 'Display name of the item',
-                  },
-                  type: {
-                    type: 'string',
-                    description: 'Item type valid for the active system (e.g. "action", "talent", "weapon")',
-                  },
-                  img: {
-                    type: 'string',
-                    description: 'Optional icon path (e.g. "icons/svg/explosion.svg" or a system-bundled path)',
-                  },
-                  system: {
-                    type: 'object',
-                    description: 'System-specific data (free-form). Passed through unchanged to Foundry\'s DataModel layer.',
-                    additionalProperties: true,
-                  },
-                },
-                required: ['name', 'type'],
-              },
-            },
-            folder: {
+            actorIdentifier: {
               type: 'string',
-              description: 'Optional folder name or ID. If the folder does not exist it will be created. Omit to place items at the sidebar root.',
+              description: 'For "add-to-actor": actor name or ID to receive the items.',
             },
           },
-          required: ['items'],
+          required: ['action'],
         },
       },
       {
@@ -693,6 +630,21 @@ export class CharacterTools {
     } catch (error) {
       this.logger.error('Failed to create world items', error);
       throw new Error(`Failed to create world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async handleManageWorldItems(args: any): Promise<any> {
+    const { action } = z.object({ action: z.enum(['create', 'list', 'update', 'add-to-actor']) }).parse(args);
+
+    switch (action) {
+      case 'create':
+        return this.handleCreateWorldItems(args);
+      case 'list':
+        return this.handleListWorldItems(args);
+      case 'update':
+        return this.handleUpdateWorldItems(args);
+      case 'add-to-actor':
+        return this.handleAddActorItems(args);
     }
   }
 

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -186,6 +186,69 @@ export class CharacterTools {
         },
       },
       {
+        name: 'update-world-items',
+        description: 'Update one or more existing world-level Item documents in Foundry\'s Items sidebar. Accepts an array of patches — each entry must include the item\'s id and at least one field to change (name, img, system, folder). system data is merged at the top level by Foundry\'s DataModel. Folder may be a name or id; a missing folder is created automatically. GM-only. Use list-world-items first to obtain item IDs.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            updates: {
+              type: 'array',
+              minItems: 1,
+              description: 'One or more item patches to apply',
+              items: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string',
+                    description: 'ID of the world Item to update',
+                  },
+                  name: {
+                    type: 'string',
+                    description: 'New display name',
+                  },
+                  img: {
+                    type: 'string',
+                    description: 'New icon path',
+                  },
+                  system: {
+                    type: 'object',
+                    description: 'System-specific fields to update (merged into existing system data)',
+                    additionalProperties: true,
+                  },
+                  folder: {
+                    type: 'string',
+                    description: 'Move item into this folder (name or ID). Created if absent.',
+                  },
+                },
+                required: ['id'],
+              },
+            },
+          },
+          required: ['updates'],
+        },
+      },
+      {
+        name: 'list-world-items',
+        description: 'List world-level Item documents from Foundry\'s Items sidebar (not actor-embedded items). Supports optional filtering by item type, folder name/ID, or a case-insensitive name substring. Returns id, name, type, img, and folder info for each match. Useful for checking what library items already exist before calling create-world-items.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              description: 'Filter by item type (e.g. "action", "talent", "weapon"). Omit to return all types.',
+            },
+            folder: {
+              type: 'string',
+              description: 'Filter to items inside this folder (name or ID). Returns empty array if the folder does not exist.',
+            },
+            nameFilter: {
+              type: 'string',
+              description: 'Case-insensitive substring match on item name.',
+            },
+          },
+        },
+      },
+      {
         name: 'create-world-items',
         description: 'Creates world-level Item documents in Foundry\'s Items sidebar. Items are NOT attached to any actor — the GM (or players, if owned) can drag-and-drop from the sidebar onto any actor sheet. Use this for reusable libraries (spell lists, action collections, gear catalogs). For items that should live on a specific actor, use add-actor-items instead. GM-only.',
         inputSchema: {
@@ -526,6 +589,70 @@ export class CharacterTools {
       throw new Error(
         `Failed to add items to "${actorIdentifier}": ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  async handleUpdateWorldItems(args: any): Promise<any> {
+    const updateEntrySchema = z.object({
+      id: z.string().min(1, 'Item id cannot be empty'),
+      name: z.string().optional(),
+      img: z.string().optional(),
+      system: z.record(z.any()).optional(),
+      folder: z.string().optional(),
+    });
+
+    const schema = z.object({
+      updates: z.array(updateEntrySchema).min(1, 'At least one update entry is required'),
+    });
+
+    const { updates } = schema.parse(args);
+
+    this.logger.info('Updating world items', {
+      count: updates.length,
+      ids: updates.map(u => u.id),
+    });
+
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.updateWorldItems', { updates });
+
+      this.logger.debug('Successfully updated world items', { count: result.updated?.length ?? 0 });
+
+      return result;
+
+    } catch (error) {
+      this.logger.error('Failed to update world items', error);
+      throw new Error(`Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async handleListWorldItems(args: any): Promise<any> {
+    const schema = z.object({
+      type: z.string().optional(),
+      folder: z.string().optional(),
+      nameFilter: z.string().optional(),
+    });
+
+    const { type, folder, nameFilter } = schema.parse(args);
+
+    this.logger.info('Listing world items', { type: type ?? null, folder: folder ?? null, nameFilter: nameFilter ?? null });
+
+    try {
+      const items = await this.foundryClient.query('foundry-mcp-bridge.listWorldItems', {
+        ...(type !== undefined ? { type } : {}),
+        ...(folder !== undefined ? { folder } : {}),
+        ...(nameFilter !== undefined ? { nameFilter } : {}),
+      });
+
+      this.logger.debug('Successfully listed world items', { count: items?.length ?? 0 });
+
+      return {
+        items: items ?? [],
+        total: items?.length ?? 0,
+      };
+
+    } catch (error) {
+      this.logger.error('Failed to list world items', error);
+      throw new Error(`Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -186,6 +186,48 @@ export class CharacterTools {
         },
       },
       {
+        name: 'create-world-items',
+        description: 'Creates world-level Item documents in Foundry\'s Items sidebar. Items are NOT attached to any actor — the GM (or players, if owned) can drag-and-drop from the sidebar onto any actor sheet. Use this for reusable libraries (spell lists, action collections, gear catalogs). For items that should live on a specific actor, use add-actor-items instead. GM-only.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              minItems: 1,
+              description: 'One or more items to create in the world Items sidebar',
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: 'Display name of the item',
+                  },
+                  type: {
+                    type: 'string',
+                    description: 'Item type valid for the active system (e.g. "action", "talent", "weapon")',
+                  },
+                  img: {
+                    type: 'string',
+                    description: 'Optional icon path (e.g. "icons/svg/explosion.svg" or a system-bundled path)',
+                  },
+                  system: {
+                    type: 'object',
+                    description: 'System-specific data (free-form). Passed through unchanged to Foundry\'s DataModel layer.',
+                    additionalProperties: true,
+                  },
+                },
+                required: ['name', 'type'],
+              },
+            },
+            folder: {
+              type: 'string',
+              description: 'Optional folder name or ID. If the folder does not exist it will be created. Omit to place items at the sidebar root.',
+            },
+          },
+          required: ['items'],
+        },
+      },
+      {
         name: 'search-character-items',
         description:
           "Search within a character's items, spells, actions, and effects. More token-efficient than get-character when you need specific items. Supports text search (name/description) and type filtering. Returns matching items with full details including targeting info for spells. Use this to find specific spells, equipment, feats, or abilities without loading the entire character.",
@@ -484,6 +526,46 @@ export class CharacterTools {
       throw new Error(
         `Failed to add items to "${actorIdentifier}": ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  async handleCreateWorldItems(args: any): Promise<any> {
+    const itemSchema = z.object({
+      name: z.string().min(1, 'Item name cannot be empty'),
+      type: z.string().min(1, 'Item type cannot be empty'),
+      img: z.string().optional(),
+      system: z.record(z.any()).optional(),
+    });
+
+    const schema = z.object({
+      items: z.array(itemSchema).min(1, 'At least one item is required'),
+      folder: z.string().optional(),
+    });
+
+    const { items, folder } = schema.parse(args);
+
+    this.logger.info('Creating world items', {
+      count: items.length,
+      folder: folder ?? null,
+      types: items.map(i => i.type),
+    });
+
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.createWorldItems', {
+        items,
+        folder,
+      });
+
+      this.logger.debug('Successfully created world items', {
+        folderId: result.folderId,
+        created: result.created?.length ?? 0,
+      });
+
+      return result;
+
+    } catch (error) {
+      this.logger.error('Failed to create world items', error);
+      throw new Error(`Failed to create world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/packages/mcp-server/src/tools/quest-creation.ts
+++ b/packages/mcp-server/src/tools/quest-creation.ts
@@ -119,6 +119,11 @@ export class QuestCreationTools {
               description:
                 'Optional additional pages to create alongside the main quest page. Use for multi-page journals with separate sections like Player Handout, GM Notes, etc.',
             },
+            folderName: {
+              type: 'string',
+              description:
+                'Optional folder name to organize the journal into. The folder is created automatically if it does not exist.',
+            },
           },
           required: ['questTitle', 'questDescription'],
         },
@@ -257,6 +262,7 @@ export class QuestCreationTools {
             })
           )
           .optional(),
+        folderName: z.string().optional(),
       });
 
       const request = requestSchema.parse(args);
@@ -269,6 +275,7 @@ export class QuestCreationTools {
         name: request.questTitle,
         content: questContent,
         additionalPages: request.additionalPages,
+        ...(request.folderName ? { folderName: request.folderName } : {}),
       });
 
       if (!result || result.error) {


### PR DESCRIPTION
  Adds three new MCP tools for managing items at the world and actor level:

  - `add-actor-items` — Create and attach one or more item documents directly to an existing actor. Accepts a name, system-valid type, optional img, and a free-form system data object. GM-only.
  - `create-world-items` — Create item documents in the world (not attached to any actor). Supports optional folder placement. GM-only.
  - `list-world-items` — List world items with optional filtering by type, folder, and name.

  Also extends `create-quest-journal` with an optional `folderName` parameter — the folder is created automatically if it doesn't already exist.