### PR TITLE
Auto-detect `wss://` protocol for HTTPS Foundry instances

### DIFF
--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -100,10 +100,11 @@ export class SocketBridge {
     // Auto-detect protocol: wss for HTTPS pages, ws for HTTP
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const host = this.config.serverHost;
-    // Use page port when connecting to same origin (e.g. behind a reverse proxy)
-    const port = host === window.location.hostname
-      ? window.location.port || (protocol === 'wss' ? '443' : '80')
-      : this.config.serverPort;
+    // Behind a TLS reverse proxy the MCP path is served on the same origin as the page,
+    // so use the page's port. On plain HTTP (localhost) the MCP backend is a separate
+    // process on the configured port, so the page port must not be used there.
+    const sameOrigin = protocol === 'wss' && host === window.location.hostname;
+    const port = sameOrigin ? window.location.port || '443' : this.config.serverPort;
     this.log(`Using WebSocket (${protocol}://${host}:${port}${this.config.namespace})`);
 
     const wsUrl = `${protocol}://${host}:${port}${this.config.namespace}`;

--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -97,12 +97,16 @@ export class SocketBridge {
   private async connectWebSocket(): Promise<void> {
     this.activeConnectionType = 'websocket';
 
-    // WebSocket for HTTP localhost connections only
-    const protocol = 'ws';
+    // Auto-detect protocol: wss for HTTPS pages, ws for HTTP
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const host = this.config.serverHost;
-    this.log(`Using WebSocket (${protocol}://${host}:${this.config.serverPort})`);
+    // Use page port when connecting to same origin (e.g. behind a reverse proxy)
+    const port = host === window.location.hostname
+      ? window.location.port || (protocol === 'wss' ? '443' : '80')
+      : this.config.serverPort;
+    this.log(`Using WebSocket (${protocol}://${host}:${port}${this.config.namespace})`);
 
-    const wsUrl = `${protocol}://${host}:${this.config.serverPort}${this.config.namespace}`;
+    const wsUrl = `${protocol}://${host}:${port}${this.config.namespace}`;
 
     return new Promise((resolve, reject) => {
       const connectTimeout = setTimeout(() => {


### PR DESCRIPTION
Hey @adambdooley, thanks for this cool project!

I'm running a Foundry instance on Docker behind a reverse proxy with TLS. I ran into issues with the connection between the MCP and Foundry Module and did some debugging into why. Even though I'm running the MCP on the same VPS server as the instance, since the Foundry instance has TLS and is on Docker, the best way to connect to it is still via a WSS connection.

Browsers block insecure WebSocket (`ws://`) connections from pages served over HTTPS (mixed content policy). The `connectWebSocket()` method previously hardcoded `ws` as the protocol, causing connections to silently fail on any Foundry instance behind an SSL/TLS reverse proxy (like mine 😄).

Changes:
- Auto-detect `wss://` vs `ws://` based on `window.location.protocol`
- Use page port when connecting to same origin (reverse proxy setups)
- Fall back to configured `serverPort` for cross-origin connections