### PR TITLE
WFRP4e: actor-editing tools (update stats, add/remove items)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Once connected, ask Claude Desktop:
 
 ## Features
 
-- **40 MCP Tools** that allow Claude to interact with Foundry
+- **42 MCP Tools** that allow Claude to interact with Foundry
 - **D&D 5e NPC Creation Suite**: Build complete NPCs from prompts — stat block, attacks, saves, auras, and spellcasting
-- **WFRP4e Support**: Character reading for Warhammer Fantasy Roleplay 4e
+- **WFRP4e Support**: Character reading plus editing — update characteristics, wounds, skills and careers, and add or remove items on existing actors
 - **Character Management**: Access stats, abilities, inventory, and detailed entity information
 - **Token Manipulation**: Move, update, delete tokens and manage status conditions
 - **Enhanced Compendium Search**: Instant filtering by CR, type, abilities, and more

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -5972,6 +5972,113 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Update a WFRP4e actor's stat block (characteristics and/or wounds).
+   * Writes initial/advances/modifier and wounds value/max; WFRP4e recomputes
+   * the derived characteristic value/bonus on update.
+   */
+  async updateWfrp4eActor(data: {
+    actor: string;
+    characteristics?: Record<string, { initial?: number; advances?: number; modifier?: number }>;
+    wounds?: { value?: number; max?: number };
+  }): Promise<any> {
+    this.validateFoundryState();
+
+    const systemId = (game.system as any).id;
+    if (systemId !== 'wfrp4e') {
+      return {
+        success: false,
+        error: `wfrp4e-update-actor requires the WFRP4e system (current: "${systemId}")`,
+      };
+    }
+
+    // Resolve actor by id (16-char) or name
+    let actor: any;
+    if (data.actor.length === 16) {
+      actor = game.actors?.get(data.actor);
+    }
+    if (!actor) {
+      actor = game.actors?.find((a: any) => a.name?.toLowerCase() === data.actor.toLowerCase());
+    }
+    if (!actor) {
+      return { success: false, error: `Actor not found: ${data.actor}` };
+    }
+
+    const CHAR_KEYS = ['ws', 'bs', 's', 't', 'i', 'ag', 'dex', 'int', 'wp', 'fel'];
+    const FIELDS = ['initial', 'advances', 'modifier'] as const;
+    const sys = actor.system || {};
+    const update: Record<string, any> = {};
+    const applied: { characteristics: Record<string, any>; wounds: Record<string, any> } = {
+      characteristics: {},
+      wounds: {},
+    };
+    const warnings: string[] = [];
+
+    if (data.characteristics) {
+      for (const [rawKey, fields] of Object.entries(data.characteristics)) {
+        const key = rawKey.toLowerCase();
+        if (!CHAR_KEYS.includes(key)) {
+          warnings.push(`Unknown characteristic "${rawKey}" — skipped`);
+          continue;
+        }
+        const current = sys.characteristics?.[key] || {};
+        const record: Record<string, any> = {};
+        for (const field of FIELDS) {
+          const val = (fields as any)[field];
+          if (val !== undefined) {
+            update[`system.characteristics.${key}.${field}`] = val;
+            record[field] = { from: current[field], to: val };
+          }
+        }
+        if (Object.keys(record).length > 0) {
+          applied.characteristics[key.toUpperCase()] = record;
+        }
+      }
+    }
+
+    if (data.wounds) {
+      const current = sys.status?.wounds || {};
+      if (data.wounds.value !== undefined) {
+        update['system.status.wounds.value'] = data.wounds.value;
+        applied.wounds.value = { from: current.value, to: data.wounds.value };
+      }
+      if (data.wounds.max !== undefined) {
+        update['system.status.wounds.max'] = data.wounds.max;
+        applied.wounds.max = { from: current.max, to: data.wounds.max };
+      }
+    }
+
+    if (Object.keys(update).length === 0) {
+      return { success: false, error: 'No valid fields to update.', ...(warnings.length ? { warnings } : {}) };
+    }
+
+    try {
+      await actor.update(update);
+    } catch (error) {
+      console.error(`[${MODULE_ID}] Error updating WFRP4e actor:`, error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+
+    // Read back recomputed characteristic totals as confirmation.
+    const after = actor.system || {};
+    const newTotals: Record<string, any> = {};
+    for (const key of CHAR_KEYS) {
+      if (applied.characteristics[key.toUpperCase()]) {
+        const c = after.characteristics?.[key];
+        if (c) newTotals[key.toUpperCase()] = { total: c.value, bonus: c.bonus };
+      }
+    }
+
+    return {
+      success: true,
+      actor: actor.name,
+      id: actor.id,
+      applied,
+      newCharacteristicTotals: newTotals,
+      ...(warnings.length ? { warnings } : {}),
+    };
+  }
+
+  /**
    * Get actor ownership information
    */
   async getActorOwnership(data: {

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -372,7 +372,7 @@ class PersistentCreatureIndex {
 
       // Convert Map data back from JSON
       const metadata = rawData.metadata;
-      if (metadata && metadata.packFingerprints) {
+      if (metadata?.packFingerprints) {
         metadata.packFingerprints = new Map(metadata.packFingerprints);
       }
 
@@ -561,7 +561,7 @@ class PersistentCreatureIndex {
     return {
       packId: pack.metadata.id,
       packLabel: pack.metadata.label,
-      lastModified: lastModified,
+      lastModified,
       documentCount: pack.index?.size || 0,
       checksum: this.generatePackChecksum(pack),
     };
@@ -925,13 +925,13 @@ class PersistentCreatureIndex {
           type: doc.type,
           pack: pack.metadata.id,
           packLabel: pack.metadata.label,
-          challengeRating: challengeRating,
+          challengeRating,
           creatureType: creatureType.toLowerCase(),
           size: size.toLowerCase(),
-          hitPoints: hitPoints,
-          armorClass: armorClass,
-          hasSpells: hasSpells,
-          hasLegendaryActions: hasLegendaryActions,
+          hitPoints,
+          armorClass,
+          hasSpells,
+          hasLegendaryActions,
           alignment: alignment.toLowerCase(),
           description: doc.system?.details?.biography || doc.system?.description || '',
           img: doc.img,
@@ -1173,14 +1173,14 @@ class PersistentCreatureIndex {
           type: doc.type,
           pack: pack.metadata.id,
           packLabel: pack.metadata.label,
-          level: level,
-          traits: traits,
-          creatureType: creatureType,
-          rarity: rarity,
-          size: size,
-          hitPoints: hitPoints,
-          armorClass: armorClass,
-          hasSpells: hasSpells,
+          level,
+          traits,
+          creatureType,
+          rarity,
+          size,
+          hitPoints,
+          armorClass,
+          hasSpells,
           alignment: alignment.toUpperCase(),
           description: system.details?.publicNotes || system.details?.biography || '',
           img: doc.img,
@@ -1555,7 +1555,7 @@ export class FoundryDataAccess {
         };
       }),
       effects: actor.effects.map(effect => {
-        const eff = effect as any;
+        const eff = effect;
         const dur = eff.duration;
         const durRaw = eff._source?.duration;
         return {
@@ -1602,7 +1602,7 @@ export class FoundryDataAccess {
     const itemToggles: any[] = [];
 
     actor.items.forEach(item => {
-      const itemAny = item as any;
+      const itemAny = item;
 
       // Extract rule element variants (e.g., weapon variants, stance toggles)
       if (itemAny.system?.rules) {
@@ -1612,7 +1612,7 @@ export class FoundryDataAccess {
             itemVariants.push({
               itemId: item.id,
               itemName: item.name,
-              ruleIndex: ruleIndex,
+              ruleIndex,
               ruleKey: rule.key,
               label: rule.label || rule.prompt,
               ...(rule.selection ? { selected: rule.selection } : {}),
@@ -1625,7 +1625,7 @@ export class FoundryDataAccess {
             itemToggles.push({
               itemId: item.id,
               itemName: item.name,
-              ruleIndex: ruleIndex,
+              ruleIndex,
               ruleKey: rule.key,
               label: rule.label,
               option: rule.option,
@@ -1713,7 +1713,7 @@ export class FoundryDataAccess {
       throw new Error(`Character not found: ${characterIdentifier}`);
     }
 
-    const actorAny = actor as any;
+    const actorAny = actor;
     const systemId = (game.system as any).id;
     const matches: Array<any> = [];
 
@@ -1737,7 +1737,7 @@ export class FoundryDataAccess {
 
     // Search items
     for (const item of actor.items) {
-      const itemSystem = item.system as any;
+      const itemSystem = item.system;
 
       // Check type filter
       if (!matchesType(item.type)) continue;
@@ -1760,13 +1760,13 @@ export class FoundryDataAccess {
         // Strip HTML and truncate
         const plainText = description.replace(/<[^>]*>/g, '').trim();
         result.description =
-          plainText.length > 300 ? plainText.substring(0, 300) + '...' : plainText;
+          plainText.length > 300 ? `${plainText.substring(0, 300)}...` : plainText;
       }
 
       // Spell-specific fields
       if (item.type === 'spell') {
         result.level = itemSystem?.level?.value ?? itemSystem?.level ?? itemSystem?.rank ?? 0;
-        const itemRaw = (item as any)._source?.system;
+        const itemRaw = item._source?.system;
         result.prepared =
           itemSystem?.prepared ?? itemRaw?.preparation?.prepared ?? itemSystem?.location?.prepared;
         result.expended = itemSystem?.location?.expended;
@@ -1832,7 +1832,7 @@ export class FoundryDataAccess {
         ['weapon', 'armour', 'trapping', 'ammunition', 'container'].includes(item.type)
       ) {
         result.quantity = itemSystem?.quantity?.value ?? 1;
-        result.equipped = itemSystem?.equipped?.value ?? (item as any).isEquipped ?? false;
+        result.equipped = itemSystem?.equipped?.value ?? item.isEquipped ?? false;
 
         if (searchCategory === 'equipped' && !result.equipped) continue;
       }
@@ -1900,7 +1900,7 @@ export class FoundryDataAccess {
       for (const effect of effects) {
         if (matches.length >= limit) break;
 
-        const effectAny = effect as any;
+        const effectAny = effect;
         if (!matchesQuery(effectAny.name || effectAny.label)) continue;
 
         matches.push({
@@ -1972,7 +1972,7 @@ export class FoundryDataAccess {
         // In PF2e, spells have a location property pointing to their spellcasting entry
         const entryId = entry.id;
         const associatedSpells = spellItems.filter((spell: any) => {
-          const spellSystem = spell.system as any;
+          const spellSystem = spell.system;
           return spellSystem?.location?.value === entryId || spellSystem?.location === entryId;
         });
 
@@ -2040,7 +2040,7 @@ export class FoundryDataAccess {
 
       // Also capture focus spells and innate spells that might not be in entries
       const focusSpells = spellItems.filter((spell: any) => {
-        const spellSystem = spell.system as any;
+        const spellSystem = spell.system;
         return (
           spellSystem?.traits?.value?.includes('focus') || spellSystem?.category?.value === 'focus'
         );
@@ -2052,7 +2052,7 @@ export class FoundryDataAccess {
           name: 'Focus Spells',
           type: 'focus',
           spells: focusSpells.map((spell: any) => {
-            const spellSystem = spell.system as any;
+            const spellSystem = spell.system;
             const targeting = this.extractPF2eSpellTargeting(spellSystem);
             return {
               id: spell.id || '',
@@ -2175,7 +2175,7 @@ export class FoundryDataAccess {
             : undefined,
           spells: astralSpells
             .map((spell: any) => {
-              const spellSystem = spell.system as any;
+              const spellSystem = spell.system;
               const targeting = this.extractDSA5SpellTargeting(spellSystem);
               return {
                 id: spell.id || '',
@@ -2205,7 +2205,7 @@ export class FoundryDataAccess {
             : undefined,
           spells: karmaSpells
             .map((spell: any) => {
-              const spellSystem = spell.system as any;
+              const spellSystem = spell.system;
               const targeting = this.extractDSA5SpellTargeting(spellSystem);
               return {
                 id: spell.id || '',
@@ -2230,7 +2230,7 @@ export class FoundryDataAccess {
           type: 'ritual',
           spells: rituals
             .map((spell: any) => {
-              const spellSystem = spell.system as any;
+              const spellSystem = spell.system;
               const targeting = this.extractDSA5SpellTargeting(spellSystem);
               return {
                 id: spell.id || '',
@@ -2617,8 +2617,7 @@ export class FoundryDataAccess {
             // Type assertion and comprehensive safety checks for entry properties
             const typedEntry = entry as any;
             if (
-              !typedEntry ||
-              !typedEntry.name ||
+              !typedEntry?.name ||
               typeof typedEntry.name !== 'string' ||
               typedEntry.name.trim().length === 0
             ) {
@@ -2945,9 +2944,9 @@ export class FoundryDataAccess {
       // Sort by power level then name for consistent ordering (system-aware).
       // Power-level dial: tier (cosmere), level (pf2e), challengeRating (dnd5e).
       const powerLevel = (c: EnhancedCreatureIndex): number => {
-        if ('tier' in c) return (c as CosmereRpgCreatureIndex).tier;
-        if ('level' in c) return (c as PF2eCreatureIndex).level;
-        return (c as DnD5eCreatureIndex).challengeRating;
+        if ('tier' in c) return c.tier;
+        if ('level' in c) return c.level;
+        return c.challengeRating;
       };
       filteredCreatures.sort((a, b) => {
         const powerA = powerLevel(a);
@@ -2980,7 +2979,7 @@ export class FoundryDataAccess {
         };
 
         if (isCosmere) {
-          const c = creature as CosmereRpgCreatureIndex;
+          const c = creature;
           return {
             ...base,
             summary: `Tier ${c.tier} ${c.role} ${c.creatureType} from ${c.packLabel}`,
@@ -3001,7 +3000,7 @@ export class FoundryDataAccess {
         }
 
         if (isPF2e) {
-          const p = creature as PF2eCreatureIndex;
+          const p = creature;
           return {
             ...base,
             armorClass: p.armorClass,
@@ -3054,7 +3053,7 @@ export class FoundryDataAccess {
           topPacks,
           totalCreaturesFound: results.length,
           resultsByPack: Object.fromEntries(packResults),
-          criteria: criteria,
+          criteria,
           indexMetadata: {
             totalIndexedCreatures: enhancedCreatures.length,
             searchMethod: 'enhanced_persistent_index',
@@ -3077,12 +3076,12 @@ export class FoundryDataAccess {
    */
   private passesEnhancedCriteria(creature: EnhancedCreatureIndex, criteria: any): boolean {
     if ('tier' in creature) {
-      return this.passesCosmereRpgCriteria(creature as CosmereRpgCreatureIndex, criteria);
+      return this.passesCosmereRpgCriteria(creature, criteria);
     }
     if ('level' in creature) {
-      return this.passesPF2eCriteria(creature as PF2eCreatureIndex, criteria);
+      return this.passesPF2eCriteria(creature, criteria);
     }
-    return this.passesDnD5eCriteria(creature as DnD5eCreatureIndex, criteria);
+    return this.passesDnD5eCriteria(creature, criteria);
   }
 
   /**
@@ -3323,7 +3322,7 @@ export class FoundryDataAccess {
         topPacks: [],
         totalCreaturesFound: basicResults.length,
         resultsByPack: {},
-        criteria: criteria,
+        criteria,
         fallback: true,
         searchMethod: 'basic_fallback',
       },
@@ -3692,7 +3691,7 @@ export class FoundryDataAccess {
         }
 
         // Recursively sanitize the value (read only after filter to avoid getter-triggered warnings)
-        sanitized[key] = this.removeSensitiveFields((obj as any)[key], visited, depth + 1);
+        sanitized[key] = this.removeSensitiveFields(obj[key], visited, depth + 1);
       }
 
       return sanitized;
@@ -3780,7 +3779,7 @@ export class FoundryDataAccess {
    * Validate that Foundry is ready and world is active
    */
   validateFoundryState(): void {
-    if (!game || !game.ready) {
+    if (!game?.ready) {
       throw new Error('Foundry VTT is not ready');
     }
 
@@ -4498,6 +4497,97 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Remove embedded Items from an existing Actor.
+   *
+   * Items can be named by id (exact, reliable) and/or by name (case-insensitive,
+   * optionally constrained to a `type` to disambiguate). Names that match nothing
+   * are reported back rather than silently ignored. This is the counterpart to
+   * `addActorItems` — useful for clearing stray items added with the wrong type.
+   */
+  async removeActorItems(params: {
+    actorIdentifier: string;
+    itemIds?: string[];
+    itemNames?: string[];
+    type?: string;
+  }): Promise<{
+    actorId: string;
+    actorName: string;
+    removed: Array<{ id: string; name: string; type: string }>;
+    notFound: string[];
+  }> {
+    this.validateFoundryState();
+
+    const { actorIdentifier, itemIds, itemNames, type } = params;
+
+    if (!actorIdentifier) {
+      throw new Error('actorIdentifier is required');
+    }
+    const hasIds = Array.isArray(itemIds) && itemIds.length > 0;
+    const hasNames = Array.isArray(itemNames) && itemNames.length > 0;
+    if (!hasIds && !hasNames) {
+      throw new Error('Provide itemIds and/or itemNames identifying the items to remove');
+    }
+
+    const actor = this.findActorByIdentifier(actorIdentifier);
+    if (!actor) {
+      throw new Error(`Actor not found: ${actorIdentifier}`);
+    }
+
+    const typeLower = type?.toLowerCase();
+    const toDelete = new Map<string, any>(); // id -> item (dedupes overlap)
+    const notFound: string[] = [];
+
+    if (hasIds) {
+      for (const id of itemIds) {
+        const item = actor.items.get(id);
+        if (item) toDelete.set(item.id, item);
+        else notFound.push(id);
+      }
+    }
+    if (hasNames) {
+      for (const name of itemNames) {
+        const nameLower = name.toLowerCase();
+        const item = actor.items.find(
+          (i: any) => i.name?.toLowerCase() === nameLower && (!typeLower || i.type === typeLower)
+        );
+        if (item) toDelete.set(item.id, item);
+        else notFound.push(name);
+      }
+    }
+
+    if (toDelete.size === 0) {
+      return { actorId: actor.id, actorName: actor.name, removed: [], notFound };
+    }
+
+    const removed = Array.from(toDelete.values()).map((i: any) => ({
+      id: i.id,
+      name: i.name,
+      type: i.type,
+    }));
+
+    try {
+      await actor.deleteEmbeddedDocuments(
+        'Item',
+        removed.map(r => r.id)
+      );
+      this.auditLog(
+        'removeActorItems',
+        { actorIdentifier, actorId: actor.id, count: removed.length },
+        'success'
+      );
+      return { actorId: actor.id, actorName: actor.name, removed, notFound };
+    } catch (error) {
+      this.auditLog(
+        'removeActorItems',
+        { actorIdentifier, actorId: actor.id, count: removed.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      throw error;
+    }
+  }
+
+  /**
    * List world-level Item documents from the Items sidebar.
    * Optionally filters by type, folder (name or id), or a case-insensitive name substring.
    */
@@ -4873,7 +4963,7 @@ export class FoundryDataAccess {
             ...tokenDoc,
             x: position.x,
             y: position.y,
-            actorId: actorId,
+            actorId,
             hidden: placement.hidden,
           });
         } catch (error) {
@@ -4975,7 +5065,7 @@ export class FoundryDataAccess {
       // Organize created actors in a folder - use "Foundry MCP Creatures" for generic monsters
       const folderId = await this.getOrCreateFolder('Foundry MCP Creatures', 'Actor');
       if (folderId) {
-        (actorData as any).folder = folderId;
+        actorData.folder = folderId;
       }
 
       // Create the new actor
@@ -5004,7 +5094,7 @@ export class FoundryDataAccess {
 
     switch (placement) {
       case 'coordinates':
-        if (coordinates && coordinates[index]) {
+        if (coordinates?.[index]) {
           return coordinates[index];
         }
         // Fallback to grid if coordinates not provided or insufficient
@@ -5166,7 +5256,7 @@ export class FoundryDataAccess {
             rollButtons: {
               [buttonId]: {
                 rolled: false,
-                rollFormula: rollFormula,
+                rollFormula,
                 rollLabel: buttonLabel,
                 isPublic: data.isPublic,
                 characterId: playerInfo.character?.id || '',
@@ -5250,7 +5340,7 @@ export class FoundryDataAccess {
     // Try partial player name match (active and inactive users)
     if (!user) {
       user = allUsers.find((u: User) => {
-        return Boolean(u.name && u.name.toLowerCase().includes(searchTerm));
+        return Boolean(u.name?.toLowerCase().includes(searchTerm));
       });
 
       if (user) {
@@ -5293,9 +5383,7 @@ export class FoundryDataAccess {
     // If no exact character match, try partial match
     if (!character) {
       character = game.actors?.find((actor: Actor) => {
-        return Boolean(
-          actor.name && actor.name.toLowerCase().includes(searchTerm) && actor.hasPlayerOwner
-        );
+        return Boolean(actor.name?.toLowerCase().includes(searchTerm) && actor.hasPlayerOwner);
       });
 
       if (character) {
@@ -5642,7 +5730,7 @@ export class FoundryDataAccess {
         // Use roll.toMessage() with proper rollMode
         await roll.toMessage(messageData, {
           create: true,
-          rollMode: rollMode,
+          rollMode,
         });
 
         // Update the ChatMessage to reflect rolled state
@@ -5807,10 +5895,10 @@ export class FoundryDataAccess {
         if (game.socket) {
           game.socket.emit('module.foundry-mcp-bridge', {
             type: 'requestMessageUpdate',
-            buttonId: buttonId,
-            userId: userId,
-            rollLabel: rollLabel,
-            messageId: messageId,
+            buttonId,
+            userId,
+            rollLabel,
+            messageId,
             fromUserId: game.user.id,
             targetGM: onlineGM.id,
           });
@@ -5829,7 +5917,7 @@ export class FoundryDataAccess {
         ...rollButtons[buttonId],
         rolled: true,
         rolledBy: userId,
-        rolledByName: rolledByName,
+        rolledByName,
         timestamp: Date.now(),
       };
 
@@ -5848,7 +5936,7 @@ export class FoundryDataAccess {
           ...currentFlags,
           [MODULE_ID]: {
             ...moduleFlags,
-            rollButtons: rollButtons,
+            rollButtons,
           },
         },
       });
@@ -5982,6 +6070,8 @@ export class FoundryDataAccess {
     wounds?: { value?: number; max?: number };
     skills?: Array<{ name: string; advances: number }>;
     career?: string;
+    movement?: number;
+    biography?: string;
   }): Promise<any> {
     this.validateFoundryState();
 
@@ -6015,6 +6105,7 @@ export class FoundryDataAccess {
       wounds: Record<string, any>;
       skills: Record<string, any>;
       career?: string;
+      details?: Record<string, any>;
     } = {
       characteristics: {},
       wounds: {},
@@ -6054,6 +6145,18 @@ export class FoundryDataAccess {
         update['system.status.wounds.max'] = data.wounds.max;
         applied.wounds.max = { from: current.max, to: data.wounds.max };
       }
+    }
+
+    // Detail fields: base movement and the biography/notes text.
+    if (data.movement !== undefined) {
+      update['system.details.move.value'] = data.movement;
+      applied.details = applied.details || {};
+      applied.details.movement = { from: sys.details?.move?.value, to: data.movement };
+    }
+    if (data.biography !== undefined) {
+      update['system.details.biography.value'] = data.biography;
+      applied.details = applied.details || {};
+      applied.details.biography = { chars: data.biography.length };
     }
 
     // Existing embedded-item edits: bump advances on skills the actor already
@@ -6700,8 +6803,8 @@ export class FoundryDataAccess {
       // Create new folder
       const folderData = {
         name: folderName,
-        type: type,
-        description: description,
+        type,
+        description,
         color: type === 'Actor' ? '#4a90e2' : '#f39c12', // Blue for actors, orange for journals
         sort: 0,
         parent: null,
@@ -6751,8 +6854,8 @@ export class FoundryDataAccess {
         name: scene.name,
         active: scene.active,
         dimensions: {
-          width: scene.dimensions?.width || (scene as any).width || 0,
-          height: scene.dimensions?.height || (scene as any).height || 0,
+          width: scene.dimensions?.width || scene.width || 0,
+          height: scene.dimensions?.height || scene.height || 0,
         },
         gridSize: scene.grid?.size || 100,
         background: scene._source?.background?.src || scene.img || '',
@@ -7362,7 +7465,7 @@ export class FoundryDataAccess {
       throw new Error(`Item "${itemIdentifier}" not found on actor "${actor.name}"`);
     }
 
-    const itemAny = item as any;
+    const itemAny = item;
     const systemId = (game.system as any).id;
 
     // Handle targeting if targets are specified

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -6069,16 +6069,20 @@ export class FoundryDataAccess {
           continue;
         }
         itemUpdates.push({ _id: item.id, 'system.advances.value': s.advances });
-        applied.skills[item.name] = { advances: { from: item.system?.advances?.value, to: s.advances } };
+        applied.skills[item.name] = {
+          advances: { from: item.system?.advances?.value, to: s.advances },
+        };
       }
     }
 
     if (data.career) {
       const target = actor.items.find(
-        (i: any) => i.type === 'career' && i.name?.toLowerCase() === data.career!.toLowerCase()
+        (i: any) => i.type === 'career' && i.name?.toLowerCase() === data.career?.toLowerCase()
       );
       if (!target) {
-        warnings.push(`Career "${data.career}" not on ${actor.name} — use wfrp4e-add-items to add it.`);
+        warnings.push(
+          `Career "${data.career}" not on ${actor.name} — use wfrp4e-add-items to add it.`
+        );
       } else {
         // Exactly one career is current; flip the target on and the rest off.
         for (const it of actor.items) {
@@ -6165,7 +6169,10 @@ export class FoundryDataAccess {
     }
 
     if (!Array.isArray(data.items) || data.items.length === 0) {
-      return { success: false, error: 'items array is required and must contain at least one entry' };
+      return {
+        success: false,
+        error: 'items array is required and must contain at least one entry',
+      };
     }
 
     const actor = this.findActorByIdentifier(data.actor);
@@ -6193,7 +6200,8 @@ export class FoundryDataAccess {
 
     const warnings: string[] = [];
     const notFound: string[] = [];
-    const ambiguous: Array<{ name: string; candidates: Array<{ pack: string; type: string }> }> = [];
+    const ambiguous: Array<{ name: string; candidates: Array<{ pack: string; type: string }> }> =
+      [];
 
     // Skill advances and gear quantity are baked into each item's creation data
     // (below) rather than patched afterwards, because createEmbeddedDocuments
@@ -6221,8 +6229,12 @@ export class FoundryDataAccess {
     const toCreate: Array<Record<string, any>> = [];
     // Keyed by `${type}::${name}` (the created doc's own name/type) so we can
     // match created documents back to their request without relying on order.
-    const plan: Array<{ nameLower: string; type: string; setCurrent: boolean | undefined; source: string }> =
-      [];
+    const plan: Array<{
+      nameLower: string;
+      type: string;
+      setCurrent: boolean | undefined;
+      source: string;
+    }> = [];
 
     // Find every compendium entry whose name (and optional type) matches, across
     // the candidate packs (their core-first order is preserved in the result).
@@ -6314,10 +6326,10 @@ export class FoundryDataAccess {
       }
 
       // matches preserves the core-first pack order, so [0] is the best source.
-      const chosen = matches[0]!;
+      const chosen = matches[0];
       const pack = (game.packs as any).get(chosen.packId);
       const sourceDoc = await pack.getDocument(chosen.entryId);
-      const obj = sourceDoc.toObject() as any;
+      const obj = sourceDoc.toObject();
       const finalName = nameOverride ?? obj.name;
       const clean: Record<string, any> = {
         name: finalName,

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -6209,6 +6209,12 @@ export class FoundryDataAccess {
       }
     } catch (error) {
       console.error(`[${MODULE_ID}] Error updating WFRP4e actor:`, error);
+      this.auditLog(
+        'updateWfrp4eActor',
+        { actor: data.actor },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
 
@@ -6221,6 +6227,8 @@ export class FoundryDataAccess {
         if (c) newTotals[key.toUpperCase()] = { total: c.value, bonus: c.bonus };
       }
     }
+
+    this.auditLog('updateWfrp4eActor', { actor: data.actor }, 'success');
 
     return {
       success: true,

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -6083,14 +6083,9 @@ export class FoundryDataAccess {
       };
     }
 
-    // Resolve actor by id (16-char) or name
-    let actor: any;
-    if (data.actor.length === 16) {
-      actor = game.actors?.get(data.actor);
-    }
-    if (!actor) {
-      actor = game.actors?.find((a: any) => a.name?.toLowerCase() === data.actor.toLowerCase());
-    }
+    // Resolve a world actor by id/name, or a scene token by id (an unlinked
+    // token resolves to its own synthetic actor — see findActorByIdentifier).
+    const actor = this.findActorByIdentifier(data.actor);
     if (!actor) {
       return { success: false, error: `Actor not found: ${data.actor}` };
     }
@@ -6601,13 +6596,23 @@ export class FoundryDataAccess {
    * Find actor by name or ID
    */
   private findActorByIdentifier(identifier: string): any {
-    return (
+    const worldActor =
       game.actors?.get(identifier) ||
       game.actors?.getName(identifier) ||
       Array.from(game.actors || []).find(a =>
         a.name?.toLowerCase().includes(identifier.toLowerCase())
-      )
-    );
+      );
+    if (worldActor) return worldActor;
+
+    // Fallback: a scene Token id. For an unlinked token this returns the token's
+    // own synthetic (delta-backed) actor, so edits persist to that token alone —
+    // the way to tweak one copy on a map without touching the prototype or its
+    // siblings. (For a linked token this is the world actor, same as above.)
+    for (const scene of (game.scenes as any) || []) {
+      const token = scene.tokens?.get(identifier);
+      if (token?.actor) return token.actor;
+    }
+    return undefined;
   }
 
   /**

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -5980,6 +5980,8 @@ export class FoundryDataAccess {
     actor: string;
     characteristics?: Record<string, { initial?: number; advances?: number; modifier?: number }>;
     wounds?: { value?: number; max?: number };
+    skills?: Array<{ name: string; advances: number }>;
+    career?: string;
   }): Promise<any> {
     this.validateFoundryState();
 
@@ -6007,9 +6009,16 @@ export class FoundryDataAccess {
     const FIELDS = ['initial', 'advances', 'modifier'] as const;
     const sys = actor.system || {};
     const update: Record<string, any> = {};
-    const applied: { characteristics: Record<string, any>; wounds: Record<string, any> } = {
+    const itemUpdates: Array<Record<string, any>> = [];
+    const applied: {
+      characteristics: Record<string, any>;
+      wounds: Record<string, any>;
+      skills: Record<string, any>;
+      career?: string;
+    } = {
       characteristics: {},
       wounds: {},
+      skills: {},
     };
     const warnings: string[] = [];
 
@@ -6047,12 +6056,55 @@ export class FoundryDataAccess {
       }
     }
 
-    if (Object.keys(update).length === 0) {
-      return { success: false, error: 'No valid fields to update.', ...(warnings.length ? { warnings } : {}) };
+    // Existing embedded-item edits: bump advances on skills the actor already
+    // has, and/or switch which career item is current. (Adding new skills or
+    // careers is wfrp4e-add-items' job.)
+    if (Array.isArray(data.skills)) {
+      for (const s of data.skills) {
+        const item = actor.items.find(
+          (i: any) => i.type === 'skill' && i.name?.toLowerCase() === s.name.toLowerCase()
+        );
+        if (!item) {
+          warnings.push(`Skill "${s.name}" not on ${actor.name} — use wfrp4e-add-items to add it.`);
+          continue;
+        }
+        itemUpdates.push({ _id: item.id, 'system.advances.value': s.advances });
+        applied.skills[item.name] = { advances: { from: item.system?.advances?.value, to: s.advances } };
+      }
+    }
+
+    if (data.career) {
+      const target = actor.items.find(
+        (i: any) => i.type === 'career' && i.name?.toLowerCase() === data.career!.toLowerCase()
+      );
+      if (!target) {
+        warnings.push(`Career "${data.career}" not on ${actor.name} — use wfrp4e-add-items to add it.`);
+      } else {
+        // Exactly one career is current; flip the target on and the rest off.
+        for (const it of actor.items) {
+          if (it.type === 'career') {
+            itemUpdates.push({ _id: it.id, 'system.current.value': it.id === target.id });
+          }
+        }
+        applied.career = target.name;
+      }
+    }
+
+    if (Object.keys(update).length === 0 && itemUpdates.length === 0) {
+      return {
+        success: false,
+        error: 'No valid fields to update.',
+        ...(warnings.length ? { warnings } : {}),
+      };
     }
 
     try {
-      await actor.update(update);
+      if (Object.keys(update).length > 0) {
+        await actor.update(update);
+      }
+      if (itemUpdates.length > 0) {
+        await actor.updateEmbeddedDocuments('Item', itemUpdates);
+      }
     } catch (error) {
       console.error(`[${MODULE_ID}] Error updating WFRP4e actor:`, error);
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -6074,6 +6126,246 @@ export class FoundryDataAccess {
       id: actor.id,
       applied,
       newCharacteristicTotals: newTotals,
+      ...(warnings.length ? { warnings } : {}),
+    };
+  }
+
+  /**
+   * Add items (skills, talents, traits, trappings, careers, weapons, spells, …)
+   * to an existing WFRP4e actor. Each requested item is matched by name against
+   * the installed WFRP4e compendiums and copied in full, so a skill keeps its
+   * linked characteristic, a talent its tests/max, a career its progression.
+   * Names with no compendium match are added as a blank item of the requested
+   * (or default) type so homebrew still works.
+   *
+   * Per-item extras: `advances` sets a skill's advances; `quantity` sets a
+   * gear count; `setCurrent` makes a career the active one (flipping the others
+   * off). Resolution prefers the Core Rulebook pack, then the rest; pass `type`
+   * and/or `pack` to disambiguate a name that exists in several places.
+   */
+  async addWfrp4eItems(data: {
+    actor: string;
+    items: Array<{
+      name: string;
+      type?: string;
+      pack?: string;
+      advances?: number;
+      quantity?: number;
+      setCurrent?: boolean;
+    }>;
+  }): Promise<any> {
+    this.validateFoundryState();
+
+    const systemId = (game.system as any).id;
+    if (systemId !== 'wfrp4e') {
+      return {
+        success: false,
+        error: `wfrp4e-add-items requires the WFRP4e system (current: "${systemId}")`,
+      };
+    }
+
+    if (!Array.isArray(data.items) || data.items.length === 0) {
+      return { success: false, error: 'items array is required and must contain at least one entry' };
+    }
+
+    const actor = this.findActorByIdentifier(data.actor);
+    if (!actor) {
+      return { success: false, error: `Actor not found: ${data.actor}` };
+    }
+
+    // Candidate Item packs, Core Rulebook first so a name shared across books
+    // resolves to the canonical entry.
+    const itemPacks: any[] = Array.from((game.packs as any) || []).filter(
+      (p: any) => (p.metadata?.type ?? p.documentName) === 'Item'
+    );
+    itemPacks.sort((a: any, b: any) => {
+      const rank = (p: any) => (String(p.metadata?.id || '').startsWith('wfrp4e-core') ? 0 : 1);
+      return rank(a) - rank(b);
+    });
+
+    // Per-call index cache — each pack's index is loaded at most once.
+    const indexCache = new Map<string, any>();
+    const getIndex = async (pack: any) => {
+      const id = pack.metadata.id;
+      if (!indexCache.has(id)) indexCache.set(id, await pack.getIndex());
+      return indexCache.get(id);
+    };
+
+    const warnings: string[] = [];
+    const notFound: string[] = [];
+    const ambiguous: Array<{ name: string; candidates: Array<{ pack: string; type: string }> }> = [];
+
+    // Aligned creation plan: toCreate[i] ↔ plan[i] (skipped items push to neither).
+    const toCreate: Array<Record<string, any>> = [];
+    const plan: Array<{
+      advances: number | undefined;
+      quantity: number | undefined;
+      setCurrent: boolean | undefined;
+      source: string;
+    }> = [];
+
+    for (const req of data.items) {
+      const nameLower = req.name.toLowerCase();
+      const typeWanted = req.type?.toLowerCase();
+      const searchPacks = req.pack
+        ? itemPacks.filter(
+            (p: any) => p.metadata.id === req.pack || p.metadata.id.includes(req.pack as string)
+          )
+        : itemPacks;
+
+      const matches: Array<{ packId: string; packLabel: string; entryId: string; type: string }> = [];
+      for (const pack of searchPacks) {
+        const index = await getIndex(pack);
+        for (const entry of index) {
+          if (
+            entry.name?.toLowerCase() === nameLower &&
+            (!typeWanted || entry.type === typeWanted)
+          ) {
+            matches.push({
+              packId: pack.metadata.id,
+              packLabel: pack.metadata.label,
+              entryId: entry._id,
+              type: entry.type,
+            });
+          }
+        }
+      }
+
+      if (matches.length === 0) {
+        const fallbackType = typeWanted || 'trapping';
+        toCreate.push({ name: req.name, type: fallbackType });
+        plan.push({
+          advances: req.advances,
+          quantity: req.quantity,
+          setCurrent: req.setCurrent,
+          source: 'custom (not in compendium)',
+        });
+        notFound.push(req.name);
+        warnings.push(
+          `"${req.name}" not found in any WFRP4e compendium — added as a blank ${fallbackType}.`
+        );
+        continue;
+      }
+
+      // Several distinct item types share this name and the caller didn't pick
+      // one — don't guess.
+      const distinctTypes = [...new Set(matches.map(m => m.type))];
+      if (!typeWanted && distinctTypes.length > 1) {
+        ambiguous.push({
+          name: req.name,
+          candidates: matches.map(m => ({ pack: m.packId, type: m.type })),
+        });
+        warnings.push(
+          `"${req.name}" matches multiple item types (${distinctTypes.join(', ')}); pass "type" to choose — skipped.`
+        );
+        continue;
+      }
+
+      // matches preserves the core-first pack order, so [0] is the best source.
+      const chosen = matches[0]!;
+      const pack = (game.packs as any).get(chosen.packId);
+      const sourceDoc = await pack.getDocument(chosen.entryId);
+      const obj = sourceDoc.toObject() as any;
+      toCreate.push({
+        name: obj.name,
+        type: obj.type,
+        img: obj.img,
+        system: obj.system,
+        effects: obj.effects || [],
+        flags: obj.flags || {},
+      });
+      plan.push({
+        advances: req.advances,
+        quantity: req.quantity,
+        setCurrent: req.setCurrent,
+        source: chosen.packLabel,
+      });
+    }
+
+    if (toCreate.length === 0) {
+      return {
+        success: false,
+        error: 'No items could be added.',
+        ...(notFound.length ? { notFound } : {}),
+        ...(ambiguous.length ? { ambiguous } : {}),
+        ...(warnings.length ? { warnings } : {}),
+      };
+    }
+
+    let created: any[] = [];
+    try {
+      created = (await actor.createEmbeddedDocuments('Item', toCreate)) || [];
+
+      // Post-create patches: skill advances, gear quantity, current career.
+      const postUpdates: Array<Record<string, any>> = [];
+      let currentCareerId: string | undefined;
+      created.forEach((doc: any, i: number) => {
+        const p = plan[i]!;
+        const patch: Record<string, any> = { _id: doc.id };
+        let dirty = false;
+        if (p.advances !== undefined && doc.type === 'skill') {
+          patch['system.advances.value'] = p.advances;
+          dirty = true;
+        }
+        if (p.quantity !== undefined && doc.system?.quantity !== undefined) {
+          patch['system.quantity.value'] = p.quantity;
+          dirty = true;
+        }
+        if (dirty) postUpdates.push(patch);
+        if (p.setCurrent && doc.type === 'career') currentCareerId = doc.id;
+      });
+
+      // Only one career is current; if asked, flip the chosen one on and every
+      // other career on the actor (new or pre-existing) off.
+      if (currentCareerId) {
+        for (const it of actor.items) {
+          if (it.type === 'career') {
+            postUpdates.push({ _id: it.id, 'system.current.value': it.id === currentCareerId });
+          }
+        }
+      }
+
+      if (postUpdates.length > 0) {
+        await actor.updateEmbeddedDocuments('Item', postUpdates);
+      }
+    } catch (error) {
+      console.error(`[${MODULE_ID}] Error adding WFRP4e items:`, error);
+      this.auditLog(
+        'addWfrp4eItems',
+        { actor: data.actor, count: toCreate.length },
+        'failure',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+
+    // Summarise, reading back derived skill totals / career state as confirmation.
+    const createdSummary = created.map((doc: any, i: number) => {
+      const after = actor.items.get(doc.id);
+      const entry: Record<string, any> = {
+        id: doc.id,
+        name: doc.name,
+        type: doc.type,
+        source: plan[i]!.source,
+      };
+      if (after?.type === 'skill') {
+        entry.advances = after.system?.advances?.value;
+        entry.total = after.system?.total?.value;
+        entry.characteristic = after.system?.characteristic?.value;
+      }
+      if (after?.type === 'career') entry.current = after.system?.current?.value ?? false;
+      return entry;
+    });
+
+    this.auditLog('addWfrp4eItems', { actor: data.actor, count: created.length }, 'success');
+
+    return {
+      success: true,
+      actor: actor.name,
+      id: actor.id,
+      created: createdSummary,
+      ...(notFound.length ? { notFound } : {}),
+      ...(ambiguous.length ? { ambiguous } : {}),
       ...(warnings.length ? { warnings } : {}),
     };
   }

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -6195,14 +6195,34 @@ export class FoundryDataAccess {
     const notFound: string[] = [];
     const ambiguous: Array<{ name: string; candidates: Array<{ pack: string; type: string }> }> = [];
 
-    // Aligned creation plan: toCreate[i] ↔ plan[i] (skipped items push to neither).
+    // Skill advances and gear quantity are baked into each item's creation data
+    // (below) rather than patched afterwards, because createEmbeddedDocuments
+    // does not guarantee it returns documents in the order we send them — so
+    // positional alignment between the created docs and our requests is unsafe.
+    const GEAR_TYPES = new Set([
+      'weapon',
+      'armour',
+      'trapping',
+      'ammunition',
+      'container',
+      'money',
+      'cargo',
+    ]);
+    const applyExtras = (obj: Record<string, any>, type: string, req: any): void => {
+      obj.system = obj.system || {};
+      if (req.advances !== undefined && type === 'skill') {
+        obj.system.advances = { ...(obj.system.advances || {}), value: req.advances };
+      }
+      if (req.quantity !== undefined && GEAR_TYPES.has(type)) {
+        obj.system.quantity = { ...(obj.system.quantity || {}), value: req.quantity };
+      }
+    };
+
     const toCreate: Array<Record<string, any>> = [];
-    const plan: Array<{
-      advances: number | undefined;
-      quantity: number | undefined;
-      setCurrent: boolean | undefined;
-      source: string;
-    }> = [];
+    // Keyed by `${type}::${name}` (the created doc's own name/type) so we can
+    // match created documents back to their request without relying on order.
+    const plan: Array<{ nameLower: string; type: string; setCurrent: boolean | undefined; source: string }> =
+      [];
 
     for (const req of data.items) {
       const nameLower = req.name.toLowerCase();
@@ -6233,10 +6253,12 @@ export class FoundryDataAccess {
 
       if (matches.length === 0) {
         const fallbackType = typeWanted || 'trapping';
-        toCreate.push({ name: req.name, type: fallbackType });
+        const obj: Record<string, any> = { name: req.name, type: fallbackType, system: {} };
+        applyExtras(obj, fallbackType, req);
+        toCreate.push(obj);
         plan.push({
-          advances: req.advances,
-          quantity: req.quantity,
+          nameLower,
+          type: fallbackType,
           setCurrent: req.setCurrent,
           source: 'custom (not in compendium)',
         });
@@ -6266,17 +6288,19 @@ export class FoundryDataAccess {
       const pack = (game.packs as any).get(chosen.packId);
       const sourceDoc = await pack.getDocument(chosen.entryId);
       const obj = sourceDoc.toObject() as any;
-      toCreate.push({
+      const clean: Record<string, any> = {
         name: obj.name,
         type: obj.type,
         img: obj.img,
-        system: obj.system,
+        system: obj.system || {},
         effects: obj.effects || [],
         flags: obj.flags || {},
-      });
+      };
+      applyExtras(clean, obj.type, req);
+      toCreate.push(clean);
       plan.push({
-        advances: req.advances,
-        quantity: req.quantity,
+        nameLower: String(obj.name).toLowerCase(),
+        type: obj.type,
         setCurrent: req.setCurrent,
         source: chosen.packLabel,
       });
@@ -6296,37 +6320,30 @@ export class FoundryDataAccess {
     try {
       created = (await actor.createEmbeddedDocuments('Item', toCreate)) || [];
 
-      // Post-create patches: skill advances, gear quantity, current career.
-      const postUpdates: Array<Record<string, any>> = [];
-      let currentCareerId: string | undefined;
-      created.forEach((doc: any, i: number) => {
-        const p = plan[i]!;
-        const patch: Record<string, any> = { _id: doc.id };
-        let dirty = false;
-        if (p.advances !== undefined && doc.type === 'skill') {
-          patch['system.advances.value'] = p.advances;
-          dirty = true;
-        }
-        if (p.quantity !== undefined && doc.system?.quantity !== undefined) {
-          patch['system.quantity.value'] = p.quantity;
-          dirty = true;
-        }
-        if (dirty) postUpdates.push(patch);
-        if (p.setCurrent && doc.type === 'career') currentCareerId = doc.id;
-      });
-
-      // Only one career is current; if asked, flip the chosen one on and every
-      // other career on the actor (new or pre-existing) off.
-      if (currentCareerId) {
-        for (const it of actor.items) {
-          if (it.type === 'career') {
-            postUpdates.push({ _id: it.id, 'system.current.value': it.id === currentCareerId });
+      // Make a career current if requested. Match the created career by NAME,
+      // not by position (see the ordering note above). Exactly one career is
+      // current, so flip the target on and every other career off.
+      const setCurrentNames = new Set(
+        plan.filter(p => p.setCurrent && p.type === 'career').map(p => p.nameLower)
+      );
+      if (setCurrentNames.size > 0) {
+        let targetId: string | undefined;
+        for (const doc of created) {
+          if (doc.type === 'career' && setCurrentNames.has(String(doc.name).toLowerCase())) {
+            targetId = doc.id;
           }
         }
-      }
-
-      if (postUpdates.length > 0) {
-        await actor.updateEmbeddedDocuments('Item', postUpdates);
+        if (targetId) {
+          const careerUpdates: Array<Record<string, any>> = [];
+          for (const it of actor.items) {
+            if (it.type === 'career') {
+              careerUpdates.push({ _id: it.id, 'system.current.value': it.id === targetId });
+            }
+          }
+          if (careerUpdates.length > 0) {
+            await actor.updateEmbeddedDocuments('Item', careerUpdates);
+          }
+        }
       }
     } catch (error) {
       console.error(`[${MODULE_ID}] Error adding WFRP4e items:`, error);
@@ -6340,13 +6357,17 @@ export class FoundryDataAccess {
     }
 
     // Summarise, reading back derived skill totals / career state as confirmation.
-    const createdSummary = created.map((doc: any, i: number) => {
+    // Source is looked up by name+type (order-independent).
+    const sourceByKey = new Map<string, string>();
+    for (const p of plan) sourceByKey.set(`${p.type}::${p.nameLower}`, p.source);
+
+    const createdSummary = created.map((doc: any) => {
       const after = actor.items.get(doc.id);
       const entry: Record<string, any> = {
         id: doc.id,
         name: doc.name,
         type: doc.type,
-        source: plan[i]!.source,
+        source: sourceByKey.get(`${doc.type}::${String(doc.name).toLowerCase()}`) ?? 'unknown',
       };
       if (after?.type === 'skill') {
         entry.advances = after.system?.advances?.value;

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -6224,6 +6224,33 @@ export class FoundryDataAccess {
     const plan: Array<{ nameLower: string; type: string; setCurrent: boolean | undefined; source: string }> =
       [];
 
+    // Find every compendium entry whose name (and optional type) matches, across
+    // the candidate packs (their core-first order is preserved in the result).
+    const findMatches = async (
+      packs: any[],
+      searchName: string,
+      typeConstraint: string | undefined
+    ): Promise<Array<{ packId: string; packLabel: string; entryId: string; type: string }>> => {
+      const found: Array<{ packId: string; packLabel: string; entryId: string; type: string }> = [];
+      for (const pack of packs) {
+        const index = await getIndex(pack);
+        for (const entry of index) {
+          if (
+            entry.name?.toLowerCase() === searchName &&
+            (!typeConstraint || entry.type === typeConstraint)
+          ) {
+            found.push({
+              packId: pack.metadata.id,
+              packLabel: pack.metadata.label,
+              entryId: entry._id,
+              type: entry.type,
+            });
+          }
+        }
+      }
+      return found;
+    };
+
     for (const req of data.items) {
       const nameLower = req.name.toLowerCase();
       const typeWanted = req.type?.toLowerCase();
@@ -6233,20 +6260,23 @@ export class FoundryDataAccess {
           )
         : itemPacks;
 
-      const matches: Array<{ packId: string; packLabel: string; entryId: string; type: string }> = [];
-      for (const pack of searchPacks) {
-        const index = await getIndex(pack);
-        for (const entry of index) {
-          if (
-            entry.name?.toLowerCase() === nameLower &&
-            (!typeWanted || entry.type === typeWanted)
-          ) {
-            matches.push({
-              packId: pack.metadata.id,
-              packLabel: pack.metadata.label,
-              entryId: entry._id,
-              type: entry.type,
-            });
+      let matches = await findMatches(searchPacks, nameLower, typeWanted);
+
+      // Grouped-skill fallback: a specialisation like "Entertain (Taunt)" often
+      // has no dedicated entry, but the group's generic template "Entertain ()"
+      // does — copy that (it carries the correct characteristic and grouping)
+      // and rename the copy to the requested specialisation.
+      let nameOverride: string | undefined;
+      let templated = false;
+      if (matches.length === 0 && (typeWanted === undefined || typeWanted === 'skill')) {
+        const grouped = /^\s*(.+?)\s*\([^)]+\)\s*$/.exec(req.name);
+        if (grouped) {
+          const templateName = `${grouped[1]} ()`.toLowerCase();
+          const templateMatches = await findMatches(searchPacks, templateName, 'skill');
+          if (templateMatches.length > 0) {
+            matches = templateMatches;
+            nameOverride = req.name.trim();
+            templated = true;
           }
         }
       }
@@ -6288,8 +6318,9 @@ export class FoundryDataAccess {
       const pack = (game.packs as any).get(chosen.packId);
       const sourceDoc = await pack.getDocument(chosen.entryId);
       const obj = sourceDoc.toObject() as any;
+      const finalName = nameOverride ?? obj.name;
       const clean: Record<string, any> = {
-        name: obj.name,
+        name: finalName,
         type: obj.type,
         img: obj.img,
         system: obj.system || {},
@@ -6299,10 +6330,10 @@ export class FoundryDataAccess {
       applyExtras(clean, obj.type, req);
       toCreate.push(clean);
       plan.push({
-        nameLower: String(obj.name).toLowerCase(),
+        nameLower: String(finalName).toLowerCase(),
         type: obj.type,
         setCurrent: req.setCurrent,
-        source: chosen.packLabel,
+        source: templated ? `${chosen.packLabel} (grouped template)` : chosen.packLabel,
       });
     }
 

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -87,6 +87,9 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.findPlayers`] = this.handleFindPlayers.bind(this);
     CONFIG.queries[`${modulePrefix}.findActor`] = this.handleFindActor.bind(this);
 
+    // WFRP4e actor stat-block update
+    CONFIG.queries[`${modulePrefix}.updateWfrp4eActor`] = this.handleUpdateWfrp4eActor.bind(this);
+
     // Token manipulation queries
     CONFIG.queries[`${modulePrefix}.moveToken`] = this.handleMoveToken.bind(this);
     CONFIG.queries[`${modulePrefix}.updateToken`] = this.handleUpdateToken.bind(this);
@@ -794,6 +797,31 @@ export class QueryHandlers {
     } catch (error) {
       throw new Error(
         `Failed to set actor ownership: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Handle WFRP4e actor stat-block update request
+   */
+  async handleUpdateWfrp4eActor(data: any): Promise<any> {
+    try {
+      // SECURITY: Silent GM validation
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data.actor) {
+        throw new Error('actor (name or id) is required');
+      }
+
+      return await this.dataAccess.updateWfrp4eActor(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to update WFRP4e actor: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -117,6 +117,7 @@ export class QueryHandlers {
 
     // Item authoring on actor sheets
     CONFIG.queries[`${modulePrefix}.addActorItems`] = this.handleAddActorItems.bind(this);
+    CONFIG.queries[`${modulePrefix}.removeActorItems`] = this.handleRemoveActorItems.bind(this);
 
     // World-level item CRUD
     CONFIG.queries[`${modulePrefix}.createWorldItems`] = this.handleCreateWorldItems.bind(this);
@@ -1062,7 +1063,7 @@ export class QueryHandlers {
         scene_name: data.scene_name.trim(),
         size: data.size || 'medium',
         grid_size: data.grid_size || 70,
-        quality: quality,
+        quality,
       };
 
       // Use ComfyUIManager to communicate with backend via WebSocket
@@ -1578,6 +1579,43 @@ export class QueryHandlers {
     }
   }
 
+  private async handleRemoveActorItems(data: {
+    actorIdentifier: string;
+    itemIds?: string[];
+    itemNames?: string[];
+    type?: string;
+  }): Promise<any> {
+    try {
+      // SECURITY: Silent GM validation - writes to actor sheets are GM-only
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data?.actorIdentifier) {
+        throw new Error('actorIdentifier is required');
+      }
+      const hasIds = Array.isArray(data?.itemIds) && data.itemIds.length > 0;
+      const hasNames = Array.isArray(data?.itemNames) && data.itemNames.length > 0;
+      if (!hasIds && !hasNames) {
+        throw new Error('Provide itemIds and/or itemNames identifying the items to remove');
+      }
+
+      return await this.dataAccess.removeActorItems({
+        actorIdentifier: data.actorIdentifier,
+        ...(data.itemIds !== undefined ? { itemIds: data.itemIds } : {}),
+        ...(data.itemNames !== undefined ? { itemNames: data.itemNames } : {}),
+        ...(data.type !== undefined ? { type: data.type } : {}),
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to remove actor items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
   private async handleUpdateWorldItems(data: {
     updates: Array<{
       id: string;
@@ -1601,7 +1639,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.updateWorldItems({ updates: data.updates });
     } catch (error) {
-      throw new Error(`Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1624,7 +1664,9 @@ export class QueryHandlers {
         ...(data.nameFilter !== undefined ? { nameFilter: data.nameFilter } : {}),
       });
     } catch (error) {
-      throw new Error(`Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1911,5 +1953,4 @@ export class QueryHandlers {
       throw new Error(`Failed to add features from compendium: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
-
 }

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -89,6 +89,7 @@ export class QueryHandlers {
 
     // WFRP4e actor stat-block update
     CONFIG.queries[`${modulePrefix}.updateWfrp4eActor`] = this.handleUpdateWfrp4eActor.bind(this);
+    CONFIG.queries[`${modulePrefix}.addWfrp4eItems`] = this.handleAddWfrp4eItems.bind(this);
 
     // Token manipulation queries
     CONFIG.queries[`${modulePrefix}.moveToken`] = this.handleMoveToken.bind(this);
@@ -822,6 +823,35 @@ export class QueryHandlers {
     } catch (error) {
       throw new Error(
         `Failed to update WFRP4e actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Add items (skills, talents, careers, trappings, …) to a WFRP4e actor,
+   * resolved from the installed compendiums. GM-only.
+   */
+  async handleAddWfrp4eItems(data: any): Promise<any> {
+    try {
+      // SECURITY: Silent GM validation
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+
+      if (!data.actor) {
+        throw new Error('actor (name or id) is required');
+      }
+      if (!Array.isArray(data.items) || data.items.length === 0) {
+        throw new Error('items array is required and must contain at least one entry');
+      }
+
+      return await this.dataAccess.addWfrp4eItems(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to add WFRP4e items: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -31,6 +31,7 @@ import { DiceRollTools } from './tools/dice-roll.js';
 import { CampaignManagementTools } from './tools/campaign-management.js';
 
 import { OwnershipTools } from './tools/ownership.js';
+import { WFRP4eUpdateActorTools } from './tools/wfrp4e/update-actor.js';
 
 import { MapGenerationTools } from './tools/map-generation.js';
 
@@ -1203,6 +1204,8 @@ async function startBackend(): Promise<void> {
 
   const tokenManipulationTools = new TokenManipulationTools({ foundryClient, logger });
 
+  const wfrp4eUpdateActorTools = new WFRP4eUpdateActorTools({ foundryClient, logger });
+
   // Initialize mapgen-style backend components for map generation
   let mapGenerationJobQueue: any = null;
   let mapGenerationComfyUIClient: any = null;
@@ -1422,6 +1425,8 @@ async function startBackend(): Promise<void> {
 
     ...ownershipTools.getToolDefinitions(),
 
+    ...wfrp4eUpdateActorTools.getToolDefinitions(),
+
     ...tokenManipulationTools.getToolDefinitions(),
 
     ...mapGenerationTools.getToolDefinitions(),
@@ -1565,6 +1570,11 @@ async function startBackend(): Promise<void> {
 
                 case 'get-compendium-entry-full':
                   result = await actorCreationTools.handleGetCompendiumEntryFull(args);
+
+                  break;
+
+                case 'wfrp4e-update-actor':
+                  result = await wfrp4eUpdateActorTools.handleUpdateActor(args);
 
                   break;
 

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -32,6 +32,7 @@ import { CampaignManagementTools } from './tools/campaign-management.js';
 
 import { OwnershipTools } from './tools/ownership.js';
 import { WFRP4eUpdateActorTools } from './tools/wfrp4e/update-actor.js';
+import { WFRP4eAddItemsTools } from './tools/wfrp4e/add-items.js';
 
 import { MapGenerationTools } from './tools/map-generation.js';
 
@@ -1205,6 +1206,7 @@ async function startBackend(): Promise<void> {
   const tokenManipulationTools = new TokenManipulationTools({ foundryClient, logger });
 
   const wfrp4eUpdateActorTools = new WFRP4eUpdateActorTools({ foundryClient, logger });
+  const wfrp4eAddItemsTools = new WFRP4eAddItemsTools({ foundryClient, logger });
 
   // Initialize mapgen-style backend components for map generation
   let mapGenerationJobQueue: any = null;
@@ -1427,6 +1429,8 @@ async function startBackend(): Promise<void> {
 
     ...wfrp4eUpdateActorTools.getToolDefinitions(),
 
+    ...wfrp4eAddItemsTools.getToolDefinitions(),
+
     ...tokenManipulationTools.getToolDefinitions(),
 
     ...mapGenerationTools.getToolDefinitions(),
@@ -1575,6 +1579,11 @@ async function startBackend(): Promise<void> {
 
                 case 'wfrp4e-update-actor':
                   result = await wfrp4eUpdateActorTools.handleUpdateActor(args);
+
+                  break;
+
+                case 'wfrp4e-add-items':
+                  result = await wfrp4eAddItemsTools.handleAddItems(args);
 
                   break;
 

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -146,15 +146,16 @@ export class CharacterTools {
           '- "create": Create world-level Items in the sidebar (not actor-attached). Good for reusable libraries. GM-only.\n' +
           '- "list": List world-level Items with optional type/folder/name filters.\n' +
           '- "update": Update existing world-level Items by ID. GM-only.\n' +
-          '- "add-to-actor": Create and attach Items directly to an existing actor. GM-only.',
+          '- "add-to-actor": Create and attach Items directly to an existing actor. GM-only.\n' +
+          '- "remove-from-actor": Delete Items already on an actor, identified by itemIds and/or itemNames (optionally constrained by type). GM-only.',
         inputSchema: {
           type: 'object',
           properties: {
             action: {
               type: 'string',
-              enum: ['create', 'list', 'update', 'add-to-actor'],
+              enum: ['create', 'list', 'update', 'add-to-actor', 'remove-from-actor'],
               description:
-                'Operation to perform: "create" world items, "list" world items, "update" world items by id, or "add-to-actor" to attach items to an actor.',
+                'Operation to perform: "create" world items, "list" world items, "update" world items by id, "add-to-actor" to attach items to an actor, or "remove-from-actor" to delete items from an actor.',
             },
             items: {
               type: 'array',
@@ -167,7 +168,8 @@ export class CharacterTools {
                   name: { type: 'string', description: 'Display name of the item' },
                   type: {
                     type: 'string',
-                    description: 'Item type valid for the active system (e.g. "action", "talent", "weapon")',
+                    description:
+                      'Item type valid for the active system (e.g. "action", "talent", "weapon")',
                   },
                   img: {
                     type: 'string',
@@ -175,7 +177,8 @@ export class CharacterTools {
                   },
                   system: {
                     type: 'object',
-                    description: 'System-specific data (free-form). Passed through to Foundry\'s DataModel layer.',
+                    description:
+                      "System-specific data (free-form). Passed through to Foundry's DataModel layer.",
                     additionalProperties: true,
                   },
                 },
@@ -195,7 +198,8 @@ export class CharacterTools {
                   img: { type: 'string', description: 'New icon path' },
                   system: {
                     type: 'object',
-                    description: 'System-specific fields to update (merged into existing system data)',
+                    description:
+                      'System-specific fields to update (merged into existing system data)',
                     additionalProperties: true,
                   },
                   folder: {
@@ -213,7 +217,8 @@ export class CharacterTools {
             },
             type: {
               type: 'string',
-              description: 'For "list": filter by item type (e.g. "action", "talent"). Omit to return all types.',
+              description:
+                'For "list": filter by item type (e.g. "action", "talent"). For "remove-from-actor": constrain itemNames to this type. Omit to return/match all types.',
             },
             nameFilter: {
               type: 'string',
@@ -221,7 +226,20 @@ export class CharacterTools {
             },
             actorIdentifier: {
               type: 'string',
-              description: 'For "add-to-actor": actor name or ID to receive the items.',
+              description:
+                'For "add-to-actor" and "remove-from-actor": actor name or ID to receive or lose the items.',
+            },
+            itemIds: {
+              type: 'array',
+              description:
+                'For "remove-from-actor": ids of items already on the actor to delete (most reliable; get them from get-character).',
+              items: { type: 'string' },
+            },
+            itemNames: {
+              type: 'array',
+              description:
+                'For "remove-from-actor": names of items on the actor to delete (case-insensitive). Combine with "type" to disambiguate.',
+              items: { type: 'string' },
             },
           },
           required: ['action'],
@@ -550,15 +568,18 @@ export class CharacterTools {
     });
 
     try {
-      const result = await this.foundryClient.query('foundry-mcp-bridge.updateWorldItems', { updates });
+      const result = await this.foundryClient.query('foundry-mcp-bridge.updateWorldItems', {
+        updates,
+      });
 
       this.logger.debug('Successfully updated world items', { count: result.updated?.length ?? 0 });
 
       return result;
-
     } catch (error) {
       this.logger.error('Failed to update world items', error);
-      throw new Error(`Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to update world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -571,7 +592,11 @@ export class CharacterTools {
 
     const { type, folder, nameFilter } = schema.parse(args);
 
-    this.logger.info('Listing world items', { type: type ?? null, folder: folder ?? null, nameFilter: nameFilter ?? null });
+    this.logger.info('Listing world items', {
+      type: type ?? null,
+      folder: folder ?? null,
+      nameFilter: nameFilter ?? null,
+    });
 
     try {
       const items = await this.foundryClient.query('foundry-mcp-bridge.listWorldItems', {
@@ -586,10 +611,11 @@ export class CharacterTools {
         items: items ?? [],
         total: items?.length ?? 0,
       };
-
     } catch (error) {
       this.logger.error('Failed to list world items', error);
-      throw new Error(`Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to list world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -626,15 +652,18 @@ export class CharacterTools {
       });
 
       return result;
-
     } catch (error) {
       this.logger.error('Failed to create world items', error);
-      throw new Error(`Failed to create world items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to create world items: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
   async handleManageWorldItems(args: any): Promise<any> {
-    const { action } = z.object({ action: z.enum(['create', 'list', 'update', 'add-to-actor']) }).parse(args);
+    const { action } = z
+      .object({ action: z.enum(['create', 'list', 'update', 'add-to-actor', 'remove-from-actor']) })
+      .parse(args);
 
     switch (action) {
       case 'create':
@@ -645,6 +674,51 @@ export class CharacterTools {
         return this.handleUpdateWorldItems(args);
       case 'add-to-actor':
         return this.handleAddActorItems(args);
+      case 'remove-from-actor':
+        return this.handleRemoveActorItems(args);
+    }
+  }
+
+  async handleRemoveActorItems(args: any): Promise<any> {
+    const schema = z
+      .object({
+        actorIdentifier: z.string().min(1, 'Actor identifier cannot be empty'),
+        itemIds: z.array(z.string().min(1)).optional(),
+        itemNames: z.array(z.string().min(1)).optional(),
+        type: z.string().optional(),
+      })
+      .refine(v => (v.itemIds?.length ?? 0) + (v.itemNames?.length ?? 0) > 0, {
+        message: 'Provide itemIds and/or itemNames identifying the items to remove',
+      });
+
+    const { actorIdentifier, itemIds, itemNames, type } = schema.parse(args);
+
+    this.logger.info('Removing items from actor', {
+      actorIdentifier,
+      ids: itemIds?.length ?? 0,
+      names: itemNames?.length ?? 0,
+      type: type ?? null,
+    });
+
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.removeActorItems', {
+        actorIdentifier,
+        ...(itemIds !== undefined ? { itemIds } : {}),
+        ...(itemNames !== undefined ? { itemNames } : {}),
+        ...(type !== undefined ? { type } : {}),
+      });
+
+      this.logger.debug('Successfully removed actor items', {
+        actorName: result.actorName,
+        removed: result.removed?.length ?? 0,
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error('Failed to remove actor items', error);
+      throw new Error(
+        `Failed to remove items from "${actorIdentifier}": ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1029,6 +1103,6 @@ export class CharacterTools {
     if (!text || text.length <= maxLength) {
       return text;
     }
-    return text.substring(0, maxLength - 3) + '...';
+    return `${text.substring(0, maxLength - 3)}...`;
   }
 }

--- a/packages/mcp-server/src/tools/wfrp4e/add-items.test.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/add-items.test.ts
@@ -1,0 +1,88 @@
+/**
+ * WFRP4e add-items tool tests.
+ *
+ * The compendium resolution itself runs browser-side (in the Foundry module),
+ * so these cover the MCP tool layer: schema validation and that valid calls are
+ * forwarded to the `addWfrp4eItems` bridge query with the expected payload.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { WFRP4eAddItemsTools } from './add-items.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ success: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new WFRP4eAddItemsTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('WFRP4eAddItemsTools.getToolDefinitions', () => {
+  it('exposes wfrp4e-add-items requiring actor and items', () => {
+    const [def] = makeTools().tools.getToolDefinitions();
+    expect(def.name).toBe('wfrp4e-add-items');
+    expect(def.inputSchema.required).toEqual(['actor', 'items']);
+    expect((def.inputSchema.properties as any).items.items.required).toEqual(['name']);
+  });
+});
+
+describe('WFRP4eAddItemsTools.handleAddItems', () => {
+  it('forwards a valid call to the addWfrp4eItems bridge query', async () => {
+    const { tools, query } = makeTools();
+    const args = {
+      actor: 'Greta',
+      items: [
+        { name: 'Stealth (Rural)', advances: 10 },
+        { name: 'Strike Mighty Blow', type: 'talent' },
+        { name: 'Huntsman', type: 'career', setCurrent: true },
+      ],
+    };
+
+    const result = await tools.handleAddItems(args);
+
+    expect(result).toEqual({ success: true });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.addWfrp4eItems', {
+      actor: 'Greta',
+      items: args.items,
+    });
+  });
+
+  it('rejects a missing actor without calling the bridge', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleAddItems({ items: [{ name: 'Stealth' }] });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty items array', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleAddItems({ actor: 'Greta', items: [] });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown top-level and per-item keys (strict schema)', async () => {
+    const { tools, query } = makeTools();
+    const bothBad = [
+      { actor: 'Greta', items: [{ name: 'Stealth' }], wounds: 5 },
+      { actor: 'Greta', items: [{ name: 'Stealth', level: 3 }] },
+    ];
+    for (const args of bothBad) {
+      const result = await tools.handleAddItems(args);
+      expect(result.success).toBe(false);
+    }
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('surfaces bridge errors as a failed result', async () => {
+    const { tools } = makeTools(async () => {
+      throw new Error('Actor not found: Greta');
+    });
+    const result = await tools.handleAddItems({
+      actor: 'Greta',
+      items: [{ name: 'Stealth' }],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Actor not found');
+  });
+});

--- a/packages/mcp-server/src/tools/wfrp4e/add-items.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/add-items.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import { FoundryClient } from '../../foundry-client.js';
+import { Logger } from '../../logger.js';
+
+export interface WFRP4eAddItemsToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+const itemSchema = z
+  .object({
+    name: z.string().min(1),
+    type: z.string().optional(),
+    pack: z.string().optional(),
+    advances: z.number().optional(),
+    quantity: z.number().optional(),
+    setCurrent: z.boolean().optional(),
+  })
+  .strict();
+
+const addItemsSchema = z
+  .object({
+    actor: z.string().min(1),
+    items: z.array(itemSchema).min(1),
+  })
+  .strict();
+
+/**
+ * WFRP4e add-items tool. Attaches skills, talents, traits, trappings, careers,
+ * weapons, spells, etc. to an existing actor by resolving each name against the
+ * installed WFRP4e compendiums (full item copied), falling back to a blank item
+ * when there is no match.
+ */
+export class WFRP4eAddItemsTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor({ foundryClient, logger }: WFRP4eAddItemsToolsOptions) {
+    this.foundryClient = foundryClient;
+    this.logger = logger.child({ component: 'WFRP4eAddItemsTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'wfrp4e-add-items',
+        description:
+          '[WFRP4e only] Add skills, talents, traits, trappings, careers, weapons, spells and ' +
+          'other items to an existing actor. Each item is matched by name against the installed ' +
+          'WFRP4e compendiums and copied in full, so a skill keeps its linked characteristic, a ' +
+          'talent its tests, and a career its progression; a name with no compendium match is ' +
+          'added as a blank custom item. Use "advances" to set a skill\'s advances, "quantity" for ' +
+          'gear counts, and "setCurrent" to make a career the active one. Pass "type" and/or ' +
+          '"pack" to disambiguate a name found in several places. USE THIS to build out a ' +
+          "character's items. To create the actor itself use create-actor-from-compendium; to " +
+          'change characteristics/wounds or bump a skill the actor already has, use wfrp4e-update-actor.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actor: {
+              type: 'string',
+              description: 'Actor name or 16-character Foundry id',
+            },
+            items: {
+              type: 'array',
+              description: 'Items to add to the actor.',
+              minItems: 1,
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description:
+                      'Item name to look up (e.g. "Stealth (Rural)", "Strike Mighty Blow").',
+                  },
+                  type: {
+                    type: 'string',
+                    description:
+                      'Optional WFRP item type to disambiguate (skill, talent, trait, trapping, ' +
+                      'career, weapon, armour, spell, prayer, …). Also used as the type when a ' +
+                      'name is not in any compendium.',
+                  },
+                  pack: {
+                    type: 'string',
+                    description:
+                      'Optional compendium pack id (or fragment) to source the item from.',
+                  },
+                  advances: {
+                    type: 'number',
+                    description: 'Skills only: advances to set on the added skill.',
+                  },
+                  quantity: {
+                    type: 'number',
+                    description: 'Gear only: quantity to set on the added item.',
+                  },
+                  setCurrent: {
+                    type: 'boolean',
+                    description: "Careers only: make this the actor's current career.",
+                  },
+                },
+                required: ['name'],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ['actor', 'items'],
+        },
+      },
+    ];
+  }
+
+  async handleAddItems(args: unknown) {
+    const parsed = addItemsSchema.safeParse(args);
+    if (!parsed.success) {
+      const detail = parsed.error.issues
+        .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      return { success: false, error: `Invalid arguments: ${detail}` };
+    }
+
+    const { actor, items } = parsed.data;
+    this.logger.info('Adding WFRP4e items', { actor, count: items.length });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.addWfrp4eItems', { actor, items });
+    } catch (error) {
+      this.logger.error('Failed to add WFRP4e items', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/wfrp4e/update-actor.test.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/update-actor.test.ts
@@ -25,12 +25,14 @@ describe('WFRP4eUpdateActorTools.getToolDefinitions', () => {
 });
 
 describe('WFRP4eUpdateActorTools.handleUpdateActor', () => {
-  it('forwards skills and career to the bridge', async () => {
+  it('forwards skills, career, movement and biography to the bridge', async () => {
     const { tools, query } = makeTools();
     const args = {
       actor: 'Tylo',
       skills: [{ name: 'Channelling (Hedgecraft)', advances: 5 }],
       career: 'Hedge Master',
+      movement: 5,
+      biography: 'A hedge wizard of the Reikwald.',
     };
 
     const result = await tools.handleUpdateActor(args);
@@ -42,7 +44,16 @@ describe('WFRP4eUpdateActorTools.handleUpdateActor', () => {
       wounds: undefined,
       skills: args.skills,
       career: 'Hedge Master',
+      movement: 5,
+      biography: 'A hedge wizard of the Reikwald.',
     });
+  });
+
+  it('accepts a biography-only update', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleUpdateActor({ actor: 'Tylo', biography: 'Notes.' });
+    expect(result).toEqual({ success: true });
+    expect(query).toHaveBeenCalled();
   });
 
   it('accepts career-only updates (not "nothing to update")', async () => {

--- a/packages/mcp-server/src/tools/wfrp4e/update-actor.test.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/update-actor.test.ts
@@ -1,0 +1,74 @@
+/**
+ * WFRP4e update-actor tool tests — focused on the schema/forwarding for the
+ * newer skills/career fields alongside the existing characteristics/wounds.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { WFRP4eUpdateActorTools } from './update-actor.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ success: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new WFRP4eUpdateActorTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('WFRP4eUpdateActorTools.getToolDefinitions', () => {
+  it('advertises skills and career inputs', () => {
+    const [def] = makeTools().tools.getToolDefinitions();
+    const props = def.inputSchema.properties as any;
+    expect(def.name).toBe('wfrp4e-update-actor');
+    expect(props.skills.type).toBe('array');
+    expect(props.career.type).toBe('string');
+  });
+});
+
+describe('WFRP4eUpdateActorTools.handleUpdateActor', () => {
+  it('forwards skills and career to the bridge', async () => {
+    const { tools, query } = makeTools();
+    const args = {
+      actor: 'Tylo',
+      skills: [{ name: 'Channelling (Hedgecraft)', advances: 5 }],
+      career: 'Hedge Master',
+    };
+
+    const result = await tools.handleUpdateActor(args);
+
+    expect(result).toEqual({ success: true });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.updateWfrp4eActor', {
+      actor: 'Tylo',
+      characteristics: undefined,
+      wounds: undefined,
+      skills: args.skills,
+      career: 'Hedge Master',
+    });
+  });
+
+  it('accepts career-only updates (not "nothing to update")', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleUpdateActor({
+      actor: 'Tylo',
+      career: 'Hedge Master',
+    });
+    expect(result).toEqual({ success: true });
+    expect(query).toHaveBeenCalled();
+  });
+
+  it('rejects an empty update with nothing to change', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleUpdateActor({ actor: 'Tylo' });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed skills entry (strict)', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleUpdateActor({
+      actor: 'Tylo',
+      skills: [{ name: 'Melee', bonus: 5 }],
+    });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod';
+import { FoundryClient } from '../../foundry-client.js';
+import { Logger } from '../../logger.js';
+
+export interface WFRP4eUpdateActorToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+const CHAR_KEYS = ['ws', 'bs', 's', 't', 'i', 'ag', 'dex', 'int', 'wp', 'fel'] as const;
+
+const charFieldSchema = z
+  .object({
+    initial: z.number().optional(),
+    advances: z.number().optional(),
+    modifier: z.number().optional(),
+  })
+  .strict();
+
+const updateActorSchema = z
+  .object({
+    actor: z.string().min(1),
+    characteristics: z.record(z.string(), charFieldSchema).optional(),
+    wounds: z.object({ value: z.number().optional(), max: z.number().optional() }).strict().optional(),
+  })
+  .strict();
+
+/**
+ * WFRP4e actor-update tool. Patches an existing actor's stat block
+ * (characteristics and/or wounds); WFRP4e recomputes derived value/bonus.
+ */
+export class WFRP4eUpdateActorTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor({ foundryClient, logger }: WFRP4eUpdateActorToolsOptions) {
+    this.foundryClient = foundryClient;
+    this.logger = logger.child({ component: 'WFRP4eUpdateActorTools' });
+  }
+
+  getToolDefinitions() {
+    const charProperty = {
+      type: 'object',
+      properties: {
+        initial: { type: 'number', description: 'Base characteristic value' },
+        advances: { type: 'number', description: 'Points advanced in this characteristic' },
+        modifier: { type: 'number', description: 'Modifier (may be negative)' },
+      },
+      additionalProperties: false,
+    };
+    const characteristicProps: Record<string, unknown> = {};
+    for (const key of CHAR_KEYS) characteristicProps[key] = charProperty;
+
+    return [
+      {
+        name: 'wfrp4e-update-actor',
+        description:
+          "[WFRP4e only] Update an existing actor's stat block: characteristic " +
+          'initial/advances/modifier and/or wounds (current value and max). Only the ' +
+          'fields you provide change; the characteristic Total and Bonus recompute ' +
+          'automatically. USE THIS to tweak a creature/NPC/PC you already have — e.g. ' +
+          'after cloning a creature to make a tougher variant. DO NOT use this to create ' +
+          'an actor (use create-actor-from-compendium) or to add/remove items, spells, ' +
+          'or talents (use manage-world-items).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actor: {
+              type: 'string',
+              description: 'Actor name or 16-character Foundry id',
+            },
+            characteristics: {
+              type: 'object',
+              description:
+                'Per-characteristic updates. Keys: ws, bs, s, t, i, ag, dex, int, wp, fel. ' +
+                'Each may set initial, advances and/or modifier.',
+              properties: characteristicProps,
+              additionalProperties: false,
+            },
+            wounds: {
+              type: 'object',
+              description: 'Wound (hit point) updates.',
+              properties: {
+                value: { type: 'number', description: 'Current wounds' },
+                max: { type: 'number', description: 'Maximum wounds' },
+              },
+              additionalProperties: false,
+            },
+          },
+          required: ['actor'],
+        },
+      },
+    ];
+  }
+
+  async handleUpdateActor(args: unknown) {
+    const parsed = updateActorSchema.safeParse(args);
+    if (!parsed.success) {
+      const detail = parsed.error.issues
+        .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      return { success: false, error: `Invalid arguments: ${detail}` };
+    }
+
+    const { actor, characteristics, wounds } = parsed.data;
+    if (!characteristics && !wounds) {
+      return { success: false, error: 'Nothing to update: provide characteristics and/or wounds.' };
+    }
+
+    // Surface unknown characteristic keys early (clearer than a silent skip).
+    if (characteristics) {
+      const unknown = Object.keys(characteristics).filter(
+        k => !CHAR_KEYS.includes(k.toLowerCase() as (typeof CHAR_KEYS)[number])
+      );
+      if (unknown.length > 0) {
+        return {
+          success: false,
+          error: `Unknown characteristic key(s): ${unknown.join(', ')}. Valid keys: ${CHAR_KEYS.join(', ')}.`,
+        };
+      }
+    }
+
+    this.logger.info('Updating WFRP4e actor', { actor });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.updateWfrp4eActor', {
+        actor,
+        characteristics,
+        wounds,
+      });
+    } catch (error) {
+      this.logger.error('Failed to update WFRP4e actor', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
@@ -29,6 +29,8 @@ const updateActorSchema = z
       .array(z.object({ name: z.string().min(1), advances: z.number() }).strict())
       .optional(),
     career: z.string().min(1).optional(),
+    movement: z.number().optional(),
+    biography: z.string().optional(),
   })
   .strict();
 
@@ -64,7 +66,8 @@ export class WFRP4eUpdateActorTools {
         description:
           "[WFRP4e only] Update an existing actor's stat block: characteristic " +
           'initial/advances/modifier, wounds (current value and max), the advances on ' +
-          'skills the actor already has, and/or which career is current. Only the fields ' +
+          'skills the actor already has, which career is current, base movement, and/or ' +
+          'the biography text. Only the fields ' +
           'you provide change; the characteristic Total/Bonus and skill totals recompute ' +
           'automatically. USE THIS to tweak a creature/NPC/PC you already have — e.g. after ' +
           'cloning a creature to make a tougher variant, or to advance a skill. To ADD a new ' +
@@ -118,6 +121,15 @@ export class WFRP4eUpdateActorTools {
                 "Name of an existing career item to make the actor's current career (the others " +
                 'are set non-current).',
             },
+            movement: {
+              type: 'number',
+              description: 'Base Movement value (system.details.move).',
+            },
+            biography: {
+              type: 'string',
+              description:
+                'Biography / notes text for the actor (replaces the current biography; HTML allowed).',
+            },
           },
           required: ['actor'],
         },
@@ -134,11 +146,19 @@ export class WFRP4eUpdateActorTools {
       return { success: false, error: `Invalid arguments: ${detail}` };
     }
 
-    const { actor, characteristics, wounds, skills, career } = parsed.data;
-    if (!characteristics && !wounds && !skills?.length && !career) {
+    const { actor, characteristics, wounds, skills, career, movement, biography } = parsed.data;
+    if (
+      !characteristics &&
+      !wounds &&
+      !skills?.length &&
+      !career &&
+      movement === undefined &&
+      biography === undefined
+    ) {
       return {
         success: false,
-        error: 'Nothing to update: provide characteristics, wounds, skills and/or career.',
+        error:
+          'Nothing to update: provide characteristics, wounds, skills, career, movement and/or biography.',
       };
     }
 
@@ -163,6 +183,8 @@ export class WFRP4eUpdateActorTools {
         wounds,
         skills,
         career,
+        movement,
+        biography,
       });
     } catch (error) {
       this.logger.error('Failed to update WFRP4e actor', error);

--- a/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
+++ b/packages/mcp-server/src/tools/wfrp4e/update-actor.ts
@@ -21,7 +21,14 @@ const updateActorSchema = z
   .object({
     actor: z.string().min(1),
     characteristics: z.record(z.string(), charFieldSchema).optional(),
-    wounds: z.object({ value: z.number().optional(), max: z.number().optional() }).strict().optional(),
+    wounds: z
+      .object({ value: z.number().optional(), max: z.number().optional() })
+      .strict()
+      .optional(),
+    skills: z
+      .array(z.object({ name: z.string().min(1), advances: z.number() }).strict())
+      .optional(),
+    career: z.string().min(1).optional(),
   })
   .strict();
 
@@ -56,12 +63,13 @@ export class WFRP4eUpdateActorTools {
         name: 'wfrp4e-update-actor',
         description:
           "[WFRP4e only] Update an existing actor's stat block: characteristic " +
-          'initial/advances/modifier and/or wounds (current value and max). Only the ' +
-          'fields you provide change; the characteristic Total and Bonus recompute ' +
-          'automatically. USE THIS to tweak a creature/NPC/PC you already have — e.g. ' +
-          'after cloning a creature to make a tougher variant. DO NOT use this to create ' +
-          'an actor (use create-actor-from-compendium) or to add/remove items, spells, ' +
-          'or talents (use manage-world-items).',
+          'initial/advances/modifier, wounds (current value and max), the advances on ' +
+          'skills the actor already has, and/or which career is current. Only the fields ' +
+          'you provide change; the characteristic Total/Bonus and skill totals recompute ' +
+          'automatically. USE THIS to tweak a creature/NPC/PC you already have — e.g. after ' +
+          'cloning a creature to make a tougher variant, or to advance a skill. To ADD a new ' +
+          'skill, talent, trait, trapping or career use wfrp4e-add-items; to create an actor ' +
+          'use create-actor-from-compendium.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -86,6 +94,30 @@ export class WFRP4eUpdateActorTools {
               },
               additionalProperties: false,
             },
+            skills: {
+              type: 'array',
+              description:
+                'Set advances on skills the actor ALREADY has. To add a new skill use ' +
+                'wfrp4e-add-items instead.',
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: 'Existing skill name (e.g. "Stealth (Rural)").',
+                  },
+                  advances: { type: 'number', description: 'Advances to set on the skill.' },
+                },
+                required: ['name', 'advances'],
+                additionalProperties: false,
+              },
+            },
+            career: {
+              type: 'string',
+              description:
+                "Name of an existing career item to make the actor's current career (the others " +
+                'are set non-current).',
+            },
           },
           required: ['actor'],
         },
@@ -102,9 +134,12 @@ export class WFRP4eUpdateActorTools {
       return { success: false, error: `Invalid arguments: ${detail}` };
     }
 
-    const { actor, characteristics, wounds } = parsed.data;
-    if (!characteristics && !wounds) {
-      return { success: false, error: 'Nothing to update: provide characteristics and/or wounds.' };
+    const { actor, characteristics, wounds, skills, career } = parsed.data;
+    if (!characteristics && !wounds && !skills?.length && !career) {
+      return {
+        success: false,
+        error: 'Nothing to update: provide characteristics, wounds, skills and/or career.',
+      };
     }
 
     // Surface unknown characteristic keys early (clearer than a silent skip).
@@ -126,6 +161,8 @@ export class WFRP4eUpdateActorTools {
         actor,
         characteristics,
         wounds,
+        skills,
+        career,
       });
     } catch (error) {
       this.logger.error('Failed to update WFRP4e actor', error);


### PR DESCRIPTION
## What this is

We've been running a Warhammer Fantasy Roleplay 4e campaign and built these editing tools for our own table. Now that the WFRP4e read support (#53) has landed in master, we figured we'd offer these up too in case they're useful to anyone else — no expectations either way.

It builds directly on the merged WFRP4e support and is rebased on the current master (v0.8.2).

## What it adds

Two new MCP tools plus an extension to the existing item tool (40 → 42):

- **`wfrp4e-update-actor`** — patch an existing actor's stat block: characteristic initial/advances/modifier, wounds, advances on skills the actor already has, current career, base movement, and biography. Only the fields you pass change; WFRP4e recomputes the derived totals/bonuses.
- **`wfrp4e-add-items`** — add skills, talents, traits, trappings, careers, weapons, spells, etc. to an existing actor. Each is matched by name against the installed WFRP4e compendiums and copied in full (so a skill keeps its characteristic, a career its progression); an unmatched name falls back to a blank custom item. Grouped-skill specialisations are handled by templating ("Entertain (Taunt)" copies the generic "Entertain ()" entry and renames it).
- **Item removal** on the existing actor-items tool, plus scene-token id resolution to the underlying (synthetic) token actor.

## Notes for review

- Follows the existing conventions — tool class + `getToolDefinitions()`/handler pair, bridge query handlers, and `validateFoundryState` / audit-log / structured-return shape in `data-access`.
- Input validation uses zod `safeParse` returning a structured error rather than throwing, so malformed input from the model comes back as a correctable message. Happy to switch to the throw style if you'd prefer consistency.
- Adds vitest coverage for both new tools.
- Write paths are GM-gated and audit-logged like the other mutation tools.

It's a wide-but-shallow diff (verbose tool schemas + readbacks), readable as seven small commits rather than one wall. Totally understand if write tools aren't a direction you want for the project — happy to adjust, split it up, or just leave it as a reference. Thanks for the project!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
