### PR TITLE
Preserve effects[] and flags{} when serializing item documents

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -4703,6 +4703,8 @@ export class FoundryDataAccess {
       const doc: Record<string, any> = { name: it.name, type: it.type };
       if (it.img) doc.img = it.img;
       if (it.system && typeof it.system === 'object') doc.system = it.system;
+      if (Array.isArray((it as any).effects)) doc.effects = (it as any).effects;
+      if ((it as any).flags && typeof (it as any).flags === 'object') doc.flags = (it as any).flags;
       return doc;
     });
 

--- a/packages/mcp-server/src/tools/character.ts
+++ b/packages/mcp-server/src/tools/character.ts
@@ -599,6 +599,8 @@ export class CharacterTools {
       type: z.string().min(1, 'Item type cannot be empty'),
       img: z.string().optional(),
       system: z.record(z.any()).optional(),
+      effects: z.array(z.record(z.any())).optional(),
+      flags: z.record(z.any()).optional(),
     });
 
     const schema = z.object({


### PR DESCRIPTION
## Summary

When `FoundryDataAccess` serializes Item documents for the MCP server (the path that backs `create-world-items` and adjacent flows), it currently forwards only `name`, `type`, `img`, and `system`. That silently strips two fields that callers downstream really do need:

- **`effects[]`** — Active Effects attached to the item. Without them an item that grants conditions or modifies stats (a +1 sword's bonus, a feat's passive aura, a magic item that imposes a status) round-trips as inert; the MCP side can't see why the item does what it does in-world.
- **`flags{}`** — module-scoped per-item data. Tidy5e Sheet, Midi-QOL, DAE, etc. all stash their automation/UI state here. Stripping `flags` means an MCP consumer can't reason about (or recreate) those module behaviors.

## Changes

Four added lines, two files, both surgically minimal:

**`packages/foundry-module/src/data-access.ts`** (around line 4705)
```ts
if (it.system && typeof it.system === 'object') doc.system = it.system;
+ if (Array.isArray((it as any).effects)) doc.effects = (it as any).effects;
+ if ((it as any).flags && typeof (it as any).flags === 'object') doc.flags = (it as any).flags;
return doc;
```

**`packages/mcp-server/src/tools/character.ts`** — `handleCreateWorldItems` `itemSchema` (around line 599)
```ts
img: z.string().optional(),
system: z.record(z.any()).optional(),
+ effects: z.array(z.record(z.any())).optional(),
+ flags: z.record(z.any()).optional(),
```

Both new fields are **optional** and **guarded**. Items that don't carry effects/flags are unaffected — `doc.effects` / `doc.flags` simply aren't set, and the Zod schema accepts payloads without them. No behavior change for existing callers.

## Why this is small but worth merging

- Same conceptual fix on both sides of the wire: producer (bridge module) now emits the fields, consumer (MCP server) now accepts them. They were already a matched pair for `name/type/img/system`; this just completes the pair for `effects/flags`.
- No new dependencies, no API surface change in the public sense, no migration.
- Without it, any MCP consumer (Claude, Codex, third-party) gets a strictly incomplete picture of items — which is the kind of silent-data-loss bug that's hard to notice until you're surprised by it.

## Notes

- I run a from-source build of this repo behind an Archivist/Nexus runtime against a live D&D 5e world (Foundry v14.363, dnd5e 5.3.3) on a Mac mini. The patch has been in use locally for several days without regression on the unchanged paths.
- One unrelated, well-known footgun I hit while building from source on macOS (worth a separate issue, not part of this PR): the backend at `dist/backend.js` creates a write stream against `~/Library/Application Support/FoundryMCPServer/comfyui.log` unconditionally. The directory only exists if your packaged installer ran. From a clean source checkout the backend exits immediately with an unhandled `ENOENT` on that stream — silent under the 75-second proxy-retry loop in `dist/index.js`. `mkdir -p` on that dir at startup (or guarding the stream) would save the next from-source contributor a long debugging session.

## Test plan

- [x] Build: `npm run build:shared && npm run build:server && npm run build:foundry`
- [x] `tools/list` returns the expected 40 tools after the patch
- [x] `get-character` on a 5e character whose items carry Active Effects now surfaces those effects in the item documents (previously absent)
- [x] `get-character` on a character with Midi-QOL-flagged items now surfaces those `flags.midi-qol` entries (previously absent)
- [x] Round-trip through `create-world-items` with an item payload that includes `effects` and `flags` validates and creates correctly
- [x] Items without `effects`/`flags` behave identically to pre-patch
