### PR TITLE
feat: add WFRP4e (Warhammer Fantasy Roleplay 4e) system support

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -1791,6 +1791,12 @@ export class FoundryDataAccess {
           if (targeting.target) result.target = targeting.target;
           if (targeting.area) result.area = targeting.area;
           result.actionCost = itemSystem?.castingTime?.value;
+        } else if (systemId === 'wfrp4e') {
+          // WFRP4e spells use a Casting Number (CN) rather than levels/slots.
+          if (itemSystem?.range?.value) result.range = itemSystem.range.value;
+          if (itemSystem?.target?.value) result.target = itemSystem.target.value;
+          const cn = itemSystem?.cn?.value;
+          if (cn !== undefined && cn !== null) result.actionCost = `CN ${cn}`;
         }
 
         // Category filter for spells
@@ -1818,6 +1824,23 @@ export class FoundryDataAccess {
           if (searchCategory === 'equipped' && !result.equipped) continue;
           if (searchCategory === 'invested' && !result.invested) continue;
         }
+      }
+
+      // WFRP4e equipment fields (British 'armour'; 'trapping' is generic gear)
+      if (
+        systemId === 'wfrp4e' &&
+        ['weapon', 'armour', 'trapping', 'ammunition', 'container'].includes(item.type)
+      ) {
+        result.quantity = itemSystem?.quantity?.value ?? 1;
+        result.equipped = itemSystem?.equipped?.value ?? (item as any).isEquipped ?? false;
+
+        if (searchCategory === 'equipped' && !result.equipped) continue;
+      }
+
+      // WFRP4e prayer targeting (divine magic; item type 'prayer')
+      if (systemId === 'wfrp4e' && item.type === 'prayer') {
+        if (itemSystem?.range?.value) result.range = itemSystem.range.value;
+        if (itemSystem?.target?.value) result.target = itemSystem.target.value;
       }
 
       // Feat/feature fields
@@ -1924,7 +1947,7 @@ export class FoundryDataAccess {
   }
 
   /**
-   * Extract spellcasting data from an actor (supports PF2e and D&D 5e)
+   * Extract spellcasting data from an actor (supports PF2e, D&D 5e, DSA5, and WFRP4e)
    */
   private extractSpellcastingData(actor: Actor): SpellcastingEntry[] {
     const entries: SpellcastingEntry[] = [];
@@ -2221,6 +2244,63 @@ export class FoundryDataAccess {
               };
             })
             .sort((a, b) => a.level - b.level || a.name.localeCompare(b.name)),
+        });
+      }
+    } else if (systemId === 'wfrp4e') {
+      // WFRP4e: arcane spells grouped by Lore, divine prayers grouped by God.
+      // WFRP4e has no spell levels or slots; spells use a Casting Number (CN).
+      const cap = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+      // Arcane spells, grouped by lore
+      const spellsByLore = new Map<string, SpellInfo[]>();
+      for (const spell of actor.items.filter(item => item.type === 'spell')) {
+        const spellSystem = spell.system as any;
+        const loreRaw = spellSystem?.lore?.value;
+        const lore = String((Array.isArray(loreRaw) ? loreRaw[0] : loreRaw) || 'arcane');
+        const cn = spellSystem?.cn?.value;
+        const info: SpellInfo = {
+          id: spell.id || '',
+          name: spell.name || '',
+          level: 0,
+          actionCost: cn !== undefined && cn !== null ? `CN ${cn}` : undefined,
+          range: spellSystem?.range?.value || undefined,
+          target: spellSystem?.target?.value || undefined,
+        };
+        if (!spellsByLore.has(lore)) spellsByLore.set(lore, []);
+        spellsByLore.get(lore)!.push(info);
+      }
+      for (const [lore, loreSpells] of spellsByLore) {
+        entries.push({
+          id: `lore-${lore}`,
+          name: `Lore of ${cap(lore)}`,
+          type: 'arcane',
+          tradition: 'arcane',
+          spells: loreSpells.sort((a, b) => a.name.localeCompare(b.name)),
+        });
+      }
+
+      // Divine prayers, grouped by god
+      const prayersByGod = new Map<string, SpellInfo[]>();
+      for (const prayer of actor.items.filter(item => item.type === 'prayer')) {
+        const praySystem = prayer.system as any;
+        const god = String(praySystem?.god?.value || 'divine');
+        const info: SpellInfo = {
+          id: prayer.id || '',
+          name: prayer.name || '',
+          level: 0,
+          range: praySystem?.range?.value || undefined,
+          target: praySystem?.target?.value || undefined,
+        };
+        if (!prayersByGod.has(god)) prayersByGod.set(god, []);
+        prayersByGod.get(god)!.push(info);
+      }
+      for (const [god, godPrayers] of prayersByGod) {
+        entries.push({
+          id: `prayers-${god}`,
+          name: god === 'divine' ? 'Prayers' : `Prayers (${cap(god)})`,
+          type: 'divine',
+          tradition: 'divine',
+          spells: godPrayers.sort((a, b) => a.name.localeCompare(b.name)),
         });
       }
     }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1146,12 +1146,14 @@ async function startBackend(): Promise<void> {
   const { PF2eAdapter } = await import('./systems/pf2e/adapter.js');
   const { DSA5Adapter } = await import('./systems/dsa5/adapter.js');
   const { CosmereRpgAdapter } = await import('./systems/cosmere-rpg/adapter.js');
+  const { WFRP4eAdapter } = await import('./systems/wfrp4e/adapter.js');
 
   const systemRegistry = getSystemRegistry(logger);
   systemRegistry.register(new DnD5eAdapter());
   systemRegistry.register(new PF2eAdapter());
   systemRegistry.register(new DSA5Adapter());
   systemRegistry.register(new CosmereRpgAdapter());
+  systemRegistry.register(new WFRP4eAdapter());
 
   logger.info('System registry initialized', {
     supportedSystems: systemRegistry.getSupportedSystems(),

--- a/packages/mcp-server/src/systems/index.ts
+++ b/packages/mcp-server/src/systems/index.ts
@@ -14,6 +14,7 @@ export type {
   DnD5eCreatureIndex,
   PF2eCreatureIndex,
   DSA5CreatureIndex,
+  WFRP4eCreatureIndex,
   GenericCreatureIndex,
   AnyCreatureIndex,
 } from './types.js';

--- a/packages/mcp-server/src/systems/types.ts
+++ b/packages/mcp-server/src/systems/types.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
  * Supported game system identifiers
  * Extend this type when adding new systems
  */
-export type SystemId = 'dnd5e' | 'pf2e' | 'dsa5' | 'cosmere-rpg' | 'other';
+export type SystemId = 'dnd5e' | 'pf2e' | 'dsa5' | 'cosmere-rpg' | 'wfrp4e' | 'other';
 
 /**
  * System metadata returned by adapters
@@ -281,6 +281,24 @@ export interface CosmereRpgCreatureIndex extends SystemCreatureIndex {
 }
 
 /**
+ * WFRP4e (Warhammer Fantasy Roleplay 4e) specific creature index structure.
+ *
+ * Character-focused adapter: the creature index is intentionally lightweight
+ * (WFRP4e has no Challenge Rating / level metric).
+ */
+export interface WFRP4eCreatureIndex extends SystemCreatureIndex {
+  system: 'wfrp4e';
+  systemData: {
+    species?: string; // Species/race (Human, Beastman, Goblin, ...)
+    size?: string; // Normalized size label
+    wounds?: number; // Maximum wounds
+    hasSpells: boolean; // Has arcane spell items
+    hasPrayers: boolean; // Has divine prayer items
+    traits?: string[]; // Creature trait item names
+  };
+}
+
+/**
  * Generic creature index for unsupported systems
  */
 export interface GenericCreatureIndex extends SystemCreatureIndex {
@@ -296,4 +314,5 @@ export type AnyCreatureIndex =
   | PF2eCreatureIndex
   | DSA5CreatureIndex
   | CosmereRpgCreatureIndex
+  | WFRP4eCreatureIndex
   | GenericCreatureIndex;

--- a/packages/mcp-server/src/systems/wfrp4e/adapter.test.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/adapter.test.ts
@@ -1,0 +1,226 @@
+/**
+ * WFRP4e Adapter Tests
+ *
+ * Validates character-stat extraction against a representative WFRP4e
+ * `character` actor (source-style data, i.e. characteristic `value`/`bonus`
+ * not yet derived) plus adapter metadata and filtering.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WFRP4eAdapter } from './adapter.js';
+
+/**
+ * Representative WFRP4e player character. Characteristics intentionally omit
+ * the derived `value`/`bonus` to exercise the adapter's fallback math
+ * (value = initial + modifier + advances; bonus = floor(value / 10)).
+ */
+const boris: any = {
+  name: 'Boris Dorchen',
+  type: 'character',
+  img: 'icons/svg/mystery-man.svg',
+  system: {
+    characteristics: {
+      ws: { initial: 30, modifier: -10, advances: 10 }, // value 30 (30 - 10 + 10), bonus 3
+      bs: { initial: 30, modifier: 0, advances: 5 },
+      s: { initial: 35, modifier: 0, advances: 0 },
+      t: { initial: 35, modifier: 0, advances: 5 },
+      i: { initial: 30, modifier: 0, advances: 0 },
+      ag: { initial: 30, modifier: 0, advances: 0 },
+      dex: { initial: 30, modifier: 0, advances: 0 },
+      int: { initial: 30, modifier: 0, advances: 0 },
+      wp: { initial: 30, modifier: 0, advances: 5 },
+      fel: { initial: 30, modifier: 0, advances: 0 },
+    },
+    status: {
+      wounds: { value: 12, max: 14 },
+      advantage: { value: 1, max: 4 },
+      fate: { value: 3 },
+      fortune: { value: 2 },
+      resilience: { value: 2 },
+      resolve: { value: 1 },
+      corruption: { value: 0, max: 3 },
+      criticalWounds: { value: 0, max: 4 },
+    },
+    details: {
+      species: { value: 'Human', subspecies: 'Reiklander' },
+      career: { value: 'Huntsman' },
+      class: { value: 'Ranger' },
+      status: { standing: 2, tier: 'silver', value: 'Silver 2' },
+      move: { value: 4, walk: 8, run: 16 },
+      size: { value: 'avg' },
+      experience: { total: 1000, spent: 800, current: 200 },
+    },
+  },
+  items: [
+    { type: 'spell', name: 'Dart', system: { lore: { value: ['fire'] }, cn: { value: 0 } } },
+    { type: 'prayer', name: 'Bless (Sigmar)', system: { god: { value: 'Sigmar' } } },
+    { type: 'weapon', name: 'Hunting Bow' },
+    // Skill with a system-derived total (preferred verbatim): Ag 30 + 15 advances = 45.
+    {
+      type: 'skill',
+      name: 'Stealth (Rural)',
+      system: {
+        characteristic: { value: 'ag' },
+        advances: { value: 15 },
+        modifier: { value: 0 },
+        total: { value: 45 },
+      },
+    },
+    // Skill WITHOUT a derived total: must fall back to BS 35 + 10 advances = 45.
+    {
+      type: 'skill',
+      name: 'Ranged (Bow)',
+      system: {
+        characteristic: { value: 'bs' },
+        advances: { value: 10 },
+        modifier: { value: 0 },
+      },
+    },
+  ],
+};
+
+describe('WFRP4eAdapter metadata', () => {
+  const adapter = new WFRP4eAdapter();
+
+  it('identifies as wfrp4e and handles the system id', () => {
+    expect(adapter.getMetadata().id).toBe('wfrp4e');
+    expect(adapter.canHandle('wfrp4e')).toBe(true);
+    expect(adapter.canHandle('WFRP4E')).toBe(true);
+    expect(adapter.canHandle('dnd5e')).toBe(false);
+  });
+
+  it('reports character-focused feature support', () => {
+    const features = adapter.getMetadata().supportedFeatures;
+    expect(features.characterStats).toBe(true);
+    expect(features.spellcasting).toBe(true);
+    expect(features.creatureIndex).toBe(false);
+    expect(features.powerLevel).toBe(false);
+  });
+});
+
+describe('WFRP4eAdapter.extractCharacterStats', () => {
+  const stats = new WFRP4eAdapter().extractCharacterStats(boris);
+
+  it('keeps identifying info', () => {
+    expect(stats.name).toBe('Boris Dorchen');
+    expect(stats.type).toBe('character');
+  });
+
+  it('derives characteristic value and bonus when not pre-computed', () => {
+    expect(stats.characteristics.T.value).toBe(40);
+    expect(stats.characteristics.Fel.value).toBe(30);
+    expect(stats.characteristics.Fel.bonus).toBe(3);
+    // All 10 characteristics present
+    expect(Object.keys(stats.characteristics)).toHaveLength(10);
+  });
+
+  it('surfaces the modifier so Total reconciles (Total = initial + advances + modifier)', () => {
+    const ws = stats.characteristics.WS;
+    // 30 initial + 10 advances + (-10 modifier) = 30 Total
+    expect(ws).toMatchObject({
+      initial: 30,
+      advances: 10,
+      modifier: -10,
+      value: 30,
+      bonus: 3,
+      name: 'Weapon Skill',
+    });
+    expect(ws.initial + ws.advances + ws.modifier).toBe(ws.value);
+    // Characteristics without a modifier report modifier: 0 (not undefined)
+    expect(stats.characteristics.T.modifier).toBe(0);
+  });
+
+  it('extracts wounds and advantage', () => {
+    expect(stats.wounds).toEqual({ value: 12, max: 14 });
+    expect(stats.advantage).toEqual({ value: 1, max: 4 });
+  });
+
+  it('extracts fate/fortune and resilience/resolve', () => {
+    expect(stats.fate).toEqual({ fate: 3, fortune: 2 });
+    expect(stats.resilience).toEqual({ resilience: 2, resolve: 1 });
+  });
+
+  it('extracts identity (species, subspecies, career, class, status)', () => {
+    expect(stats.identity).toMatchObject({
+      species: 'Human',
+      subspecies: 'Reiklander',
+      career: 'Huntsman',
+      class: 'Ranger',
+      status: 'Silver 2',
+    });
+  });
+
+  it('normalizes size and reports experience', () => {
+    expect(stats.size).toBe('average');
+    expect(stats.experience).toEqual({ total: 1000, spent: 800, current: 200 });
+  });
+
+  it('detects arcane spells and divine prayers from items', () => {
+    expect(stats.spellcasting).toEqual({ hasSpells: true, hasPrayers: true });
+  });
+
+  it('reports skill totals (characteristic + advances), not advances alone', () => {
+    const stealth = stats.skills.find((s: any) => s.name === 'Stealth (Rural)');
+    const bow = stats.skills.find((s: any) => s.name === 'Ranged (Bow)');
+
+    // Uses the system-derived total verbatim when present.
+    expect(stealth).toMatchObject({ total: 45, advances: 15, characteristic: 'Ag' });
+
+    // Falls back to linked-characteristic value + advances when total is absent:
+    // BS value 35 (initial 30 + 5 advances) + 10 skill advances = 45 (NOT 10).
+    expect(bow).toMatchObject({ total: 45, advances: 10, characteristic: 'BS' });
+  });
+});
+
+describe('WFRP4eAdapter.extractBasicInfo', () => {
+  const basic = new WFRP4eAdapter().extractBasicInfo(boris);
+
+  it('maps wounds to hitPoints and surfaces movement', () => {
+    expect(basic.hitPoints).toEqual({ current: 12, max: 14 });
+    expect(basic.movement).toBe(4);
+  });
+
+  it('does not invent an armour class (WFRP4e has none)', () => {
+    expect(basic.armorClass).toBeUndefined();
+  });
+});
+
+describe('WFRP4eAdapter career resolution', () => {
+  const adapter = new WFRP4eAdapter();
+
+  it('reads the current career from the career item, ignoring a circular details.career', () => {
+    // In derived data details.career is the career item, which the browser
+    // sanitizes to "[Circular Reference]"; the current career item is the
+    // reliable source.
+    const a = {
+      name: 'Tylo',
+      type: 'character',
+      system: { details: { career: '[Circular Reference]' } },
+      items: [
+        { type: 'career', name: 'Old Career', system: { current: { value: false } } },
+        { type: 'career', name: 'Hedge Apprentice', system: { current: { value: true } } },
+      ],
+    };
+    expect(adapter.extractCharacterStats(a).identity.career).toBe('Hedge Apprentice');
+  });
+
+  it('falls back to details.career.value when there is no career item (source data)', () => {
+    const a = {
+      name: 'Greta',
+      type: 'character',
+      system: { details: { career: { value: 'Witch Hunter' } } },
+      items: [],
+    };
+    expect(adapter.extractCharacterStats(a).identity.career).toBe('Witch Hunter');
+  });
+
+  it('never surfaces a sanitized circular reference as the career', () => {
+    const a = {
+      name: 'Anon',
+      type: 'character',
+      system: { details: { career: '[Circular Reference]' } },
+      items: [],
+    };
+    expect(adapter.extractCharacterStats(a).identity?.career).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/systems/wfrp4e/adapter.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/adapter.ts
@@ -1,0 +1,372 @@
+/**
+ * WFRP4e System Adapter
+ *
+ * Character-focused SystemAdapter for Warhammer Fantasy Roleplay 4e: extracts
+ * player-character stats so the get-character / list-characters tools work
+ * against WFRP4e worlds. Creature indexing is minimal (WFRP4e has no Challenge
+ * Rating metric).
+ */
+
+import type {
+  SystemAdapter,
+  SystemMetadata,
+  SystemCreatureIndex,
+  WFRP4eCreatureIndex,
+} from '../types.js';
+import { WFRP4eFiltersSchema, matchesWFRP4eFilters, describeWFRP4eFilters } from './filters.js';
+import { CHARACTERISTIC_NAMES, FIELD_PATHS, normalizeSize } from './constants.js';
+
+/**
+ * WFRP4e system adapter.
+ */
+export class WFRP4eAdapter implements SystemAdapter {
+  getMetadata(): SystemMetadata {
+    return {
+      id: 'wfrp4e',
+      name: 'wfrp4e',
+      displayName: 'Warhammer Fantasy Roleplay 4e',
+      version: '1.0.0',
+      description:
+        'Character-focused support for Warhammer Fantasy Roleplay 4th Edition: ' +
+        '10 characteristics, wounds, fate/fortune/resilience/resolve, career, ' +
+        'species, and arcane/divine spellcasting detection.',
+      supportedFeatures: {
+        creatureIndex: false,
+        characterStats: true,
+        spellcasting: true,
+        powerLevel: false, // WFRP4e has no Challenge Rating / level metric
+      },
+    };
+  }
+
+  canHandle(systemId: string): boolean {
+    return systemId.toLowerCase() === 'wfrp4e';
+  }
+
+  /**
+   * Creature extraction runs in the Foundry browser context via the
+   * IndexBuilder; the adapter only delegates (matches the dsa5 pattern).
+   */
+  extractCreatureData(
+    _doc: any,
+    _pack: any
+  ): { creature: SystemCreatureIndex; errors: number } | null {
+    throw new Error(
+      'extractCreatureData should be called from WFRP4eIndexBuilder, not the adapter'
+    );
+  }
+
+  getFilterSchema() {
+    return WFRP4eFiltersSchema;
+  }
+
+  matchesFilters(creature: SystemCreatureIndex, filters: Record<string, any>): boolean {
+    const validated = WFRP4eFiltersSchema.safeParse(filters);
+    if (!validated.success) {
+      return false;
+    }
+    return matchesWFRP4eFilters(creature, validated.data);
+  }
+
+  getDataPaths(): Record<string, string | null> {
+    return {
+      // WFRP4e-specific paths
+      characteristics: FIELD_PATHS.CHARACTERISTICS,
+      wounds: FIELD_PATHS.STATUS_WOUNDS,
+      advantage: FIELD_PATHS.STATUS_ADVANTAGE,
+      fate: FIELD_PATHS.STATUS_FATE,
+      fortune: FIELD_PATHS.STATUS_FORTUNE,
+      resilience: FIELD_PATHS.STATUS_RESILIENCE,
+      resolve: FIELD_PATHS.STATUS_RESOLVE,
+      corruption: FIELD_PATHS.STATUS_CORRUPTION,
+      armour: FIELD_PATHS.STATUS_ARMOUR,
+      species: FIELD_PATHS.DETAILS_SPECIES,
+      career: FIELD_PATHS.DETAILS_CAREER,
+      class: FIELD_PATHS.DETAILS_CLASS,
+      move: FIELD_PATHS.DETAILS_MOVE,
+      size: FIELD_PATHS.DETAILS_SIZE,
+
+      // D&D5e / PF2e paths that do not exist in WFRP4e
+      challengeRating: null,
+      creatureType: null,
+      alignment: null,
+      hitPoints: null,
+      armorClass: null,
+      legendaryActions: null,
+      legendaryResistances: null,
+      perception: null,
+      saves: null,
+      rarity: null,
+    };
+  }
+
+  formatCreatureForList(creature: SystemCreatureIndex): any {
+    const wfrpCreature = creature as WFRP4eCreatureIndex;
+    const formatted: any = {
+      id: creature.id,
+      name: creature.name,
+      type: creature.type,
+      pack: {
+        id: creature.packName,
+        label: creature.packLabel,
+      },
+    };
+
+    if (wfrpCreature.systemData) {
+      const stats: any = {};
+      if (wfrpCreature.systemData.species) stats.species = wfrpCreature.systemData.species;
+      if (wfrpCreature.systemData.size) stats.size = wfrpCreature.systemData.size;
+      if (wfrpCreature.systemData.wounds !== undefined) {
+        stats.wounds = wfrpCreature.systemData.wounds;
+      }
+      if (wfrpCreature.systemData.hasSpells) stats.spellcaster = true;
+      if (Object.keys(stats).length > 0) formatted.stats = stats;
+    }
+
+    if (creature.img) formatted.hasImage = true;
+
+    return formatted;
+  }
+
+  formatCreatureForDetails(creature: SystemCreatureIndex): any {
+    const wfrpCreature = creature as WFRP4eCreatureIndex;
+    const formatted = this.formatCreatureForList(creature);
+
+    if (wfrpCreature.systemData) {
+      formatted.detailedStats = {
+        species: wfrpCreature.systemData.species,
+        size: wfrpCreature.systemData.size,
+        wounds: wfrpCreature.systemData.wounds,
+        hasSpells: wfrpCreature.systemData.hasSpells,
+        hasPrayers: wfrpCreature.systemData.hasPrayers,
+        traits: wfrpCreature.systemData.traits || [],
+      };
+    }
+
+    if (creature.img) formatted.img = creature.img;
+
+    return formatted;
+  }
+
+  describeFilters(filters: Record<string, any>): string {
+    const validated = WFRP4eFiltersSchema.safeParse(filters);
+    if (!validated.success) {
+      return 'invalid filters';
+    }
+    return describeWFRP4eFilters(validated.data);
+  }
+
+  getPowerLevel(_creature: SystemCreatureIndex): number | undefined {
+    // WFRP4e has no Challenge Rating / level equivalent.
+    return undefined;
+  }
+
+  /**
+   * Extract character statistics from actor data.
+   * Receives the full character object (system + items).
+   */
+  extractCharacterStats(actorData: any): any {
+    const system = actorData.system || {};
+    const stats: any = {};
+
+    stats.name = actorData.name;
+    stats.type = actorData.type;
+
+    // Characteristics (WS/BS/S/T/I/Ag/Dex/Int/WP/Fel)
+    if (system.characteristics) {
+      stats.characteristics = {};
+      for (const [key, raw] of Object.entries(system.characteristics)) {
+        const char = raw as any;
+        const value = this.characteristicValue(char);
+        const meta = CHARACTERISTIC_NAMES[key];
+        // Total = initial + advances + modifier; surface all four so it reconciles.
+        stats.characteristics[meta?.short ?? key.toUpperCase()] = {
+          value, // Total
+          bonus: this.characteristicBonus(char, value),
+          initial: char?.initial ?? 0,
+          advances: char?.advances ?? 0,
+          modifier: char?.modifier ?? 0,
+          name: meta?.name,
+        };
+      }
+    }
+
+    // Wounds (HP equivalent)
+    const wounds = system.status?.wounds;
+    if (wounds) {
+      stats.wounds = { value: wounds.value ?? 0, max: wounds.max ?? 0 };
+    }
+
+    // Advantage
+    const advantage = system.status?.advantage;
+    if (advantage) {
+      stats.advantage = { value: advantage.value ?? 0, max: advantage.max ?? 0 };
+    }
+
+    // Fate & Fortune (permanent / spendable)
+    const fate = system.status?.fate?.value;
+    const fortune = system.status?.fortune?.value;
+    if (fate !== undefined || fortune !== undefined) {
+      stats.fate = { fate: fate ?? 0, fortune: fortune ?? 0 };
+    }
+
+    // Resilience & Resolve (permanent / spendable)
+    const resilience = system.status?.resilience?.value;
+    const resolve = system.status?.resolve?.value;
+    if (resilience !== undefined || resolve !== undefined) {
+      stats.resilience = { resilience: resilience ?? 0, resolve: resolve ?? 0 };
+    }
+
+    // Corruption & critical wounds
+    const corruption = system.status?.corruption;
+    if (corruption) {
+      stats.corruption = { value: corruption.value ?? 0, max: corruption.max ?? 0 };
+    }
+    const criticalWounds = system.status?.criticalWounds;
+    if (criticalWounds) {
+      stats.criticalWounds = {
+        value: criticalWounds.value ?? 0,
+        max: criticalWounds.max ?? 0,
+      };
+    }
+
+    // Movement
+    const move = system.details?.move;
+    if (move) {
+      stats.movement = {
+        value: move.value,
+        ...(move.walk !== undefined && { walk: move.walk }),
+        ...(move.run !== undefined && { run: move.run }),
+      };
+    }
+
+    // Identity (species / subspecies / career / class / social status)
+    const identity: any = {};
+    const species = system.details?.species?.value;
+    if (species) identity.species = species;
+    const subspecies = system.details?.species?.subspecies;
+    if (subspecies) identity.subspecies = subspecies;
+    const career = this.currentCareer(actorData);
+    if (career) identity.career = career;
+    const klass = system.details?.class?.value;
+    if (klass) identity.class = klass;
+    const status = system.details?.status;
+    const statusLabel = typeof status === 'string' ? status : status?.value || status?.standing;
+    if (statusLabel) identity.status = statusLabel;
+    if (Object.keys(identity).length > 0) stats.identity = identity;
+
+    // Size
+    const size = normalizeSize(system.details?.size?.value);
+    if (size) stats.size = size;
+
+    // Experience
+    const experience = system.details?.experience;
+    if (experience) {
+      const total = experience.total ?? 0;
+      const spent = experience.spent ?? 0;
+      stats.experience = {
+        total,
+        spent,
+        current: experience.current ?? total - spent,
+      };
+    }
+
+    const items: any[] = Array.isArray(actorData.items) ? actorData.items : [];
+
+    // Skill value is the linked characteristic + advances + modifier (per the
+    // system's Skill computeOwned), not advances alone. Prefer the derived total.
+    const skillItems = items.filter(i => i?.type === 'skill');
+    if (skillItems.length > 0) {
+      const chars = system.characteristics || {};
+      stats.skills = skillItems
+        .map(skill => {
+          const sk = skill.system || {};
+          const charKey: string | undefined = sk.characteristic?.value;
+          const advances = sk.advances?.value ?? 0;
+          const modifier = sk.modifier?.value ?? 0;
+          const charValue =
+            charKey && chars[charKey] ? this.characteristicValue(chars[charKey]) : 0;
+          const total = sk.total?.value ?? charValue + advances + modifier;
+          const entry: any = { name: skill.name, advances, total };
+          if (charKey) {
+            entry.characteristic = CHARACTERISTIC_NAMES[charKey]?.short ?? charKey.toUpperCase();
+          }
+          return entry;
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Spellcasting detection (from items)
+    const hasSpells = items.some(i => i?.type === 'spell');
+    const hasPrayers = items.some(i => i?.type === 'prayer');
+    if (hasSpells || hasPrayers) {
+      stats.spellcasting = { hasSpells, hasPrayers };
+    }
+
+    return stats;
+  }
+
+  /**
+   * Seed the get-character `basicInfo` block with WFRP4e-native fields.
+   * Wounds stand in for hit points; WFRP4e has no single armour-class value.
+   */
+  extractBasicInfo(actorData: any): any {
+    const system = actorData.system || {};
+    const basicInfo: any = {};
+
+    const wounds = system.status?.wounds;
+    if (wounds) {
+      basicInfo.hitPoints = { current: wounds.value ?? 0, max: wounds.max ?? 0 };
+    }
+
+    const move = system.details?.move?.value;
+    if (move !== undefined) {
+      basicInfo.movement = move;
+    }
+
+    return basicInfo;
+  }
+
+  /**
+   * Derive a characteristic's total value. Prefers the system-derived `value`;
+   * falls back to initial + modifier + advances for raw/source actor data.
+   */
+  private characteristicValue(char: any): number {
+    if (typeof char?.value === 'number') {
+      return char.value;
+    }
+    return (char?.initial ?? 0) + (char?.modifier ?? 0) + (char?.advances ?? 0);
+  }
+
+  /**
+   * Derive a characteristic bonus (tens digit). Prefers system-derived `bonus`.
+   */
+  private characteristicBonus(char: any, value: number): number {
+    if (typeof char?.bonus === 'number') {
+      return char.bonus;
+    }
+    return Math.floor(value / 10) + (char?.bonusMod ?? 0);
+  }
+
+  /**
+   * Resolve the current career name. Prefer the current career *item* (the one
+   * flagged `system.current.value`) — `system.details.career` is unreliable in
+   * derived data, where it becomes the circular-ref'd career item that the
+   * browser sanitizes to the literal string "[Circular Reference]". Falls back
+   * to `details.career.value` for source data.
+   */
+  private currentCareer(actorData: any): string | undefined {
+    const items: any[] = Array.isArray(actorData.items) ? actorData.items : [];
+    const currentCareerItem = items.find(i => i?.type === 'career' && i.system?.current?.value);
+    if (currentCareerItem?.name) {
+      return currentCareerItem.name;
+    }
+
+    const raw = actorData.system?.details?.career;
+    const value = typeof raw === 'string' ? raw : raw?.value || raw?.name;
+    if (typeof value === 'string' && value && value !== '[Circular Reference]') {
+      return value;
+    }
+    return undefined;
+  }
+}

--- a/packages/mcp-server/src/systems/wfrp4e/constants.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/constants.ts
@@ -1,0 +1,131 @@
+/**
+ * WFRP4e Constants
+ *
+ * Central definitions for the Warhammer Fantasy Roleplay 4th Edition system:
+ * characteristic names, field paths, size mappings, and type maps.
+ *
+ * Data model reference (DataModel-based system):
+ * https://github.com/moo-man/WFRP4e-FoundryVTT/tree/master/src/model/actor
+ */
+
+/**
+ * The 10 WFRP4e characteristics (abbreviation -> full name).
+ * Keys match `system.characteristics.<key>`.
+ */
+export const CHARACTERISTIC_NAMES: Record<string, { short: string; name: string }> = {
+  ws: { short: 'WS', name: 'Weapon Skill' },
+  bs: { short: 'BS', name: 'Ballistic Skill' },
+  s: { short: 'S', name: 'Strength' },
+  t: { short: 'T', name: 'Toughness' },
+  i: { short: 'I', name: 'Initiative' },
+  ag: { short: 'Ag', name: 'Agility' },
+  dex: { short: 'Dex', name: 'Dexterity' },
+  int: { short: 'Int', name: 'Intelligence' },
+  wp: { short: 'WP', name: 'Willpower' },
+  fel: { short: 'Fel', name: 'Fellowship' },
+};
+
+/**
+ * Ordered list of characteristic keys (book order).
+ */
+export const CHARACTERISTIC_ORDER = [
+  'ws',
+  'bs',
+  's',
+  't',
+  'i',
+  'ag',
+  'dex',
+  'int',
+  'wp',
+  'fel',
+] as const;
+
+/**
+ * WFRP4e size keys (game.wfrp4e.config.actorSizes) -> English label.
+ */
+export const SIZE_MAP: Record<string, string> = {
+  tiny: 'tiny',
+  ltl: 'little',
+  sml: 'small',
+  avg: 'average',
+  lrg: 'large',
+  enor: 'enormous',
+  mnst: 'monstrous',
+};
+
+/**
+ * Common WFRP4e field paths for system data access.
+ */
+export const FIELD_PATHS = {
+  // Characteristics
+  CHARACTERISTICS: 'system.characteristics',
+
+  // Status / resources
+  STATUS_WOUNDS: 'system.status.wounds',
+  STATUS_ADVANTAGE: 'system.status.advantage',
+  STATUS_CRITICAL_WOUNDS: 'system.status.criticalWounds',
+  STATUS_CORRUPTION: 'system.status.corruption',
+  STATUS_ENCUMBRANCE: 'system.status.encumbrance',
+  STATUS_ARMOUR: 'system.status.armour',
+
+  // Character-only fortune/fate pools (value-only, no max)
+  STATUS_FATE: 'system.status.fate.value',
+  STATUS_FORTUNE: 'system.status.fortune.value',
+  STATUS_RESILIENCE: 'system.status.resilience.value',
+  STATUS_RESOLVE: 'system.status.resolve.value',
+
+  // Details / profile
+  DETAILS_SPECIES: 'system.details.species.value',
+  DETAILS_SUBSPECIES: 'system.details.species.subspecies',
+  DETAILS_CAREER: 'system.details.career.value',
+  DETAILS_CLASS: 'system.details.class.value',
+  DETAILS_STATUS: 'system.details.status',
+  DETAILS_MOVE: 'system.details.move.value',
+  DETAILS_SIZE: 'system.details.size.value',
+  DETAILS_EXPERIENCE: 'system.details.experience',
+} as const;
+
+/**
+ * Item types in WFRP4e.
+ */
+export const ITEM_TYPES = {
+  SKILL: 'skill',
+  TALENT: 'talent',
+  TRAIT: 'trait',
+  CAREER: 'career',
+  SPELL: 'spell', // Arcane magic (grouped by lore)
+  PRAYER: 'prayer', // Divine magic (grouped by god)
+  WEAPON: 'weapon',
+  ARMOUR: 'armour',
+  TRAPPING: 'trapping',
+  AMMUNITION: 'ammunition',
+  CONTAINER: 'container',
+  MONEY: 'money',
+  PSYCHOLOGY: 'psychology',
+  DISEASE: 'disease',
+  INJURY: 'injury',
+  CRITICAL: 'critical',
+  MUTATION: 'mutation',
+  DISORDER: 'disorder',
+} as const;
+
+/**
+ * Actor types in WFRP4e.
+ */
+export const ACTOR_TYPES = {
+  CHARACTER: 'character', // Player characters
+  NPC: 'npc', // Non-player characters
+  CREATURE: 'creature', // Monsters / beasts
+  VEHICLE: 'vehicle', // Vehicles
+} as const;
+
+/**
+ * Normalize a raw WFRP4e size key to an English label.
+ */
+export function normalizeSize(size: unknown): string | undefined {
+  if (typeof size !== 'string' || size.length === 0) {
+    return undefined;
+  }
+  return SIZE_MAP[size.toLowerCase()] ?? size;
+}

--- a/packages/mcp-server/src/systems/wfrp4e/filters.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/filters.ts
@@ -1,0 +1,82 @@
+/**
+ * WFRP4e Filter Schemas
+ *
+ * Minimal creature filters (species, size, spellcaster). WFRP4e has no
+ * Challenge Rating / level metric, so filtering is intentionally lightweight.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Creature sizes (English labels; see SIZE_MAP in constants.ts).
+ */
+export const CreatureSizes = [
+  'tiny',
+  'little',
+  'small',
+  'average',
+  'large',
+  'enormous',
+  'monstrous',
+] as const;
+export type CreatureSize = (typeof CreatureSizes)[number];
+
+/**
+ * WFRP4e creature filter schema (permissive).
+ */
+export const WFRP4eFiltersSchema = z.object({
+  // Species/race, free-form (e.g. "Human", "Beastman", "Goblin")
+  species: z.string().optional(),
+
+  // Size category
+  size: z.enum(CreatureSizes).optional(),
+
+  // Has arcane spells or divine prayers
+  hasSpells: z.boolean().optional(),
+});
+
+export type WFRP4eFilters = z.infer<typeof WFRP4eFiltersSchema>;
+
+/**
+ * Check if a creature matches WFRP4e filters.
+ */
+export function matchesWFRP4eFilters(creature: any, filters: WFRP4eFilters): boolean {
+  // Species filter
+  if (filters.species) {
+    const species = creature.systemData?.species;
+    if (!species?.toLowerCase().includes(filters.species.toLowerCase())) {
+      return false;
+    }
+  }
+
+  // Size filter
+  if (filters.size) {
+    const size = creature.systemData?.size;
+    if (!size || size.toLowerCase() !== filters.size.toLowerCase()) {
+      return false;
+    }
+  }
+
+  // Spellcaster filter
+  if (filters.hasSpells !== undefined) {
+    const hasSpells = creature.systemData?.hasSpells || false;
+    if (hasSpells !== filters.hasSpells) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Generate a human-readable description of WFRP4e filters.
+ */
+export function describeWFRP4eFilters(filters: WFRP4eFilters): string {
+  const parts: string[] = [];
+
+  if (filters.species) parts.push(filters.species);
+  if (filters.size) parts.push(filters.size);
+  if (filters.hasSpells) parts.push('spellcaster');
+
+  return parts.length > 0 ? parts.join(', ') : 'no filters';
+}

--- a/packages/mcp-server/src/systems/wfrp4e/index-builder.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/index-builder.ts
@@ -1,0 +1,172 @@
+/**
+ * WFRP4e Index Builder
+ *
+ * Builds a basic creature index from Foundry compendiums. Runs in Foundry's
+ * browser context (not Node.js).
+ *
+ * This adapter is character-focused, so the creature index is intentionally
+ * lightweight (species, size, wounds, spellcaster flags). It follows the dsa5
+ * IndexBuilder structure for consistency.
+ */
+
+import type { IndexBuilder, WFRP4eCreatureIndex } from '../types.js';
+import { normalizeSize } from './constants.js';
+
+// Foundry browser global (unavailable during Node.js TypeScript compilation)
+declare const ui: any;
+
+interface WFRP4eExtractionResult {
+  creature: WFRP4eCreatureIndex;
+  errors: number;
+}
+
+/**
+ * WFRP4e implementation of IndexBuilder.
+ */
+export class WFRP4eIndexBuilder implements IndexBuilder {
+  private moduleId: string;
+
+  constructor(moduleId: string = 'foundry-mcp-bridge') {
+    this.moduleId = moduleId;
+  }
+
+  getSystemId() {
+    return 'wfrp4e' as const;
+  }
+
+  async buildIndex(packs: any[], _force = false): Promise<WFRP4eCreatureIndex[]> {
+    const startTime = Date.now();
+    let totalErrors = 0;
+
+    const actorPacks = packs.filter(pack => pack.metadata.type === 'Actor');
+    const creatures: WFRP4eCreatureIndex[] = [];
+
+    console.log(
+      `[${this.moduleId}] Building WFRP4e creature index from ${actorPacks.length} packs...`
+    );
+
+    for (const pack of actorPacks) {
+      try {
+        if (!pack.indexed) {
+          await pack.getIndex({});
+        }
+        const packResult = await this.extractDataFromPack(pack);
+        creatures.push(...packResult.creatures);
+        totalErrors += packResult.errors;
+      } catch (error) {
+        console.warn(`[${this.moduleId}] Failed to process pack ${pack.metadata.label}:`, error);
+        if (typeof ui !== 'undefined' && ui.notifications) {
+          ui.notifications.warn(`Warning: failed to index "${pack.metadata.label}" - continuing`);
+        }
+      }
+    }
+
+    const seconds = Math.round((Date.now() - startTime) / 1000);
+    console.log(
+      `[${this.moduleId}] WFRP4e creature index complete: ${creatures.length} creatures from ` +
+        `${actorPacks.length} packs in ${seconds}s${
+          totalErrors > 0 ? ` (${totalErrors} extraction errors)` : ''
+        }`
+    );
+
+    return creatures;
+  }
+
+  async extractDataFromPack(
+    pack: any
+  ): Promise<{ creatures: WFRP4eCreatureIndex[]; errors: number }> {
+    const creatures: WFRP4eCreatureIndex[] = [];
+    let errors = 0;
+
+    try {
+      const documents = await pack.getDocuments();
+      for (const doc of documents) {
+        try {
+          if (doc.type !== 'npc' && doc.type !== 'character' && doc.type !== 'creature') {
+            continue;
+          }
+          const result = this.extractCreatureData(doc, pack);
+          if (result) {
+            creatures.push(result.creature);
+            errors += result.errors;
+          }
+        } catch (error) {
+          console.warn(
+            `[${this.moduleId}] Failed to extract WFRP4e data from ${doc.name} in ${pack.metadata.label}:`,
+            error
+          );
+          errors++;
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `[${this.moduleId}] Failed to load documents from ${pack.metadata.label}:`,
+        error
+      );
+      errors++;
+    }
+
+    return { creatures, errors };
+  }
+
+  extractCreatureData(doc: any, pack: any): WFRP4eExtractionResult | null {
+    try {
+      const system = doc.system || {};
+      const items: any[] = Array.from(doc.items?.values?.() ?? doc.items ?? []);
+
+      const species =
+        typeof system.details?.species?.value === 'string'
+          ? system.details.species.value
+          : undefined;
+      const size = normalizeSize(system.details?.size?.value);
+      const woundsRaw = system.status?.wounds?.max ?? system.status?.wounds?.value;
+      const wounds = typeof woundsRaw === 'number' ? woundsRaw : undefined;
+
+      const hasSpells = items.some(i => i?.type === 'spell');
+      const hasPrayers = items.some(i => i?.type === 'prayer');
+      const traits = items
+        .filter(i => i?.type === 'trait')
+        .map(i => i?.name)
+        .filter((n): n is string => typeof n === 'string');
+
+      // Build systemData omitting undefined keys (exactOptionalPropertyTypes).
+      const systemData: WFRP4eCreatureIndex['systemData'] = { hasSpells, hasPrayers, traits };
+      if (species !== undefined) systemData.species = species;
+      if (size !== undefined) systemData.size = size;
+      if (wounds !== undefined) systemData.wounds = wounds;
+
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          packName: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          img: doc.img,
+          system: 'wfrp4e',
+          systemData,
+        },
+        errors: 0,
+      };
+    } catch (error) {
+      console.warn(`[${this.moduleId}] Failed to extract WFRP4e data from ${doc.name}:`, error);
+      return {
+        creature: {
+          id: doc._id,
+          name: doc.name,
+          type: doc.type,
+          packName: pack.metadata.id,
+          packLabel: pack.metadata.label,
+          img: doc.img,
+          system: 'wfrp4e',
+          systemData: {
+            hasSpells: false,
+            hasPrayers: false,
+            traits: [],
+          },
+        },
+        errors: 1,
+      };
+    }
+  }
+}

--- a/packages/mcp-server/src/systems/wfrp4e/index.ts
+++ b/packages/mcp-server/src/systems/wfrp4e/index.ts
@@ -1,0 +1,35 @@
+/**
+ * WFRP4e System Module
+ *
+ * Exports for Warhammer Fantasy Roleplay 4th Edition support in the Registry
+ * Pattern architecture.
+ */
+
+// Type definitions (from central types.ts)
+export type { WFRP4eCreatureIndex } from '../types.js';
+
+// System adapter (runs in MCP server Node.js context)
+export { WFRP4eAdapter } from './adapter.js';
+
+// Index builder (runs in Foundry browser context)
+export { WFRP4eIndexBuilder } from './index-builder.js';
+
+// Filter system
+export {
+  CreatureSizes,
+  WFRP4eFiltersSchema,
+  matchesWFRP4eFilters,
+  describeWFRP4eFilters,
+} from './filters.js';
+export type { CreatureSize, WFRP4eFilters } from './filters.js';
+
+// Constants
+export {
+  CHARACTERISTIC_NAMES,
+  CHARACTERISTIC_ORDER,
+  SIZE_MAP,
+  FIELD_PATHS,
+  ITEM_TYPES,
+  ACTOR_TYPES,
+  normalizeSize,
+} from './constants.js';


### PR DESCRIPTION
## Summary

Adds a character-focused system adapter for Warhammer Fantasy Roleplay 4e (`wfrp4e`), following the existing `dsa5` pattern. Previously WFRP4e worlds fell through to the dnd5e/pf2e extraction paths, so `get-character` / `list-characters` returned empty or timed out on player characters.

## Server adapter (`packages/mcp-server/src/systems/wfrp4e/`)

- Character stats: 10 characteristics (initial/advances/modifier/total), wounds, advantage, fate/fortune, resilience/resolve, corruption, movement, career/species/class/status, experience, and skills (total = characteristic + advances + modifier, per the system's Skill `computeOwned`).
- `extractBasicInfo`: wounds as hit points; no armour class (WFRP4e tracks armour per hit location).
- Registered in `backend.ts`; `'wfrp4e'` added to `SystemId`.
- Minimal creature index/filters to satisfy the `SystemAdapter` interface — WFRP4e has no Challenge Rating metric, so `creatureIndex` is reported `false`.

## Foundry module (`packages/foundry-module/src/data-access.ts`)

- Spellcasting grouped by Lore (arcane) and God (divine), each spell with its Casting Number (WFRP4e has no spell levels/slots).
- `search-character-items`: WFRP4e spell/prayer targeting and weapon/armour/trapping equipment fields.

## Testing

- Unit tests: `packages/mcp-server/src/systems/wfrp4e/adapter.test.ts` (vitest).
- Verified against a live WFRP4e world: characteristic modifiers reconciling, skill totals including advances, and spells grouped by Lore with casting numbers.

## Notes

- Data model references the WFRP4e system's DataModels (`moo-man/WFRP4e-FoundryVTT`).
- Scope is character tools; bestiary/compendium creature filtering is intentionally minimal and can be extended later.
