### PR TITLE
chore: Prettier sweep + convert dsa5 filter test to real vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Foundry VTT MCP Bridge
 
-Connect Foundry VTT to Claude Desktop for AI-powered campaign management through the Model Context Protocol (MCP). It currently supports Dungeons and Dragons Fifth Edition, Pathfinder Second Edition, Das Schwarze Augen Fifth Edition, Cosmere RPG System, & Warhammer Fantasy Roleplay 4th Edition. The majority of MCP tools are system agnostic or have features that are aware of the system it is working with, excluding some DSA 5 specific tools. 
+Connect Foundry VTT to Claude Desktop for AI-powered campaign management through the Model Context Protocol (MCP). It currently supports Dungeons and Dragons Fifth Edition, Pathfinder Second Edition, Das Schwarze Augen Fifth Edition, Cosmere RPG System, & Warhammer Fantasy Roleplay 4th Edition. The majority of MCP tools are system agnostic or have features that are aware of the system it is working with, excluding some DSA 5 specific tools.
 
 ## Overview
 

--- a/docs/spec-create-npc.md
+++ b/docs/spec-create-npc.md
@@ -6,11 +6,13 @@ Repository: `adambdooley/foundry-vtt-mcp` (fork locale in
 `C:\Users\lucam\Documents\Progetti\foundry-vtt-mcp`)
 
 Stack:
+
 - `packages/mcp-server/` — Node.js MCP server in TypeScript
 - `packages/foundry-module/` — modulo Foundry VTT (browser)
 - `packages/shared/` — tipi condivisi (workspace dep)
 
 Pattern architetturale a 4 layer (seguito da tutti i tool esistenti):
+
 1. **Server tool class** (`mcp-server/src/tools/…`) — Zod validation, query dispatch
 2. **Backend registration** (`mcp-server/src/backend.ts`) — import, instantiate, allTools, switch
 3. **Query handler** (`foundry-module/src/queries.ts`) — GM check, validation, call data-access
@@ -36,35 +38,35 @@ immunities, CR, biography). **Nessun item/azione/feature/spell nell'Actor.**
 
 ### Identità
 
-| Campo             | Tipo    | Req | Default | Validazione |
-|-------------------|---------|-----|---------|-------------|
-| `name`            | string  | ✅  | —       | min 1 |
-| `creatureType`    | enum    | ✅  | —       | humanoid / undead / beast / dragon / aberration / construct / elemental / fey / fiend / giant / monstrosity / ooze / plant / celestial / swarm |
-| `creatureSubtype` | string  | ❌  | `""`    | — |
-| `size`            | enum    | ✅  | —       | tiny / small / medium / large / huge / gargantuan |
-| `alignment`       | string  | ❌  | `""`    | — |
-| `cr`              | string\|number | ✅ | — | string: `/^\d+(\/(2\|4\|8))?$/`; number: finite ≥ 0 |
+| Campo             | Tipo           | Req | Default | Validazione                                                                                                                                    |
+| ----------------- | -------------- | --- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`            | string         | ✅  | —       | min 1                                                                                                                                          |
+| `creatureType`    | enum           | ✅  | —       | humanoid / undead / beast / dragon / aberration / construct / elemental / fey / fiend / giant / monstrosity / ooze / plant / celestial / swarm |
+| `creatureSubtype` | string         | ❌  | `""`    | —                                                                                                                                              |
+| `size`            | enum           | ✅  | —       | tiny / small / medium / large / huge / gargantuan                                                                                              |
+| `alignment`       | string         | ❌  | `""`    | —                                                                                                                                              |
+| `cr`              | string\|number | ✅  | —       | string: `/^\d+(\/(2\|4\|8))?$/`; number: finite ≥ 0                                                                                            |
 
 ### Stat block
 
-| Campo          | Tipo | Req | Default | Validazione |
-|----------------|------|-----|---------|-------------|
-| `abilities`    | oggetto | ✅ | — | 6 chiavi: str/dex/con/int/wis/cha, ognuna int 1–30 |
-| `savingThrows` | string[] | ❌ | `[]` | ogni elemento in: str/dex/con/int/wis/cha |
-| `hpAverage`    | int  | ✅  | —       | ≥ 1 |
-| `hpFormula`    | string | ✅ | —     | min 1 (es. "2d6", "3d8+9") — non validato sintatticamente |
+| Campo          | Tipo     | Req | Default | Validazione                                               |
+| -------------- | -------- | --- | ------- | --------------------------------------------------------- |
+| `abilities`    | oggetto  | ✅  | —       | 6 chiavi: str/dex/con/int/wis/cha, ognuna int 1–30        |
+| `savingThrows` | string[] | ❌  | `[]`    | ogni elemento in: str/dex/con/int/wis/cha                 |
+| `hpAverage`    | int      | ✅  | —       | ≥ 1                                                       |
+| `hpFormula`    | string   | ✅  | —       | min 1 (es. "2d6", "3d8+9") — non validato sintatticamente |
 
 ### CA — superRefine: `acValue` obbligatorio quando `acMode === "flat"`
 
-| Campo     | Tipo  | Req | Default | Validazione |
-|-----------|-------|-----|---------|-------------|
-| `acMode`  | enum  | ✅  | —       | "default" / "flat" |
-| `acValue` | int   | ❌  | —       | 0–30 — obbligatorio se acMode==="flat" |
+| Campo     | Tipo | Req | Default | Validazione                            |
+| --------- | ---- | --- | ------- | -------------------------------------- |
+| `acMode`  | enum | ✅  | —       | "default" / "flat"                     |
+| `acValue` | int  | ❌  | —       | 0–30 — obbligatorio se acMode==="flat" |
 
 ### Movimento
 
 | Campo         | Tipo | Req | Default |
-|---------------|------|-----|---------|
+| ------------- | ---- | --- | ------- |
 | `walkSpeed`   | int  | ❌  | `30`    |
 | `flySpeed`    | int  | ❌  | `0`     |
 | `swimSpeed`   | int  | ❌  | `0`     |
@@ -76,20 +78,20 @@ Tutti i campi velocità: ≥ 0.
 
 ### Sensi
 
-| Campo          | Tipo   | Req | Default |
-|----------------|--------|-----|---------|
-| `darkvision`   | int    | ❌  | `0`     |
-| `blindsight`   | int    | ❌  | `0`     |
-| `tremorsense`  | int    | ❌  | `0`     |
-| `truesight`    | int    | ❌  | `0`     |
-| `specialSenses`| string | ❌  | `""`    |
+| Campo           | Tipo   | Req | Default |
+| --------------- | ------ | --- | ------- |
+| `darkvision`    | int    | ❌  | `0`     |
+| `blindsight`    | int    | ❌  | `0`     |
+| `tremorsense`   | int    | ❌  | `0`     |
+| `truesight`     | int    | ❌  | `0`     |
+| `specialSenses` | string | ❌  | `""`    |
 
 Tutti i campi distanza: ≥ 0.
 
 ### Competenze
 
-| Campo    | Tipo  | Req | Default | Validazione |
-|----------|-------|-----|---------|-------------|
+| Campo    | Tipo  | Req | Default | Validazione                                                                |
+| -------- | ----- | --- | ------- | -------------------------------------------------------------------------- |
 | `skills` | array | ❌  | `[]`    | ogni elemento: `{ skill: SkillEnum, proficiency: "proficient"\|"expert" }` |
 
 SkillEnum (18 valori): Acrobatics / Animal Handling / Arcana / Athletics /
@@ -99,14 +101,14 @@ Stealth / Survival
 
 ### Traits
 
-| Campo                    | Tipo     | Req | Default | Note |
-|--------------------------|----------|-----|---------|------|
-| `damageImmunities`       | string[] | ❌  | `[]`    | soft validation (vedi sotto) |
-| `damageResistances`      | string[] | ❌  | `[]`    | soft validation |
-| `damageVulnerabilities`  | string[] | ❌  | `[]`    | soft validation |
-| `conditionImmunities`    | string[] | ❌  | `[]`    | soft validation |
-| `languages`              | string[] | ❌  | `[]`    | — |
-| `languagesCustom`        | string   | ❌  | `""`    | — |
+| Campo                   | Tipo     | Req | Default | Note                         |
+| ----------------------- | -------- | --- | ------- | ---------------------------- |
+| `damageImmunities`      | string[] | ❌  | `[]`    | soft validation (vedi sotto) |
+| `damageResistances`     | string[] | ❌  | `[]`    | soft validation              |
+| `damageVulnerabilities` | string[] | ❌  | `[]`    | soft validation              |
+| `conditionImmunities`   | string[] | ❌  | `[]`    | soft validation              |
+| `languages`             | string[] | ❌  | `[]`    | —                            |
+| `languagesCustom`       | string   | ❌  | `""`    | —                            |
 
 **Soft validation:** valori fuori dai set canonici non bloccano la creazione,
 ma vengono raccolti in `warnings: string[]` nella risposta.
@@ -128,12 +130,12 @@ a `warnings[]`. La creazione procede comunque.
 
 ### Biografia e source
 
-| Campo         | Tipo  | Req | Default  | Validazione |
-|---------------|-------|-----|----------|-------------|
-| `biography`   | string | ❌ | `""`    | — |
-| `sourceBook`  | string | ❌ | `""`    | — |
-| `sourcePage`  | string | ❌ | `""`    | — |
-| `sourceRules` | enum   | ❌ | `"2014"` | "2014" / "2024" |
+| Campo         | Tipo   | Req | Default  | Validazione     |
+| ------------- | ------ | --- | -------- | --------------- |
+| `biography`   | string | ❌  | `""`     | —               |
+| `sourceBook`  | string | ❌  | `""`     | —               |
+| `sourcePage`  | string | ❌  | `""`     | —               |
+| `sourceRules` | enum   | ❌  | `"2014"` | "2014" / "2024" |
 
 ---
 
@@ -273,48 +275,56 @@ Banshee (CR 4).
 
 ## 3. Decisioni di design confermate
 
-| # | Decisione |
-|---|-----------|
-| 1 | `acValue` obbligatorio via `superRefine` solo quando `acMode === "flat"` |
-| 2 | `flat` omesso dall'oggetto ac quando `acMode === "default"` |
-| 3 | Soft validation per damage/condition values — warning non bloccante |
-| 4 | `hpFormula` non validato sintatticamente — stringa non vuota |
-| 5 | `attributes.prof` non settato — auto-derivato dal CR da Foundry |
-| 6 | Saving throws: `abilities[x].proficient: 1` per le abilities in `savingThrows[]` |
-| 7 | Skills: solo le skill fornite incluse in `system.skills`, le altre al default |
-| 8 | `bypasses: []` incluso in di/dr/dv (come nello schema reale), ma non esposto in input (V1) |
-| 9 | CR accetta string fraction ("1/4", "1/2") o number — normalizzato a float internamente |
-| 10 | Folder: `getOrCreateFolder('Foundry MCP Creatures', 'Actor')` — stesso degli altri tool |
-| 11 | `sourceRules` default `"2014"` |
-| 12 | `detectGameSystem()` guard — errore se sistema non è dnd5e |
+| #   | Decisione                                                                                  |
+| --- | ------------------------------------------------------------------------------------------ |
+| 1   | `acValue` obbligatorio via `superRefine` solo quando `acMode === "flat"`                   |
+| 2   | `flat` omesso dall'oggetto ac quando `acMode === "default"`                                |
+| 3   | Soft validation per damage/condition values — warning non bloccante                        |
+| 4   | `hpFormula` non validato sintatticamente — stringa non vuota                               |
+| 5   | `attributes.prof` non settato — auto-derivato dal CR da Foundry                            |
+| 6   | Saving throws: `abilities[x].proficient: 1` per le abilities in `savingThrows[]`           |
+| 7   | Skills: solo le skill fornite incluse in `system.skills`, le altre al default              |
+| 8   | `bypasses: []` incluso in di/dr/dv (come nello schema reale), ma non esposto in input (V1) |
+| 9   | CR accetta string fraction ("1/4", "1/2") o number — normalizzato a float internamente     |
+| 10  | Folder: `getOrCreateFolder('Foundry MCP Creatures', 'Actor')` — stesso degli altri tool    |
+| 11  | `sourceRules` default `"2014"`                                                             |
+| 12  | `detectGameSystem()` guard — errore se sistema non è dnd5e                                 |
 
 ---
 
 ## 4. File da creare / modificare (4 layer)
 
 ### Layer 1 — CREATE
+
 **`packages/mcp-server/src/tools/dnd5e/npc.ts`**  
 Nuova classe `DnD5eNpcTools`. Metodi:
+
 - `getToolDefinitions()` → definizione tool con JSON Schema
 - `handleCreateNpc(args)` → Zod parse → soft validation warnings → query dispatch → format response
 
 ### Layer 2 — MODIFY
+
 **`packages/mcp-server/src/backend.ts`**  
 4 touch point:
+
 1. `import { DnD5eNpcTools } from './tools/dnd5e/npc.js';`
 2. `const dnd5eNpcTools = new DnD5eNpcTools({ foundryClient, logger });` (dopo `dnd5eFeatureTools`)
 3. `...dnd5eNpcTools.getToolDefinitions(),` in `allTools` (dopo la riga `dnd5eFeatureTools`)
 4. `case 'dnd5e-create-npc':` nel blocco switch D&D 5e (dopo il case `dnd5e-add-feature-with-save`)
 
 ### Layer 3 — MODIFY
+
 **`packages/foundry-module/src/queries.ts`**  
 2 touch point:
+
 1. In `registerHandlers()`: `CONFIG.queries[\`${modulePrefix}.createNpcActor\`] = this.handleCreateNpcActor.bind(this);`
 2. Nuovo metodo privato `handleCreateNpcActor(data)`: GM check → validateFoundryState → validazione base (name, cr) → `this.dataAccess.createNpcActor(data)`
 
 ### Layer 4 — MODIFY
+
 **`packages/foundry-module/src/data-access.ts`**  
 Nuovo metodo pubblico `createNpcActor(data)`:
+
 - `this.validateFoundryState()` (fuori dal try)
 - System guard: `(game.system as any).id !== 'dnd5e'`
 - `normalizeCR`, `buildSkillsBlock`, `SIZE_MAP` come funzioni/const locali nel file

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -7712,7 +7712,7 @@ export class FoundryDataAccess {
       if ((game.system as any).id !== 'dnd5e') {
         throw new Error(
           `addSaveFeatureToActor requires D&D 5e. ` +
-          `Current system: "${(game.system as any).id}".`,
+            `Current system: "${(game.system as any).id}".`
         );
       }
 
@@ -7721,7 +7721,7 @@ export class FoundryDataAccess {
       if (existing) {
         throw new Error(
           `Feature "${data.featureName}" already exists on actor "${actor.name}" ` +
-          `(id: ${existing.id}). Use a different name or remove the existing feature first.`,
+            `(id: ${existing.id}). Use a different name or remove the existing feature first.`
         );
       }
 
@@ -7790,7 +7790,7 @@ export class FoundryDataAccess {
               },
               damage: {
                 onSave: data.halfOnSave ? 'half' : 'none',
-                parts: data.damageParts.map((p) => ({
+                parts: data.damageParts.map(p => ({
                   custom: { enabled: false, formula: '' },
                   number: p.number,
                   denomination: p.denomination,
@@ -7813,24 +7813,27 @@ export class FoundryDataAccess {
       };
 
       // 7. Create embedded item
-      const [created] = await actor.createEmbeddedDocuments('Item', [itemData]) as any[];
+      const [created] = (await actor.createEmbeddedDocuments('Item', [itemData])) as any[];
 
-      this.auditLog('addSaveFeatureToActor', { actorId: actor.id, featureName: data.featureName }, 'success');
+      this.auditLog(
+        'addSaveFeatureToActor',
+        { actorId: actor.id, featureName: data.featureName },
+        'success'
+      );
 
       // 8. Return structured result
       return {
         success: true,
-        item:  { id: created.id,    name: created.name },
-        actor: { id: actor.id,      name: actor.name },
+        item: { id: created.id, name: created.name },
+        actor: { id: actor.id, name: actor.name },
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add save feature to actor`, error);
       this.auditLog(
         'addSaveFeatureToActor',
         { actorIdentifier: data.actorIdentifier, featureName: data.featureName },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -7880,29 +7883,26 @@ export class FoundryDataAccess {
       // 1. System guard
       if ((game.system as any).id !== 'dnd5e') {
         throw new Error(
-          `createNpcActor requires D&D 5e. ` +
-          `Current system: "${(game.system as any).id}".`,
+          `createNpcActor requires D&D 5e. ` + `Current system: "${(game.system as any).id}".`
         );
       }
 
       // 2. Duplicate check by name — only against other NPCs, so a player
       //    character sharing the name does not block NPC creation.
-      const existingActor = game.actors?.find(
-        (a: any) => a.name === data.name && a.type === 'npc',
-      );
+      const existingActor = game.actors?.find((a: any) => a.name === data.name && a.type === 'npc');
       if (existingActor) {
         throw new Error(
           `NPC "${data.name}" already exists (id: ${existingActor.id}). ` +
-          `Use a different name or remove the existing NPC first.`,
+            `Use a different name or remove the existing NPC first.`
         );
       }
 
       // 3. Soft validation — collect warnings, do NOT block creation
       const warnings: string[] = [];
       const allDamageValues: Array<{ field: string; value: string }> = [
-        ...data.damageImmunities.map((v) => ({ field: 'damageImmunities', value: v })),
-        ...data.damageResistances.map((v) => ({ field: 'damageResistances', value: v })),
-        ...data.damageVulnerabilities.map((v) => ({ field: 'damageVulnerabilities', value: v })),
+        ...data.damageImmunities.map(v => ({ field: 'damageImmunities', value: v })),
+        ...data.damageResistances.map(v => ({ field: 'damageResistances', value: v })),
+        ...data.damageVulnerabilities.map(v => ({ field: 'damageVulnerabilities', value: v })),
       ];
       for (const { field, value } of allDamageValues) {
         if (!NPC_DAMAGE_CANONICAL.has(value)) {
@@ -7937,9 +7937,8 @@ export class FoundryDataAccess {
       };
 
       // 7. AC block — omit flat when mode is "default"
-      const acBlock = data.acMode === 'flat'
-        ? { calc: 'flat', flat: data.acValue }
-        : { calc: 'default' };
+      const acBlock =
+        data.acMode === 'flat' ? { calc: 'flat', flat: data.acValue } : { calc: 'default' };
 
       // 8. Build full actor data
       const actorData: any = {
@@ -7950,60 +7949,60 @@ export class FoundryDataAccess {
           attributes: {
             ac: acBlock,
             hp: {
-              value:   data.hpAverage,
-              max:     data.hpAverage,
-              temp:    0,
+              value: data.hpAverage,
+              max: data.hpAverage,
+              temp: 0,
               tempmax: 0,
               formula: data.hpFormula,
             },
             movement: {
-              walk:    data.walkSpeed,
-              fly:     data.flySpeed,
-              swim:    data.swimSpeed,
-              climb:   data.climbSpeed,
-              burrow:  data.burrowSpeed,
-              units:   'ft',
-              hover:   data.hover,
+              walk: data.walkSpeed,
+              fly: data.flySpeed,
+              swim: data.swimSpeed,
+              climb: data.climbSpeed,
+              burrow: data.burrowSpeed,
+              units: 'ft',
+              hover: data.hover,
               special: '',
             },
             senses: {
-              darkvision:  data.darkvision,
-              blindsight:  data.blindsight,
+              darkvision: data.darkvision,
+              blindsight: data.blindsight,
               tremorsense: data.tremorsense,
-              truesight:   data.truesight,
-              units:       'ft',
-              special:     data.specialSenses,
+              truesight: data.truesight,
+              units: 'ft',
+              special: data.specialSenses,
             },
           },
           details: {
-            cr:        normalizedCR,
+            cr: normalizedCR,
             type: {
-              value:   data.creatureType,
+              value: data.creatureType,
               subtype: data.creatureSubtype,
             },
             alignment: data.alignment,
             biography: {
-              value:  data.biography,
+              value: data.biography,
               public: '',
             },
             source: {
               revision: 1,
-              rules:    data.sourceRules,
-              book:     data.sourceBook,
-              page:     data.sourcePage,
-              custom:   '',
-              license:  '',
+              rules: data.sourceRules,
+              book: data.sourceBook,
+              page: data.sourcePage,
+              custom: '',
+              license: '',
             },
           },
           traits: {
             size: NPC_SIZE_MAP[data.size] ?? 'med',
-            di:   { value: data.damageImmunities,      custom: '', bypasses: [] },
-            dr:   { value: data.damageResistances,     custom: '', bypasses: [] },
-            dv:   { value: data.damageVulnerabilities, custom: '', bypasses: [] },
-            ci:   { value: data.conditionImmunities,   custom: '' },
+            di: { value: data.damageImmunities, custom: '', bypasses: [] },
+            dr: { value: data.damageResistances, custom: '', bypasses: [] },
+            dv: { value: data.damageVulnerabilities, custom: '', bypasses: [] },
+            ci: { value: data.conditionImmunities, custom: '' },
             languages: {
-              value:         data.languages,
-              custom:        data.languagesCustom,
+              value: data.languages,
+              custom: data.languagesCustom,
               communication: {},
             },
           },
@@ -8028,21 +8027,20 @@ export class FoundryDataAccess {
       return {
         success: true,
         actor: {
-          id:     actor.id,
-          name:   actor.name,
-          cr:     npcFormatCR(normalizedCR),
+          id: actor.id,
+          name: actor.name,
+          cr: npcFormatCR(normalizedCR),
           folder: folderId ?? null,
         },
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to create NPC actor`, error);
       this.auditLog(
         'createNpcActor',
         { name: data.name },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8068,26 +8066,30 @@ export class FoundryDataAccess {
 
       // 2. Duplicate check
       const existing = actor.items.find(
-        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase(),
+        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase()
       );
       if (existing) {
         throw new Error(
           `An item named "${data.featureName}" already exists on actor "${actor.name}". ` +
-          `Remove or rename it first.`,
+            `Remove or rename it first.`
         );
       }
 
       // 3. Soft validation — collect warnings, never block
       const warnings: string[] = [];
 
-      for (const part of (data.damageParts as Array<{ number: number; denomination: number; type: string }>)) {
+      for (const part of data.damageParts as Array<{
+        number: number;
+        denomination: number;
+        type: string;
+      }>) {
         if (!ATTACK_DAMAGE_CANONICAL.has(part.type)) {
           const msg = `Unknown damage type "${part.type}" — verify it matches dnd5e system values`;
           warnings.push(msg);
           console.warn(`[${MODULE_ID}] ${msg}`);
         }
       }
-      for (const prop of (data.properties as string[])) {
+      for (const prop of data.properties as string[]) {
         if (!ATTACK_PROPERTY_CANONICAL.has(prop)) {
           const msg = `Unknown weapon property "${prop}" — verify it matches dnd5e system values`;
           warnings.push(msg);
@@ -8099,27 +8101,30 @@ export class FoundryDataAccess {
       const activityId: string = (foundry.utils as any).randomID(16);
 
       // 5. Damage parts for the activity (all except the first — which is system.damage.base)
-      const activityDamageParts = (data.damageParts as Array<{ number: number; denomination: number; type: string }>)
+      const activityDamageParts = (
+        data.damageParts as Array<{ number: number; denomination: number; type: string }>
+      )
         .slice(1)
-        .map((p) => ({
-          types:        [p.type],
-          number:       p.number,
+        .map(p => ({
+          types: [p.type],
+          number: p.number,
           denomination: p.denomination,
-          bonus:        '',
-          scaling:      { mode: '', number: 1 },
-          custom:       { enabled: false },
+          bonus: '',
+          scaling: { mode: '', number: 1 },
+          custom: { enabled: false },
         }));
 
       // 6. Range object (system-level — holds the real range/reach)
-      const rangeObj = data.attackType === 'melee'
-        ? { value: data.reachFt ?? 5, long: null,                         units: 'ft' }
-        : { value: data.rangeFt,       long: data.longRangeFt ?? null,     units: 'ft' };
+      const rangeObj =
+        data.attackType === 'melee'
+          ? { value: data.reachFt ?? 5, long: null, units: 'ft' }
+          : { value: data.rangeFt, long: data.longRangeFt ?? null, units: 'ft' };
 
       // 7. Conditional 2024-only fields
       const sourceRules: string = data.sourceRules ?? '2014';
-      const masteryField    = sourceRules === '2024' ? { mastery: '' }                   : {};
-      const abilityField    = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
-      const classification  = sourceRules === '2014' ? 'weapon'                           : '';
+      const masteryField = sourceRules === '2024' ? { mastery: '' } : {};
+      const abilityField = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
+      const classification = sourceRules === '2014' ? 'weapon' : '';
 
       // 8. Build item data
       const itemData: Record<string, any> = {
@@ -8127,101 +8132,117 @@ export class FoundryDataAccess {
         type: 'weapon',
         system: {
           description: {
-            value:  data.description ?? '',
-            chat:   '',
+            value: data.description ?? '',
+            chat: '',
             unidentified: '',
           },
           source: {
             custom: '',
-            book:   data.sourceBook ?? '',
-            page:   data.sourcePage ?? '',
+            book: data.sourceBook ?? '',
+            page: data.sourcePage ?? '',
             license: '',
-            rules:  sourceRules,
+            rules: sourceRules,
           },
-          quantity:  1,
-          weight:    { value: 0, units: 'lb' },
-          price:     { value: 0, denomination: 'gp' },
+          quantity: 1,
+          weight: { value: 0, units: 'lb' },
+          price: { value: 0, denomination: 'gp' },
           attunement: '',
-          equipped:   data.equipped !== false,
-          rarity:     '',
+          equipped: data.equipped !== false,
+          rarity: '',
           identified: true,
-          activation:  {
-            type:      data.activationType ?? 'action',
-            value:     1,
+          activation: {
+            type: data.activationType ?? 'action',
+            value: 1,
             condition: '',
-            override:  false,
+            override: false,
           },
-          duration:   { value: '',  units: '' },
-          cover:      null,
-          target:     {
-            template:   { count: '', contiguous: false, type: '', size: '', width: '', height: '', units: '' },
-            affects:    { count: '', type: '', choice: false, special: '' },
-            prompt:     true,
-            override:   false,
+          duration: { value: '', units: '' },
+          cover: null,
+          target: {
+            template: {
+              count: '',
+              contiguous: false,
+              type: '',
+              size: '',
+              width: '',
+              height: '',
+              units: '',
+            },
+            affects: { count: '', type: '', choice: false, special: '' },
+            prompt: true,
+            override: false,
           },
-          range:       rangeObj,
-          uses:        { value: null, max: '', recovery: [], prompt: true },
-          damage:      {
+          range: rangeObj,
+          uses: { value: null, max: '', recovery: [], prompt: true },
+          damage: {
             base: {
-              types:        [(data.damageParts as any[])[0].type],
-              number:       (data.damageParts as any[])[0].number,
+              types: [(data.damageParts as any[])[0].type],
+              number: (data.damageParts as any[])[0].number,
               denomination: (data.damageParts as any[])[0].denomination,
-              bonus:        '',
-              scaling:      { mode: '', number: 1 },
-              custom:       { enabled: false },
+              bonus: '',
+              scaling: { mode: '', number: 1 },
+              custom: { enabled: false },
             },
           },
-          type:        { value: data.weaponClass ?? 'natural', baseItem: '' },
-          properties:  (data.properties as string[]),
-          proficient:  1,
+          type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+          properties: data.properties as string[],
+          proficient: 1,
           magicalBonus: null,
           ...masteryField,
           activities: {
             [activityId]: {
-              _id:          activityId,
-              type:         'attack',
-              name:         '',
-              img:          '',
-              sort:         0,
-              description:  {},
-              activation:   {
-                type:      data.activationType ?? 'action',
-                value:     1,
+              _id: activityId,
+              type: 'attack',
+              name: '',
+              img: '',
+              sort: 0,
+              description: {},
+              activation: {
+                type: data.activationType ?? 'action',
+                value: 1,
                 condition: '',
-                override:  false,
+                override: false,
               },
-              duration:     { units: '', value: '', override: false },
-              target:       {
-                template:  { count: '', contiguous: false, type: '', size: '', width: '', height: '', units: '' },
-                affects:   { count: '', type: '', choice: false, special: '' },
-                prompt:    true,
-                override:  false,
+              duration: { units: '', value: '', override: false },
+              target: {
+                template: {
+                  count: '',
+                  contiguous: false,
+                  type: '',
+                  size: '',
+                  width: '',
+                  height: '',
+                  units: '',
+                },
+                affects: { count: '', type: '', choice: false, special: '' },
+                prompt: true,
+                override: false,
               },
-              range:        { units: 'self', override: false },
-              uses:         { spent: 0, max: '', recovery: [] },
-              consumption:  {
-                targets:   [],
-                scaling:   { allowed: false, max: '' },
+              range: { units: 'self', override: false },
+              uses: { spent: 0, max: '', recovery: [] },
+              consumption: {
+                targets: [],
+                scaling: { allowed: false, max: '' },
                 spellSlot: true,
               },
               attack: {
-                ability:   '',
-                bonus:     data.attackBonus > 0 ? String(data.attackBonus) : '',
-                critical:  { threshold: null },
-                flat:      false,
+                ability: '',
+                bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
+                critical: { threshold: null },
+                flat: false,
                 type: {
-                  value:         data.attackType ?? 'melee',
+                  value: data.attackType ?? 'melee',
                   classification: classification,
                 },
                 ...abilityField,
               },
               damage: {
-                critical:    { bonus: '' },
+                critical: { bonus: '' },
                 includeBase: true,
-                parts:       activityDamageParts,
+                parts: activityDamageParts,
               },
-              effects:  [],
-              save:     { ability: '', dc: { formula: '', calculation: '' } },
+              effects: [],
+              save: { ability: '', dc: { formula: '', calculation: '' } },
             },
           },
         },
@@ -8230,25 +8251,30 @@ export class FoundryDataAccess {
       // 9. Create the item on the actor
       const created = (await actor.createEmbeddedDocuments('Item', [itemData]))[0];
       if (!created) {
-        throw new Error(`Failed to create attack item "${data.featureName}" on actor "${actor.name}"`);
+        throw new Error(
+          `Failed to create attack item "${data.featureName}" on actor "${actor.name}"`
+        );
       }
 
-      this.auditLog('addAttackToActor', { actorId: actor.id, featureName: data.featureName }, 'success');
+      this.auditLog(
+        'addAttackToActor',
+        { actorId: actor.id, featureName: data.featureName },
+        'success'
+      );
 
       return {
-        success:  true,
-        actor:    { id: actor.id,    name: actor.name },
-        item:     { id: created.id,  name: created.name, type: 'weapon' },
+        success: true,
+        actor: { id: actor.id, name: actor.name },
+        item: { id: created.id, name: created.name, type: 'weapon' },
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add attack to actor`, error);
       this.auditLog(
         'addAttackToActor',
         { actorIdentifier: data.actorIdentifier, featureName: data.featureName },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8275,19 +8301,23 @@ export class FoundryDataAccess {
 
       // 2. Duplicate check (case-insensitive name match)
       const existing = actor.items.find(
-        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase(),
+        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase()
       );
       if (existing) {
         throw new Error(
           `An item named "${data.featureName}" already exists on actor "${actor.name}". ` +
-          `Remove or rename it first.`,
+            `Remove or rename it first.`
         );
       }
 
       // 3. Soft validation — collect warnings, never block
       const warnings: string[] = [];
 
-      for (const part of (data.damageParts as Array<{ number: number; denomination: number; type: string }>)) {
+      for (const part of data.damageParts as Array<{
+        number: number;
+        denomination: number;
+        type: string;
+      }>) {
         if (!AURA_DAMAGE_CANONICAL.has(part.type)) {
           const msg = `Unknown damage type "${part.type}" — verify it matches dnd5e system values`;
           warnings.push(msg);
@@ -8309,80 +8339,82 @@ export class FoundryDataAccess {
       const itemData = {
         name: data.featureName,
         type: 'feat',
-        img:  'systems/dnd5e/icons/svg/items/feature.svg',
+        img: 'systems/dnd5e/icons/svg/items/feature.svg',
         system: {
           description: { value: data.description ?? '', chat: '' },
           identifier,
           source: {
             revision: 1,
-            rules:    data.sourceRules ?? '2014',
-            custom:   '',
-            book:     data.sourceBook  ?? '',
-            page:     data.sourcePage  ?? '',
-            license:  '',
+            rules: data.sourceRules ?? '2014',
+            custom: '',
+            book: data.sourceBook ?? '',
+            page: data.sourcePage ?? '',
+            license: '',
           },
-          type:          { value: 'monster', subtype: '' },
-          uses:          { spent: 0, recovery: [], max: '' },
-          advancement:   [],
-          crewed:        false,
-          enchant:       {},
+          type: { value: 'monster', subtype: '' },
+          uses: { spent: 0, recovery: [], max: '' },
+          advancement: [],
+          crewed: false,
+          enchant: {},
           prerequisites: { items: [], repeatable: false, level: null },
-          properties:    [],
-          requirements:  '',
+          properties: [],
+          requirements: '',
           activities: {
             [activityId]: {
-              _id:  activityId,
-              type: 'damage',           // activity type: damage — no attack roll, no save
+              _id: activityId,
+              type: 'damage', // activity type: damage — no attack roll, no save
               name: '',
               sort: 0,
               activation: {
-                type:     data.activationType ?? 'action',
-                value:    1,
+                type: data.activationType ?? 'action',
+                value: 1,
                 override: false,
                 // NO condition — not present in real dnd5e 5.1.8 schema
               },
               consumption: {
-                scaling:   { allowed: false },
-                spellSlot: true,        // confirmed: true in real Banshee Wail schema
-                targets:   [],          // no uses management in V1
+                scaling: { allowed: false },
+                spellSlot: true, // confirmed: true in real Banshee Wail schema
+                targets: [], // no uses management in V1
               },
-              description: {},          // empty object — confirmed from real schema
+              description: {}, // empty object — confirmed from real schema
               duration: {
-                units:         'inst',
+                units: 'inst',
                 concentration: false,
-                override:      false,
+                override: false,
               },
               effects: [],
-              range:   { units: 'self', override: false }, // NO value, NO special
-              uses:    { spent: 0, recovery: [] },          // NO max field
+              range: { units: 'self', override: false }, // NO value, NO special
+              uses: { spent: 0, recovery: [] }, // NO max field
               target: {
                 template: {
                   contiguous: false,
-                  units:      data.areaUnits ?? 'ft',
-                  count:      '',
-                  type:       mappedAreaType,
-                  size:       String(data.areaSize),
-                  width:      '',
-                  height:     '',
+                  units: data.areaUnits ?? 'ft',
+                  count: '',
+                  type: mappedAreaType,
+                  size: String(data.areaSize),
+                  width: '',
+                  height: '',
                 },
                 affects: {
-                  count:   '',
-                  type:    data.affectsType ?? 'creature',
-                  choice:  false,
+                  count: '',
+                  type: data.affectsType ?? 'creature',
+                  choice: false,
                   special: '',
                 },
                 override: false,
-                prompt:   true,
+                prompt: true,
               },
               damage: {
-                critical: { allow: false },  // only this key — no bonus, no dice
-                parts: (data.damageParts as Array<{ number: number; denomination: number; type: string }>).map((p) => ({
-                  types:        [p.type],
-                  number:       p.number,
+                critical: { allow: false }, // only this key — no bonus, no dice
+                parts: (
+                  data.damageParts as Array<{ number: number; denomination: number; type: string }>
+                ).map(p => ({
+                  types: [p.type],
+                  number: p.number,
                   denomination: p.denomination,
-                  bonus:        '',
-                  scaling:      { mode: '', number: 1 }, // mode: '' required — from real schema
-                  custom:       { enabled: false },       // NO formula field
+                  bonus: '',
+                  scaling: { mode: '', number: 1 }, // mode: '' required — from real schema
+                  custom: { enabled: false }, // NO formula field
                 })),
                 // NO onSave — damage activity has no save concept
               },
@@ -8395,29 +8427,32 @@ export class FoundryDataAccess {
       };
 
       // 7. Create embedded item
-      const [created] = await actor.createEmbeddedDocuments('Item', [itemData]) as any[];
+      const [created] = (await actor.createEmbeddedDocuments('Item', [itemData])) as any[];
       if (!created) {
         throw new Error(
-          `Failed to create aura item "${data.featureName}" on actor "${actor.name}"`,
+          `Failed to create aura item "${data.featureName}" on actor "${actor.name}"`
         );
       }
 
-      this.auditLog('addAuraToActor', { actorId: actor.id, featureName: data.featureName }, 'success');
+      this.auditLog(
+        'addAuraToActor',
+        { actorId: actor.id, featureName: data.featureName },
+        'success'
+      );
 
       return {
-        success:  true,
-        actor:    { id: actor.id,    name: actor.name },
-        item:     { id: created.id,  name: created.name, type: 'feat' },
+        success: true,
+        actor: { id: actor.id, name: actor.name },
+        item: { id: created.id, name: created.name, type: 'feat' },
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add aura to actor`, error);
       this.auditLog(
         'addAuraToActor',
         { actorIdentifier: data.actorIdentifier, featureName: data.featureName },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8444,12 +8479,12 @@ export class FoundryDataAccess {
 
       // 2. Duplicate check (case-insensitive)
       const existing = actor.items.find(
-        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase(),
+        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase()
       );
       if (existing) {
         throw new Error(
           `An item named "${data.featureName}" already exists on actor "${actor.name}". ` +
-          `Remove or rename it first.`,
+            `Remove or rename it first.`
         );
       }
 
@@ -8460,54 +8495,57 @@ export class FoundryDataAccess {
       const itemData = {
         name: data.featureName,
         type: 'feat',
-        img:  'systems/dnd5e/icons/svg/items/feature.svg',
+        img: 'systems/dnd5e/icons/svg/items/feature.svg',
         system: {
           description: { value: data.description ?? '', chat: '' },
           identifier,
           source: {
             revision: 1,
-            rules:    data.sourceRules ?? '2014',
-            custom:   '',
-            book:     data.sourceBook  ?? '',
-            page:     data.sourcePage  ?? '',
-            license:  '',
+            rules: data.sourceRules ?? '2014',
+            custom: '',
+            book: data.sourceBook ?? '',
+            page: data.sourcePage ?? '',
+            license: '',
           },
-          type:          { value: 'monster', subtype: '' },
-          uses:          { spent: 0, recovery: [], max: '' },
-          advancement:   [],
-          crewed:        false,
-          enchant:       {},
+          type: { value: 'monster', subtype: '' },
+          uses: { spent: 0, recovery: [], max: '' },
+          advancement: [],
+          crewed: false,
+          enchant: {},
           prerequisites: { items: [], repeatable: false, level: null },
-          properties:    [],
-          requirements:  '',
-          activities:    {},  // empty — passive feature has no mechanical activity
+          properties: [],
+          requirements: '',
+          activities: {}, // empty — passive feature has no mechanical activity
         },
         effects: [],
       };
 
       // 5. Create embedded item
-      const [created] = await actor.createEmbeddedDocuments('Item', [itemData]) as any[];
+      const [created] = (await actor.createEmbeddedDocuments('Item', [itemData])) as any[];
       if (!created) {
         throw new Error(
-          `Failed to create passive feature "${data.featureName}" on actor "${actor.name}"`,
+          `Failed to create passive feature "${data.featureName}" on actor "${actor.name}"`
         );
       }
 
-      this.auditLog('addPassiveFeatureToActor', { actorId: actor.id, featureName: data.featureName }, 'success');
+      this.auditLog(
+        'addPassiveFeatureToActor',
+        { actorId: actor.id, featureName: data.featureName },
+        'success'
+      );
 
       return {
         success: true,
-        actor:   { id: actor.id,    name: actor.name },
-        item:    { id: created.id,  name: created.name, type: 'feat' },
+        actor: { id: actor.id, name: actor.name },
+        item: { id: created.id, name: created.name, type: 'feat' },
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add passive feature to actor`, error);
       this.auditLog(
         'addPassiveFeatureToActor',
         { actorIdentifier: data.actorIdentifier, featureName: data.featureName },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8535,19 +8573,19 @@ export class FoundryDataAccess {
 
       // 2. Duplicate check
       const existing = actor.items.find(
-        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase(),
+        (i: any) => i.name.toLowerCase() === data.featureName.toLowerCase()
       );
       if (existing) {
         throw new Error(
           `An item named "${data.featureName}" already exists on actor "${actor.name}". ` +
-          `Remove or rename it first.`,
+            `Remove or rename it first.`
         );
       }
 
       // 3. Soft validation — both damage groups unified
       const warnings: string[] = [];
       const allParts = [
-        ...(data.damageParts     as Array<{ type: string }>),
+        ...(data.damageParts as Array<{ type: string }>),
         ...(data.saveDamageParts as Array<{ type: string }>),
       ];
       for (const part of allParts) {
@@ -8560,41 +8598,45 @@ export class FoundryDataAccess {
 
       // 4. Generate two distinct activity IDs
       const attackActivityId: string = (foundry.utils as any).randomID(16);
-      const saveActivityId:   string = (foundry.utils as any).randomID(16);
+      const saveActivityId: string = (foundry.utils as any).randomID(16);
 
       // 5. Attack activity damage parts: damageParts[1+] (base is in system.damage.base)
-      const activityDamageParts = (data.damageParts as Array<{ number: number; denomination: number; type: string }>)
+      const activityDamageParts = (
+        data.damageParts as Array<{ number: number; denomination: number; type: string }>
+      )
         .slice(1)
-        .map((p) => ({
-          types:        [p.type],
-          number:       p.number,
+        .map(p => ({
+          types: [p.type],
+          number: p.number,
           denomination: p.denomination,
-          bonus:        '',
-          scaling:      { mode: '', number: 1 },
-          custom:       { enabled: false },
+          bonus: '',
+          scaling: { mode: '', number: 1 },
+          custom: { enabled: false },
         }));
 
       // 6. Save activity damage parts: ALL saveDamageParts (no base — independent)
-      const saveActivityDamageParts = (data.saveDamageParts as Array<{ number: number; denomination: number; type: string }>)
-        .map((p) => ({
-          types:        [p.type],
-          number:       p.number,
-          denomination: p.denomination,
-          bonus:        '',
-          scaling:      { mode: '', number: 1 },
-          custom:       { enabled: false },
-        }));
+      const saveActivityDamageParts = (
+        data.saveDamageParts as Array<{ number: number; denomination: number; type: string }>
+      ).map(p => ({
+        types: [p.type],
+        number: p.number,
+        denomination: p.denomination,
+        bonus: '',
+        scaling: { mode: '', number: 1 },
+        custom: { enabled: false },
+      }));
 
       // 7. System-level range (real reach/range — activity range is always 'self')
-      const rangeObj = data.attackType === 'melee'
-        ? { value: data.reachFt ?? 5, long: null,                     units: 'ft' }
-        : { value: data.rangeFt,       long: data.longRangeFt ?? null, units: 'ft' };
+      const rangeObj =
+        data.attackType === 'melee'
+          ? { value: data.reachFt ?? 5, long: null, units: 'ft' }
+          : { value: data.rangeFt, long: data.longRangeFt ?? null, units: 'ft' };
 
       // 8. Conditional 2024-only fields (same rules as Tipo A)
       const sourceRules: string = data.sourceRules ?? '2014';
-      const masteryField   = sourceRules === '2024' ? { mastery: '' }                   : {};
-      const abilityField   = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
-      const classification = sourceRules === '2014' ? 'weapon'                           : '';
+      const masteryField = sourceRules === '2024' ? { mastery: '' } : {};
+      const abilityField = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
+      const classification = sourceRules === '2014' ? 'weapon' : '';
 
       // 9. Build item data
       const itemData: Record<string, any> = {
@@ -8602,136 +8644,155 @@ export class FoundryDataAccess {
         type: 'weapon',
         system: {
           description: {
-            value:        data.description ?? '',
-            chat:         '',
+            value: data.description ?? '',
+            chat: '',
             unidentified: '',
           },
           source: {
-            custom:  '',
-            book:    data.sourceBook ?? '',
-            page:    data.sourcePage ?? '',
+            custom: '',
+            book: data.sourceBook ?? '',
+            page: data.sourcePage ?? '',
             license: '',
-            rules:   sourceRules,
+            rules: sourceRules,
           },
-          quantity:   1,
-          weight:     { value: 0, units: 'lb' },
-          price:      { value: 0, denomination: 'gp' },
+          quantity: 1,
+          weight: { value: 0, units: 'lb' },
+          price: { value: 0, denomination: 'gp' },
           attunement: '',
-          equipped:   data.equipped !== false,
-          rarity:     '',
+          equipped: data.equipped !== false,
+          rarity: '',
           identified: true,
           activation: {
-            type:      data.activationType ?? 'action',
-            value:     1,
+            type: data.activationType ?? 'action',
+            value: 1,
             condition: '',
-            override:  false,
-          },
-          duration: { value: '', units: '' },
-          cover:    null,
-          target:   {
-            template: { count: '', contiguous: false, type: '', size: '', width: '', height: '', units: '' },
-            affects:  { count: '', type: '', choice: false, special: '' },
-            prompt:   true,
             override: false,
           },
-          range:    rangeObj,
-          uses:     { value: null, max: '', recovery: [], prompt: true },
-          damage:   {
+          duration: { value: '', units: '' },
+          cover: null,
+          target: {
+            template: {
+              count: '',
+              contiguous: false,
+              type: '',
+              size: '',
+              width: '',
+              height: '',
+              units: '',
+            },
+            affects: { count: '', type: '', choice: false, special: '' },
+            prompt: true,
+            override: false,
+          },
+          range: rangeObj,
+          uses: { value: null, max: '', recovery: [], prompt: true },
+          damage: {
             base: {
-              types:        [(data.damageParts as any[])[0].type],
-              number:       (data.damageParts as any[])[0].number,
+              types: [(data.damageParts as any[])[0].type],
+              number: (data.damageParts as any[])[0].number,
               denomination: (data.damageParts as any[])[0].denomination,
-              bonus:        '',
-              scaling:      { mode: '', number: 1 },
-              custom:       { enabled: false },
+              bonus: '',
+              scaling: { mode: '', number: 1 },
+              custom: { enabled: false },
             },
           },
-          type:         { value: data.weaponClass ?? 'natural', baseItem: '' },
-          properties:   (data.properties as string[]),
-          proficient:   1,
+          type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+          properties: data.properties as string[],
+          proficient: 1,
           magicalBonus: null,
           ...masteryField,
           activities: {
-
             // ── Activity 1: attack (sort 0) ───────────────────────────────
             [attackActivityId]: {
-              _id:         attackActivityId,
-              type:        'attack',
-              name:        '',
-              img:         '',
-              sort:        0,
+              _id: attackActivityId,
+              type: 'attack',
+              name: '',
+              img: '',
+              sort: 0,
               description: {},
-              activation:  {
-                type:      data.activationType ?? 'action',
-                value:     1,
+              activation: {
+                type: data.activationType ?? 'action',
+                value: 1,
                 condition: '',
-                override:  false,
-              },
-              duration:    { units: '', value: '', override: false },
-              target:      {
-                template: { count: '', contiguous: false, type: '', size: '', width: '', height: '', units: '' },
-                affects:  { count: '', type: '', choice: false, special: '' },
-                prompt:   true,
                 override: false,
               },
-              range:       { units: 'self', override: false },
-              uses:        { spent: 0, max: '', recovery: [] },
+              duration: { units: '', value: '', override: false },
+              target: {
+                template: {
+                  count: '',
+                  contiguous: false,
+                  type: '',
+                  size: '',
+                  width: '',
+                  height: '',
+                  units: '',
+                },
+                affects: { count: '', type: '', choice: false, special: '' },
+                prompt: true,
+                override: false,
+              },
+              range: { units: 'self', override: false },
+              uses: { spent: 0, max: '', recovery: [] },
               consumption: { targets: [], scaling: { allowed: false, max: '' }, spellSlot: true },
               attack: {
-                ability:  '',
-                bonus:    data.attackBonus > 0 ? String(data.attackBonus) : '',
+                ability: '',
+                bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
                 critical: { threshold: null },
-                flat:     false,
-                type:     { value: data.attackType ?? 'melee', classification },
+                flat: false,
+                type: { value: data.attackType ?? 'melee', classification },
                 ...abilityField,
               },
               damage: {
-                critical:    { bonus: '' },
+                critical: { bonus: '' },
                 includeBase: true,
-                parts:       activityDamageParts,
+                parts: activityDamageParts,
               },
               effects: [],
-              save:    { ability: '', dc: { formula: '', calculation: '' } },
+              save: { ability: '', dc: { formula: '', calculation: '' } },
             },
 
             // ── Activity 2: save (sort 1) ─────────────────────────────────
             [saveActivityId]: {
-              _id:         saveActivityId,
-              type:        'save',
-              name:        '',
-              sort:        1,
-              description: {},           // {} — not { chatFlavor: '' } (real schema confirmed)
-              activation:  {
-                type:     data.activationType ?? 'action',
-                value:    1,
+              _id: saveActivityId,
+              type: 'save',
+              name: '',
+              sort: 1,
+              description: {}, // {} — not { chatFlavor: '' } (real schema confirmed)
+              activation: {
+                type: data.activationType ?? 'action',
+                value: 1,
                 override: false,
                 // NO condition — per real schema
               },
-              duration:    { units: 'inst', concentration: false, override: false },
-              effects:     [],
-              range:       { units: 'self', override: false },
-              uses:        { spent: 0, recovery: [] },  // NO max
+              duration: { units: 'inst', concentration: false, override: false },
+              effects: [],
+              range: { units: 'self', override: false },
+              uses: { spent: 0, recovery: [] }, // NO max
               consumption: { scaling: { allowed: false }, spellSlot: true, targets: [] },
-              target:      {
+              target: {
                 template: {
-                  count: '', contiguous: false, type: '', size: '',
-                  width: '', height: '', units: '',
+                  count: '',
+                  contiguous: false,
+                  type: '',
+                  size: '',
+                  width: '',
+                  height: '',
+                  units: '',
                 },
-                affects:  { count: '1', type: 'creature', choice: false, special: '' },
+                affects: { count: '1', type: 'creature', choice: false, special: '' },
                 override: false,
-                prompt:   true,
+                prompt: true,
               },
               damage: {
                 onSave: data.saveOnSave ?? 'none',
-                parts:  saveActivityDamageParts,
+                parts: saveActivityDamageParts,
                 // NO includeBase — save damage is independent from weapon base damage
               },
               save: {
                 ability: [data.saveAbility],
-                dc:      { calculation: '', formula: String(data.saveDC) },
+                dc: { calculation: '', formula: String(data.saveDC) },
               },
             },
-
           },
         },
       };
@@ -8740,26 +8801,29 @@ export class FoundryDataAccess {
       const created = (await actor.createEmbeddedDocuments('Item', [itemData]))[0];
       if (!created) {
         throw new Error(
-          `Failed to create attack+save item "${data.featureName}" on actor "${actor.name}"`,
+          `Failed to create attack+save item "${data.featureName}" on actor "${actor.name}"`
         );
       }
 
-      this.auditLog('addAttackWithSaveToActor', { actorId: actor.id, featureName: data.featureName }, 'success');
+      this.auditLog(
+        'addAttackWithSaveToActor',
+        { actorId: actor.id, featureName: data.featureName },
+        'success'
+      );
 
       return {
-        success:  true,
-        actor:    { id: actor.id,    name: actor.name },
-        item:     { id: created.id,  name: created.name, type: 'weapon' },
+        success: true,
+        actor: { id: actor.id, name: actor.name },
+        item: { id: created.id, name: created.name, type: 'weapon' },
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add attack+save to actor`, error);
       this.auditLog(
         'addAttackWithSaveToActor',
         { actorIdentifier: data.actorIdentifier, featureName: data.featureName },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8783,10 +8847,10 @@ export class FoundryDataAccess {
         throw new Error(`Actor not found: "${data.actorIdentifier}"`);
       }
 
-      const cls        = data.spellcastingClass  as string;
-      const lvl        = data.spellcastingLevel  as number;
-      const ability    = data.effectiveAbility   as string;
-      const idx        = lvl - 1; // 0-based index into slot tables
+      const cls = data.spellcastingClass as string;
+      const lvl = data.spellcastingLevel as number;
+      const ability = data.effectiveAbility as string;
+      const idx = lvl - 1; // 0-based index into slot tables
       const warnings: string[] = [];
 
       // 2. Build flat updates object for a single actor.update() call
@@ -8799,14 +8863,13 @@ export class FoundryDataAccess {
         // ── Pact Magic ────────────────────────────────────────────────────────
         // All regular slots set to 0; pact slots from table
         for (let i = 1; i <= 9; i++) {
-          updates[`system.spells.spell${i}.max`]   = 0;
+          updates[`system.spells.spell${i}.max`] = 0;
           updates[`system.spells.spell${i}.value`] = 0;
         }
         const pact = WARLOCK_PACT_TABLE[idx];
-        updates['system.spells.pact.max']   = pact.max;
+        updates['system.spells.pact.max'] = pact.max;
         updates['system.spells.pact.value'] = pact.max;
         updates['system.spells.pact.level'] = pact.level;
-
       } else {
         // ── Regular spell slots ───────────────────────────────────────────────
         let slotRow: number[];
@@ -8817,7 +8880,7 @@ export class FoundryDataAccess {
           slotRow = HALF_CASTER_SLOTS[idx];
           if (lvl === 1) {
             warnings.push(
-              `${cls} level 1 has no spell slots — use level 2+ to unlock spellcasting`,
+              `${cls} level 1 has no spell slots — use level 2+ to unlock spellcasting`
             );
           }
         } else {
@@ -8827,7 +8890,7 @@ export class FoundryDataAccess {
 
         for (let i = 1; i <= 9; i++) {
           const n = slotRow[i - 1];
-          updates[`system.spells.spell${i}.max`]   = n;
+          updates[`system.spells.spell${i}.max`] = n;
           updates[`system.spells.spell${i}.value`] = n;
         }
       }
@@ -8841,11 +8904,12 @@ export class FoundryDataAccess {
         const pact = WARLOCK_PACT_TABLE[idx];
         slots['pact'] = { max: pact.max, level: pact.level };
       } else {
-        const slotRow = cls === 'artificer'
-          ? ARTIFICER_SLOTS[idx]
-          : (cls === 'paladin' || cls === 'ranger')
-            ? HALF_CASTER_SLOTS[idx]
-            : FULL_CASTER_SLOTS[idx];
+        const slotRow =
+          cls === 'artificer'
+            ? ARTIFICER_SLOTS[idx]
+            : cls === 'paladin' || cls === 'ranger'
+              ? HALF_CASTER_SLOTS[idx]
+              : FULL_CASTER_SLOTS[idx];
 
         for (let i = 1; i <= 9; i++) {
           (slots as Record<string, number>)[`spell${i}`] = slotRow[i - 1];
@@ -8855,18 +8919,17 @@ export class FoundryDataAccess {
       this.auditLog('setActorSpellcasting', { actorId: actor.id, cls, lvl, ability }, 'success');
 
       return {
-        actor:        { id: actor.id, name: actor.name },
+        actor: { id: actor.id, name: actor.name },
         spellcasting: { ability, slots },
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to set actor spellcasting`, error);
       this.auditLog(
         'setActorSpellcasting',
         { actorIdentifier: data.actorIdentifier, spellcastingClass: data.spellcastingClass },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -8890,13 +8953,13 @@ export class FoundryDataAccess {
         throw new Error(`Actor not found: "${data.actorIdentifier}"`);
       }
 
-      const spellNames:      string[] = data.spellNames;
+      const spellNames: string[] = data.spellNames;
       const compendiumPacks: string[] = data.compendiumPacks ?? ['dnd5e.spells'];
-      const warnings:        string[] = [];
+      const warnings: string[] = [];
 
       // ── Phase A: deduplicate input (case-insensitive) ─────────────────────
-      const seen            = new Set<string>();
-      const unique:  string[] = [];
+      const seen = new Set<string>();
+      const unique: string[] = [];
       const skipped: Array<{ name: string; reason: string }> = [];
 
       for (const name of spellNames) {
@@ -8911,9 +8974,9 @@ export class FoundryDataAccess {
 
       // ── Phase B: build pack index maps (once per pack) ────────────────────
       interface PackMap {
-        packId:    string;
+        packId: string;
         packLabel: string;
-        nameMap:   Map<string, string>; // lowercase name → _id
+        nameMap: Map<string, string>; // lowercase name → _id
       }
       const packMaps: PackMap[] = [];
 
@@ -8927,7 +8990,7 @@ export class FoundryDataAccess {
         // Q6: type guard — Item packs only
         if (pack.metadata.type !== 'Item') {
           warnings.push(
-            `Pack "${packId}" has type "${pack.metadata.type}", expected "Item" — skipped`,
+            `Pack "${packId}" has type "${pack.metadata.type}", expected "Item" — skipped`
           );
           continue;
         }
@@ -8949,21 +9012,21 @@ export class FoundryDataAccess {
       if (packMaps.length === 0) {
         throw new Error(
           'No valid compendium packs available — check the compendiumPacks parameter. ' +
-          'Valid pack IDs for D&D 5e: "dnd5e.spells" (2014) or "dnd5e.spells24" (2024).',
+            'Valid pack IDs for D&D 5e: "dnd5e.spells" (2014) or "dnd5e.spells24" (2024).'
         );
       }
 
       // ── Phase C: per-spell search + import ───────────────────────────────
-      const added:    Array<{ name: string; packId: string; packLabel: string; itemId: string }> = [];
+      const added: Array<{ name: string; packId: string; packLabel: string; itemId: string }> = [];
       const notFound: string[] = [];
-      const failed:   Array<{ name: string; error: string }> = [];
+      const failed: Array<{ name: string; error: string }> = [];
 
       for (const name of unique) {
         const normalizedName = name.toLowerCase();
 
         // 1. Duplicate check on actor (only items of type 'spell')
         const existing = (actor.items as any[]).find(
-          (i: any) => i.type === 'spell' && i.name?.toLowerCase() === normalizedName,
+          (i: any) => i.type === 'spell' && i.name?.toLowerCase() === normalizedName
         );
         if (existing) {
           skipped.push({ name, reason: 'already on actor' });
@@ -8986,13 +9049,15 @@ export class FoundryDataAccess {
         }
 
         // 3. Fetch full document from compendium
-        const pack     = game.packs.get(found.packId);
+        const pack = game.packs.get(found.packId);
         const document = await (pack as any).getDocument(found.entryId);
 
         if (!document) {
           // Entry was in index but document is missing (shouldn't happen, defensive)
           notFound.push(name);
-          warnings.push(`"${name}" found in index but document missing in pack "${found.packId}" — skipped`);
+          warnings.push(
+            `"${name}" found in index but document missing in pack "${found.packId}" — skipped`
+          );
           continue;
         }
 
@@ -9002,12 +9067,12 @@ export class FoundryDataAccess {
 
         // 5. Embed individually — per-spell error isolation
         try {
-          const [created] = await actor.createEmbeddedDocuments('Item', [spellData]) as any[];
+          const [created] = (await actor.createEmbeddedDocuments('Item', [spellData])) as any[];
           added.push({
             name,
-            packId:    found.packId,
+            packId: found.packId,
             packLabel: found.packLabel,
-            itemId:    created.id,
+            itemId: created.id,
           });
         } catch (embedErr) {
           failed.push({
@@ -9018,30 +9083,33 @@ export class FoundryDataAccess {
       }
 
       // ── Phase D: audit + return ───────────────────────────────────────────
-      this.auditLog('addSpellsToActor', {
-        actorId:  actor.id,
-        added:    added.length,
-        skipped:  skipped.length,
-        notFound: notFound.length,
-        failed:   failed.length,
-      }, 'success');
+      this.auditLog(
+        'addSpellsToActor',
+        {
+          actorId: actor.id,
+          added: added.length,
+          skipped: skipped.length,
+          notFound: notFound.length,
+          failed: failed.length,
+        },
+        'success'
+      );
 
       return {
-        actor:    { id: actor.id, name: actor.name },
+        actor: { id: actor.id, name: actor.name },
         added,
         skipped,
         notFound,
         failed,
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add spells to actor`, error);
       this.auditLog(
         'addSpellsToActor',
         { actorIdentifier: data.actorIdentifier },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
@@ -9065,13 +9133,16 @@ export class FoundryDataAccess {
         throw new Error(`Actor not found: "${data.actorIdentifier}"`);
       }
 
-      const featureNames:    string[] = data.featureNames;
-      const compendiumPacks: string[] = data.compendiumPacks ?? ['dnd5e.monsterfeatures', 'dnd5e.classfeatures'];
-      const warnings:        string[] = [];
+      const featureNames: string[] = data.featureNames;
+      const compendiumPacks: string[] = data.compendiumPacks ?? [
+        'dnd5e.monsterfeatures',
+        'dnd5e.classfeatures',
+      ];
+      const warnings: string[] = [];
 
       // ── Phase A: deduplicate input (case-insensitive) ─────────────────────
-      const seen            = new Set<string>();
-      const unique:  string[] = [];
+      const seen = new Set<string>();
+      const unique: string[] = [];
       const skipped: Array<{ name: string; reason: string }> = [];
 
       for (const name of featureNames) {
@@ -9086,9 +9157,9 @@ export class FoundryDataAccess {
 
       // ── Phase B: build pack index maps (once per pack) ────────────────────
       interface PackMap {
-        packId:    string;
+        packId: string;
         packLabel: string;
-        nameMap:   Map<string, string>; // lowercase name → _id
+        nameMap: Map<string, string>; // lowercase name → _id
       }
       const packMaps: PackMap[] = [];
 
@@ -9102,7 +9173,7 @@ export class FoundryDataAccess {
         // Type guard — Item packs only
         if (pack.metadata.type !== 'Item') {
           warnings.push(
-            `Pack "${packId}" has type "${pack.metadata.type}", expected "Item" — skipped`,
+            `Pack "${packId}" has type "${pack.metadata.type}", expected "Item" — skipped`
           );
           continue;
         }
@@ -9124,16 +9195,16 @@ export class FoundryDataAccess {
       if (packMaps.length === 0) {
         throw new Error(
           'No valid compendium packs available — check the compendiumPacks parameter. ' +
-          'Valid pack IDs for D&D 5e: "dnd5e.monsterfeatures" or "dnd5e.classfeatures" (2014), ' +
-          '"dnd5e.monsterfeatures24" (2024 monster features). ' +
-          'Note: 2024 class features are embedded in class items and cannot be imported with this tool.',
+            'Valid pack IDs for D&D 5e: "dnd5e.monsterfeatures" or "dnd5e.classfeatures" (2014), ' +
+            '"dnd5e.monsterfeatures24" (2024 monster features). ' +
+            'Note: 2024 class features are embedded in class items and cannot be imported with this tool.'
         );
       }
 
       // ── Phase C: per-feature search + import ─────────────────────────────
-      const added:    Array<{ name: string; packId: string; packLabel: string; itemId: string }> = [];
+      const added: Array<{ name: string; packId: string; packLabel: string; itemId: string }> = [];
       const notFound: string[] = [];
-      const failed:   Array<{ name: string; error: string }> = [];
+      const failed: Array<{ name: string; error: string }> = [];
 
       for (const name of unique) {
         const normalizedName = name.toLowerCase();
@@ -9141,7 +9212,7 @@ export class FoundryDataAccess {
         // 1. Duplicate check on actor — name-only, any item type
         //    (feature names are semantically unique on an actor regardless of stored type)
         const existing = (actor.items as any[]).find(
-          (i: any) => i.name?.toLowerCase() === normalizedName,
+          (i: any) => i.name?.toLowerCase() === normalizedName
         );
         if (existing) {
           skipped.push({ name, reason: 'already on actor' });
@@ -9164,13 +9235,15 @@ export class FoundryDataAccess {
         }
 
         // 3. Fetch full document from compendium
-        const pack     = game.packs.get(found.packId);
+        const pack = game.packs.get(found.packId);
         const document = await (pack as any).getDocument(found.entryId);
 
         if (!document) {
           // Entry was in index but document is missing (shouldn't happen, defensive)
           notFound.push(name);
-          warnings.push(`"${name}" found in index but document missing in pack "${found.packId}" — skipped`);
+          warnings.push(
+            `"${name}" found in index but document missing in pack "${found.packId}" — skipped`
+          );
           continue;
         }
 
@@ -9180,12 +9253,12 @@ export class FoundryDataAccess {
 
         // 5. Embed individually — per-feature error isolation
         try {
-          const [created] = await actor.createEmbeddedDocuments('Item', [featureData]) as any[];
+          const [created] = (await actor.createEmbeddedDocuments('Item', [featureData])) as any[];
           added.push({
             name,
-            packId:    found.packId,
+            packId: found.packId,
             packLabel: found.packLabel,
-            itemId:    created.id,
+            itemId: created.id,
           });
         } catch (embedErr) {
           failed.push({
@@ -9196,35 +9269,37 @@ export class FoundryDataAccess {
       }
 
       // ── Phase D: audit + return ───────────────────────────────────────────
-      this.auditLog('addFeaturesFromCompendium', {
-        actorId:  actor.id,
-        added:    added.length,
-        skipped:  skipped.length,
-        notFound: notFound.length,
-        failed:   failed.length,
-      }, 'success');
+      this.auditLog(
+        'addFeaturesFromCompendium',
+        {
+          actorId: actor.id,
+          added: added.length,
+          skipped: skipped.length,
+          notFound: notFound.length,
+          failed: failed.length,
+        },
+        'success'
+      );
 
       return {
-        actor:    { id: actor.id, name: actor.name },
+        actor: { id: actor.id, name: actor.name },
         added,
         skipped,
         notFound,
         failed,
         warnings,
       };
-
     } catch (error) {
       console.error(`[${MODULE_ID}] Failed to add features from compendium`, error);
       this.auditLog(
         'addFeaturesFromCompendium',
         { actorIdentifier: data.actorIdentifier },
         'failure',
-        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.message : 'Unknown error'
       );
       throw error;
     }
   }
-
 }
 
 // =============================================================================
@@ -9247,44 +9322,67 @@ function slugify(name: string, fallback = 'feature'): string {
 // =============================================================================
 
 const NPC_DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 const NPC_CONDITION_CANONICAL = new Set([
-  'blinded', 'charmed', 'deafened', 'exhaustion', 'frightened', 'grappled',
-  'incapacitated', 'invisible', 'paralyzed', 'petrified', 'poisoned',
-  'prone', 'restrained', 'stunned', 'unconscious',
+  'blinded',
+  'charmed',
+  'deafened',
+  'exhaustion',
+  'frightened',
+  'grappled',
+  'incapacitated',
+  'invisible',
+  'paralyzed',
+  'petrified',
+  'poisoned',
+  'prone',
+  'restrained',
+  'stunned',
+  'unconscious',
 ]);
 
 const NPC_SIZE_MAP: Record<string, string> = {
-  tiny:       'tiny',
-  small:      'sm',
-  medium:     'med',
-  large:      'lg',
-  huge:       'huge',
+  tiny: 'tiny',
+  small: 'sm',
+  medium: 'med',
+  large: 'lg',
+  huge: 'huge',
   gargantuan: 'grg',
 };
 
 const NPC_SKILL_MAP: Record<string, string> = {
-  'Acrobatics':      'acr',
+  Acrobatics: 'acr',
   'Animal Handling': 'ani',
-  'Arcana':          'arc',
-  'Athletics':       'ath',
-  'Deception':       'dec',
-  'History':         'his',
-  'Insight':         'ins',
-  'Intimidation':    'itm',
-  'Investigation':   'inv',
-  'Medicine':        'med',
-  'Nature':          'nat',
-  'Perception':      'prc',
-  'Performance':     'prf',
-  'Persuasion':      'per',
-  'Religion':        'rel',
+  Arcana: 'arc',
+  Athletics: 'ath',
+  Deception: 'dec',
+  History: 'his',
+  Insight: 'ins',
+  Intimidation: 'itm',
+  Investigation: 'inv',
+  Medicine: 'med',
+  Nature: 'nat',
+  Perception: 'prc',
+  Performance: 'prf',
+  Persuasion: 'per',
+  Religion: 'rel',
   'Sleight of Hand': 'slt',
-  'Stealth':         'ste',
-  'Survival':        'sur',
+  Stealth: 'ste',
+  Survival: 'sur',
 };
 
 function npcNormalizeCR(input: string | number): number {
@@ -9297,15 +9395,15 @@ function npcNormalizeCR(input: string | number): number {
 }
 
 function npcFormatCR(value: number): string {
-  if (value === 0)     return '0';
+  if (value === 0) return '0';
   if (value === 0.125) return '1/8';
-  if (value === 0.25)  return '1/4';
-  if (value === 0.5)   return '1/2';
+  if (value === 0.25) return '1/4';
+  if (value === 0.5) return '1/2';
   return String(Math.round(value));
 }
 
 function npcBuildSkillsBlock(
-  skills: Array<{ skill: string; proficiency: string }>,
+  skills: Array<{ skill: string; proficiency: string }>
 ): Record<string, { value: number }> {
   const result: Record<string, { value: number }> = {};
   for (const { skill, proficiency } of skills) {
@@ -9322,13 +9420,37 @@ function npcBuildSkillsBlock(
 // =============================================================================
 
 const ATTACK_DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 const ATTACK_PROPERTY_CANONICAL = new Set([
-  'ada', 'amm', 'fin', 'fir', 'foc', 'hvy', 'lgt', 'lod', 'mgc',
-  'rch', 'ret', 'spc', 'thr', 'two', 'ver',
+  'ada',
+  'amm',
+  'fin',
+  'fir',
+  'foc',
+  'hvy',
+  'lgt',
+  'lod',
+  'mgc',
+  'rch',
+  'ret',
+  'spc',
+  'thr',
+  'two',
+  'ver',
 ]);
 
 // =============================================================================
@@ -9336,8 +9458,19 @@ const ATTACK_PROPERTY_CANONICAL = new Set([
 // =============================================================================
 
 const AURA_DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 // =============================================================================
@@ -9345,8 +9478,19 @@ const AURA_DAMAGE_CANONICAL = new Set([
 // =============================================================================
 
 const ATTACK_WITH_SAVE_DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 // =============================================================================

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -135,15 +135,20 @@ export class QueryHandlers {
       this.handleGetAvailableConditions.bind(this);
 
     // D&D 5e queries
-    CONFIG.queries[`${modulePrefix}.addSaveFeatureToActor`] = this.handleAddSaveFeatureToActor.bind(this);
+    CONFIG.queries[`${modulePrefix}.addSaveFeatureToActor`] =
+      this.handleAddSaveFeatureToActor.bind(this);
     CONFIG.queries[`${modulePrefix}.createNpcActor`] = this.handleCreateNpcActor.bind(this);
     CONFIG.queries[`${modulePrefix}.addAttackToActor`] = this.handleAddAttackToActor.bind(this);
     CONFIG.queries[`${modulePrefix}.addAuraToActor`] = this.handleAddAuraToActor.bind(this);
-    CONFIG.queries[`${modulePrefix}.addPassiveFeatureToActor`] = this.handleAddPassiveFeatureToActor.bind(this);
-    CONFIG.queries[`${modulePrefix}.addAttackWithSaveToActor`] = this.handleAddAttackWithSaveToActor.bind(this);
-    CONFIG.queries[`${modulePrefix}.setActorSpellcasting`] = this.handleSetActorSpellcasting.bind(this);
+    CONFIG.queries[`${modulePrefix}.addPassiveFeatureToActor`] =
+      this.handleAddPassiveFeatureToActor.bind(this);
+    CONFIG.queries[`${modulePrefix}.addAttackWithSaveToActor`] =
+      this.handleAddAttackWithSaveToActor.bind(this);
+    CONFIG.queries[`${modulePrefix}.setActorSpellcasting`] =
+      this.handleSetActorSpellcasting.bind(this);
     CONFIG.queries[`${modulePrefix}.addSpellsToActor`] = this.handleAddSpellsToActor.bind(this);
-    CONFIG.queries[`${modulePrefix}.addFeaturesFromCompendium`] = this.handleAddFeaturesFromCompendium.bind(this);
+    CONFIG.queries[`${modulePrefix}.addFeaturesFromCompendium`] =
+      this.handleAddFeaturesFromCompendium.bind(this);
   }
 
   /**
@@ -1727,7 +1732,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addSaveFeatureToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add save feature to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add save feature to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1771,7 +1778,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.createNpcActor(data);
     } catch (error) {
-      throw new Error(`Failed to create NPC actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to create NPC actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1803,7 +1812,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addAttackToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add attack to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add attack to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1838,7 +1849,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addAuraToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add aura to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add aura to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1863,7 +1876,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addPassiveFeatureToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add passive feature to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add passive feature to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1880,20 +1895,22 @@ export class QueryHandlers {
       this.dataAccess.validateFoundryState();
 
       if (!data.actorIdentifier) throw new Error('actorIdentifier is required');
-      if (!data.featureName)     throw new Error('featureName is required');
-      if (!data.attackType)      throw new Error('attackType is required');
+      if (!data.featureName) throw new Error('featureName is required');
+      if (!data.attackType) throw new Error('attackType is required');
       if (!Array.isArray(data.damageParts) || data.damageParts.length === 0) {
         throw new Error('damageParts is required and must contain at least one element');
       }
       if (!data.saveAbility) throw new Error('saveAbility is required');
-      if (!data.saveDC)      throw new Error('saveDC is required');
+      if (!data.saveDC) throw new Error('saveDC is required');
       if (!Array.isArray(data.saveDamageParts) || data.saveDamageParts.length === 0) {
         throw new Error('saveDamageParts is required and must contain at least one element');
       }
 
       return await this.dataAccess.addAttackWithSaveToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add attack+save to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add attack+save to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1905,7 +1922,11 @@ export class QueryHandlers {
       if (!data.spellcastingClass) {
         throw new Error('spellcastingClass is required');
       }
-      if (typeof data.spellcastingLevel !== 'number' || data.spellcastingLevel < 1 || data.spellcastingLevel > 20) {
+      if (
+        typeof data.spellcastingLevel !== 'number' ||
+        data.spellcastingLevel < 1 ||
+        data.spellcastingLevel > 20
+      ) {
         throw new Error('spellcastingLevel must be a number between 1 and 20');
       }
       if (!data.effectiveAbility) {
@@ -1914,7 +1935,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.setActorSpellcasting(data);
     } catch (error) {
-      throw new Error(`Failed to set actor spellcasting: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to set actor spellcasting: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1932,7 +1955,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addSpellsToActor(data);
     } catch (error) {
-      throw new Error(`Failed to add spells to actor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add spells to actor: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1950,7 +1975,9 @@ export class QueryHandlers {
 
       return await this.dataAccess.addFeaturesFromCompendium(data);
     } catch (error) {
-      throw new Error(`Failed to add features from compendium: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to add features from compendium: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -192,15 +192,16 @@ function acquireLock(): boolean {
             if (evaluateLockFile(lockPid, LOCK_FILE) === 'orphaned') {
               console.error(
                 `Removing orphaned backend lock for PID ${lockPid} ` +
-                `(process is not node.exe or lock file is stale)`,
+                  `(process is not node.exe or lock file is stale)`
               );
-              try { fs.unlinkSync(LOCK_FILE); } catch {}
+              try {
+                fs.unlinkSync(LOCK_FILE);
+              } catch {}
               lockFd = fs.openSync(LOCK_FILE, 'wx');
             } else {
               // Backend is genuinely running — exit gracefully
               return false;
             }
-
           } catch {
             console.error(`Removing stale backend lock for PID ${lockPid}`);
 
@@ -1191,9 +1192,12 @@ async function startBackend(): Promise<void> {
 
   const dsa5CharacterCreator = new DSA5CharacterCreator({ foundryClient, logger });
 
-  const dnd5eAddFeatureTool              = new DnD5eAddFeatureTool({ foundryClient, logger });
-  const dnd5eNpcTools                    = new DnD5eNpcTools({ foundryClient, logger });
-  const dnd5eFeaturesFromCompendiumTools = new DnD5eFeaturesFromCompendiumTools({ foundryClient, logger });
+  const dnd5eAddFeatureTool = new DnD5eAddFeatureTool({ foundryClient, logger });
+  const dnd5eNpcTools = new DnD5eNpcTools({ foundryClient, logger });
+  const dnd5eFeaturesFromCompendiumTools = new DnD5eFeaturesFromCompendiumTools({
+    foundryClient,
+    logger,
+  });
 
   const questCreationTools = new QuestCreationTools({ foundryClient, logger });
 
@@ -1602,20 +1606,18 @@ async function startBackend(): Promise<void> {
                 // D&D 5e tools
 
                 case 'dnd5e-add-feature':
-
                   result = await dnd5eAddFeatureTool.handleAddFeature(args);
 
                   break;
 
                 case 'dnd5e-create-npc':
-
                   result = await dnd5eNpcTools.handleCreateNpc(args);
 
                   break;
 
                 case 'dnd5e-add-features-from-compendium':
-
-                  result = await dnd5eFeaturesFromCompendiumTools.handleAddFeaturesFromCompendium(args);
+                  result =
+                    await dnd5eFeaturesFromCompendiumTools.handleAddFeaturesFromCompendium(args);
 
                   break;
 

--- a/packages/mcp-server/src/lock.test.ts
+++ b/packages/mcp-server/src/lock.test.ts
@@ -11,21 +11,26 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { evaluateLockFile, isLockStale, isNodeProcess, getProcessName, LOCK_MAX_AGE_MS } from './lock.js';
+import {
+  evaluateLockFile,
+  isLockStale,
+  isNodeProcess,
+  getProcessName,
+  LOCK_MAX_AGE_MS,
+} from './lock.js';
 
 // ---------------------------------------------------------------------------
 // evaluateLockFile — the four core scenarios from the bug report
 // ---------------------------------------------------------------------------
 
 describe('evaluateLockFile', () => {
-
   const FAKE_LOCK = '/tmp/test-foundry-backend.lock';
 
   // Test 1: PID belongs to a non-Node process (e.g. GameInputRedistService)
   it('returns "orphaned" when process is not node.exe (PID reuse by OS service)', () => {
     const result = evaluateLockFile(26188, FAKE_LOCK, {
-      checkProcessName: (_pid) => false,   // not a node process
-      checkStaleness:   (_p)   => false,   // lock file is fresh
+      checkProcessName: _pid => false, // not a node process
+      checkStaleness: _p => false, // lock file is fresh
     });
     expect(result).toBe('orphaned');
   });
@@ -33,8 +38,8 @@ describe('evaluateLockFile', () => {
   // Test 2: PID belongs to a live node process with a fresh lock file
   it('returns "valid" when process is node.exe and lock file is fresh', () => {
     const result = evaluateLockFile(12345, FAKE_LOCK, {
-      checkProcessName: (_pid) => true,    // node process alive
-      checkStaleness:   (_p)   => false,   // lock file is fresh
+      checkProcessName: _pid => true, // node process alive
+      checkStaleness: _p => false, // lock file is fresh
     });
     expect(result).toBe('valid');
   });
@@ -45,8 +50,8 @@ describe('evaluateLockFile', () => {
   // "non-existent PID" gracefully if checkProcessName returns false.
   it('returns "orphaned" when checkProcessName returns false for a non-existent PID', () => {
     const result = evaluateLockFile(99999, FAKE_LOCK, {
-      checkProcessName: (_pid) => false,   // getProcessName would return null for dead PIDs
-      checkStaleness:   (_p)   => false,
+      checkProcessName: _pid => false, // getProcessName would return null for dead PIDs
+      checkStaleness: _p => false,
     });
     expect(result).toBe('orphaned');
   });
@@ -54,8 +59,8 @@ describe('evaluateLockFile', () => {
   // Test 4: Lock file older than 60 minutes (stale), even if process is node
   it('returns "orphaned" when lock file is stale (> 60 min) even if process is node.exe', () => {
     const result = evaluateLockFile(12345, FAKE_LOCK, {
-      checkProcessName: (_pid) => true,    // node process alive
-      checkStaleness:   (_p)   => true,    // lock file is stale
+      checkProcessName: _pid => true, // node process alive
+      checkStaleness: _p => true, // lock file is stale
     });
     expect(result).toBe('orphaned');
   });
@@ -64,7 +69,7 @@ describe('evaluateLockFile', () => {
   it('returns "orphaned" when process is not node AND lock file is stale', () => {
     const result = evaluateLockFile(26188, FAKE_LOCK, {
       checkProcessName: () => false,
-      checkStaleness:   () => true,
+      checkStaleness: () => true,
     });
     expect(result).toBe('orphaned');
   });
@@ -79,7 +84,6 @@ describe('evaluateLockFile', () => {
     });
     expect(checkStaleness).toHaveBeenCalledWith(FAKE_LOCK, 999);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -87,7 +91,6 @@ describe('evaluateLockFile', () => {
 // ---------------------------------------------------------------------------
 
 describe('isLockStale', () => {
-
   let tmpFile: string;
 
   beforeEach(() => {
@@ -96,7 +99,9 @@ describe('isLockStale', () => {
   });
 
   afterEach(() => {
-    try { fs.unlinkSync(tmpFile); } catch {}
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {}
   });
 
   it('returns false for a freshly created file', () => {
@@ -124,7 +129,6 @@ describe('isLockStale', () => {
     // Should use the 60-min default
     expect(isLockStale(tmpFile)).toBe(true);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -132,7 +136,6 @@ describe('isLockStale', () => {
 // ---------------------------------------------------------------------------
 
 describe('isNodeProcess', () => {
-
   it('returns true for every recognized node executable name', () => {
     // Inject the name resolver so the result does not depend on the live
     // runner's process name (macOS `ps -o comm=` reports the process title,
@@ -155,7 +158,6 @@ describe('isNodeProcess', () => {
     // Very large PID that is extremely unlikely to exist
     expect(isNodeProcess(9_999_999)).toBe(false);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -163,7 +165,6 @@ describe('isNodeProcess', () => {
 // ---------------------------------------------------------------------------
 
 describe('getProcessName', () => {
-
   it('returns a node-related name for the current process PID', () => {
     const name = getProcessName(process.pid);
     // The test runner is Node.js; the process name must be node/node.exe/nodejs
@@ -173,5 +174,4 @@ describe('getProcessName', () => {
   it('returns null for a non-existent PID', () => {
     expect(getProcessName(9_999_999)).toBeNull();
   });
-
 });

--- a/packages/mcp-server/src/lock.ts
+++ b/packages/mcp-server/src/lock.ts
@@ -42,11 +42,11 @@ const NODE_PROCESS_NAMES = new Set(['node', 'node.exe', 'nodejs', 'nodejs.exe'])
 export function getProcessName(pid: number): string | null {
   try {
     if (process.platform === 'win32') {
-      const output = execFileSync(
-        'tasklist',
-        ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'],
-        { encoding: 'utf8', timeout: 3_000, windowsHide: true },
-      );
+      const output = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'], {
+        encoding: 'utf8',
+        timeout: 3_000,
+        windowsHide: true,
+      });
       // A matching row looks like: "node.exe","12345","Console","1","3,028 K"
       // Non-matching output:       INFO: No tasks are running…
       const match = output.match(/^"([^"]+)"/m);
@@ -64,13 +64,12 @@ export function getProcessName(pid: number): string | null {
     }
 
     // macOS + Linux fallback
-    const output = execFileSync(
-      'ps', ['-p', String(pid), '-o', 'comm='],
-      { encoding: 'utf8', timeout: 3_000 },
-    );
+    const output = execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
+      encoding: 'utf8',
+      timeout: 3_000,
+    });
     // On macOS, comm= can be a full path; extract the basename
     return path.basename(output.trim()).toLowerCase();
-
   } catch {
     // Process not found, permission denied, tool missing, etc.
     return null;
@@ -91,7 +90,7 @@ export function getProcessName(pid: number): string | null {
  */
 export function isNodeProcess(
   pid: number,
-  getName: (pid: number) => string | null = getProcessName,
+  getName: (pid: number) => string | null = getProcessName
 ): boolean {
   const name = getName(pid);
   return name !== null && NODE_PROCESS_NAMES.has(name);
@@ -107,10 +106,7 @@ export function isNodeProcess(
  *
  * Returns `false` if the file cannot be stat'd (missing, permission error).
  */
-export function isLockStale(
-  lockFilePath: string,
-  maxAgeMs: number = LOCK_MAX_AGE_MS,
-): boolean {
+export function isLockStale(lockFilePath: string, maxAgeMs: number = LOCK_MAX_AGE_MS): boolean {
   try {
     const stat = fs.statSync(lockFilePath);
     return Date.now() - stat.mtimeMs >= maxAgeMs;
@@ -142,14 +138,14 @@ export function evaluateLockFile(
   lockPid: number,
   lockFilePath: string,
   {
-    maxAgeMs         = LOCK_MAX_AGE_MS,
+    maxAgeMs = LOCK_MAX_AGE_MS,
     checkProcessName = isNodeProcess,
-    checkStaleness   = isLockStale,
+    checkStaleness = isLockStale,
   }: {
-    maxAgeMs?:         number;
+    maxAgeMs?: number;
     checkProcessName?: (pid: number) => boolean;
-    checkStaleness?:   (filePath: string, maxAgeMs?: number) => boolean;
-  } = {},
+    checkStaleness?: (filePath: string, maxAgeMs?: number) => boolean;
+  } = {}
 ): 'valid' | 'orphaned' {
   if (!checkProcessName(lockPid)) {
     return 'orphaned';

--- a/packages/mcp-server/src/systems/dsa5/filters.test.ts
+++ b/packages/mcp-server/src/systems/dsa5/filters.test.ts
@@ -1,9 +1,11 @@
 /**
  * DSA5 Filter Tests
  *
- * Simple tests to validate filter logic
+ * Validates filter matching, description rendering, and validation helpers
+ * against representative DSA5 creature data.
  */
 
+import { describe, it, expect } from 'vitest';
 import {
   matchesDSA5Filters,
   describeDSA5Filters,
@@ -12,8 +14,7 @@ import {
 } from './filters.js';
 import type { DSA5Filters } from './filters.js';
 
-// Test creature data
-const testCreature = {
+const goblin = {
   id: 'test-goblin-1',
   name: 'Goblin Krieger',
   type: 'character',
@@ -27,7 +28,7 @@ const testCreature = {
   },
 };
 
-const testSpellcaster = {
+const elfMagier = {
   id: 'test-magier-1',
   name: 'Elf Magier',
   type: 'character',
@@ -41,67 +42,74 @@ const testSpellcaster = {
   },
 };
 
-console.log('=== DSA5 Filter Tests ===\n');
+describe('matchesDSA5Filters', () => {
+  it('matches exact level', () => {
+    const filter: DSA5Filters = { level: 2 };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(true);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(false);
+  });
 
-// Test 1: Level filter (exact)
-console.log('Test 1: Level filter (exact)');
-const filter1: DSA5Filters = { level: 2 };
-console.log(`Filter: ${describeDSA5Filters(filter1)}`);
-console.log(`Matches Goblin (Level 2): ${matchesDSA5Filters(testCreature, filter1)}`); // true
-console.log(`Matches Magier (Level 5): ${matchesDSA5Filters(testSpellcaster, filter1)}`); // false
-console.log('');
+  it('matches level range', () => {
+    const filter: DSA5Filters = { level: { min: 2, max: 5 } };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(true);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(true);
+  });
 
-// Test 2: Level range filter
-console.log('Test 2: Level range filter');
-const filter2: DSA5Filters = { level: { min: 2, max: 5 } };
-console.log(`Filter: ${describeDSA5Filters(filter2)}`);
-console.log(`Matches Goblin (Level 2): ${matchesDSA5Filters(testCreature, filter2)}`); // true
-console.log(`Matches Magier (Level 5): ${matchesDSA5Filters(testSpellcaster, filter2)}`); // true
-console.log('');
+  it('matches species', () => {
+    const filter: DSA5Filters = { species: 'goblin' };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(true);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(false);
+  });
 
-// Test 3: Species filter
-console.log('Test 3: Species filter');
-const filter3: DSA5Filters = { species: 'goblin' };
-console.log(`Filter: ${describeDSA5Filters(filter3)}`);
-console.log(`Matches Goblin: ${matchesDSA5Filters(testCreature, filter3)}`); // true
-console.log(`Matches Elf: ${matchesDSA5Filters(testSpellcaster, filter3)}`); // false
-console.log('');
+  it('matches hasSpells flag', () => {
+    const filter: DSA5Filters = { hasSpells: true };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(false);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(true);
+  });
 
-// Test 4: Has spells filter
-console.log('Test 4: Has spells filter');
-const filter4: DSA5Filters = { hasSpells: true };
-console.log(`Filter: ${describeDSA5Filters(filter4)}`);
-console.log(`Matches Goblin (no spells): ${matchesDSA5Filters(testCreature, filter4)}`); // false
-console.log(`Matches Magier (has spells): ${matchesDSA5Filters(testSpellcaster, filter4)}`); // true
-console.log('');
+  it('matches combined filters', () => {
+    const filter: DSA5Filters = {
+      level: { min: 1, max: 3 },
+      size: 'small',
+      hasSpells: false,
+    };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(true);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(false);
+  });
 
-// Test 5: Combined filters
-console.log('Test 5: Combined filters');
-const filter5: DSA5Filters = {
-  level: { min: 1, max: 3 },
-  size: 'small',
-  hasSpells: false,
-};
-console.log(`Filter: ${describeDSA5Filters(filter5)}`);
-console.log(`Matches Goblin: ${matchesDSA5Filters(testCreature, filter5)}`); // true
-console.log(`Matches Magier: ${matchesDSA5Filters(testSpellcaster, filter5)}`); // false
-console.log('');
+  it('matches experience-points range', () => {
+    const filter: DSA5Filters = { experiencePoints: { min: 1000, max: 2000 } };
+    expect(matchesDSA5Filters(goblin, filter)).toBe(true);
+    expect(matchesDSA5Filters(elfMagier, filter)).toBe(false);
+  });
+});
 
-// Test 6: Experience points filter
-console.log('Test 6: Experience points filter');
-const filter6: DSA5Filters = { experiencePoints: { min: 1000, max: 2000 } };
-console.log(`Filter: ${describeDSA5Filters(filter6)}`);
-console.log(`Matches Goblin (1200 AP): ${matchesDSA5Filters(testCreature, filter6)}`); // true
-console.log(`Matches Magier (4000 AP): ${matchesDSA5Filters(testSpellcaster, filter6)}`); // false
-console.log('');
+describe('describeDSA5Filters', () => {
+  it('returns a non-empty string for a populated filter', () => {
+    const filter: DSA5Filters = { level: 2, species: 'goblin' };
+    const description = describeDSA5Filters(filter);
+    expect(typeof description).toBe('string');
+    expect(description.length).toBeGreaterThan(0);
+  });
+});
 
-// Test 7: Validation helpers
-console.log('Test 7: Validation helpers');
-console.log(`isValidDSA5Species('goblin'): ${isValidDSA5Species('goblin')}`); // true
-console.log(`isValidDSA5Species('unicorn'): ${isValidDSA5Species('unicorn')}`); // false
-console.log(`isValidExperienceLevel(3): ${isValidExperienceLevel(3)}`); // true
-console.log(`isValidExperienceLevel(0): ${isValidExperienceLevel(0)}`); // false
-console.log(`isValidExperienceLevel(8): ${isValidExperienceLevel(8)}`); // false
-console.log('');
+describe('validation helpers', () => {
+  it('isValidDSA5Species recognises known species', () => {
+    expect(isValidDSA5Species('goblin')).toBe(true);
+  });
 
-console.log('=== All Tests Completed ===');
+  it('isValidDSA5Species rejects unknown species', () => {
+    expect(isValidDSA5Species('unicorn')).toBe(false);
+  });
+
+  it('isValidExperienceLevel accepts levels 1-7', () => {
+    expect(isValidExperienceLevel(3)).toBe(true);
+    expect(isValidExperienceLevel(1)).toBe(true);
+    expect(isValidExperienceLevel(7)).toBe(true);
+  });
+
+  it('isValidExperienceLevel rejects out-of-range values', () => {
+    expect(isValidExperienceLevel(0)).toBe(false);
+    expect(isValidExperienceLevel(8)).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/tools/dnd5e/add-feature.ts
+++ b/packages/mcp-server/src/tools/dnd5e/add-feature.ts
@@ -9,25 +9,49 @@ import { detectGameSystem, getCachedSystemId } from '../../utils/system-detectio
 // ---------------------------------------------------------------------------
 
 const DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 const ATTACK_PROPERTY_CANONICAL = new Set([
-  'ada', 'amm', 'fin', 'fir', 'foc', 'hvy', 'lgt', 'lod', 'mgc',
-  'rch', 'ret', 'spc', 'thr', 'two', 'ver',
+  'ada',
+  'amm',
+  'fin',
+  'fir',
+  'foc',
+  'hvy',
+  'lgt',
+  'lod',
+  'mgc',
+  'rch',
+  'ret',
+  'spc',
+  'thr',
+  'two',
+  'ver',
 ]);
 
 const CLASS_DEFAULT_ABILITY: Record<string, string> = {
-  wizard:    'int',
+  wizard: 'int',
   artificer: 'int',
-  cleric:    'wis',
-  druid:     'wis',
-  ranger:    'wis',
-  sorcerer:  'cha',
-  warlock:   'cha',
-  bard:      'cha',
-  paladin:   'cha',
+  cleric: 'wis',
+  druid: 'wis',
+  ranger: 'wis',
+  sorcerer: 'cha',
+  warlock: 'cha',
+  bard: 'cha',
+  paladin: 'cha',
 };
 
 // ---------------------------------------------------------------------------
@@ -36,19 +60,21 @@ const CLASS_DEFAULT_ABILITY: Record<string, string> = {
 
 const damagePart = z.object({
   number: z.number().int().min(1),
-  denomination: z.number().int().refine(
-    (d) => [4, 6, 8, 10, 12, 20, 100].includes(d),
-    { message: 'denomination must be one of 4, 6, 8, 10, 12, 20, 100' },
-  ),
+  denomination: z
+    .number()
+    .int()
+    .refine(d => [4, 6, 8, 10, 12, 20, 100].includes(d), {
+      message: 'denomination must be one of 4, 6, 8, 10, 12, 20, 100',
+    }),
   type: z.string().min(1, 'damage type cannot be empty'),
 });
 
 const damagePartSchema = {
   type: 'object',
   properties: {
-    number:       { type: 'number', description: 'Number of dice (e.g. 4)', minimum: 1 },
+    number: { type: 'number', description: 'Number of dice (e.g. 4)', minimum: 1 },
     denomination: { type: 'number', description: 'Die size', enum: [4, 6, 8, 10, 12, 20, 100] },
-    type:         { type: 'string', description: 'Damage type (e.g. "fire", "slashing", "cold")' },
+    type: { type: 'string', description: 'Damage type (e.g. "fire", "slashing", "cold")' },
   },
   required: ['number', 'denomination', 'type'],
 };
@@ -84,22 +110,18 @@ export class DnD5eAddFeatureTool {
         description:
           '[D&D 5e only] Add a feature, attack, spellcasting setup, or spells to an existing actor. ' +
           'Set featureType to select the mode — each mode uses only its own parameters:\n\n' +
-
           '• passive — descriptive trait, no roll (Multiattack, Magic Resistance, Spider Climb).\n' +
           '  Required: actorIdentifier, featureName\n' +
           '  Optional: description, sourceRules, sourceBook, sourcePage\n\n' +
-
           '• save — feature that forces a saving throw (breath weapon, cone of cold, etc.).\n' +
           '  Required: actorIdentifier, featureName, saveAbility, saveDC, damageParts\n' +
           '  Optional: description, activationType, halfOnSave, areaType, areaSize ' +
           '(required if areaType set), areaUnits, affectsType\n\n' +
-
           '• attack — weapon attack with to-hit roll (Claw, Bite, Scimitar, etc.).\n' +
           '  Required: actorIdentifier, featureName, attackType, damageParts\n' +
           '  Required when ranged: rangeFt\n' +
           '  Optional: description, activationType, weaponClass, abilityModifier, attackBonus, ' +
           'proficient, equipped, reachFt, longRangeFt, properties, sourceRules, sourceBook, sourcePage\n\n' +
-
           '• attack-with-save — attack roll on hit + forced save for bonus damage ' +
           '(e.g. Stinger: piercing hit + CON save or poison damage).\n' +
           '  Required: actorIdentifier, featureName, attackType, damageParts, ' +
@@ -108,32 +130,35 @@ export class DnD5eAddFeatureTool {
           '  Optional: description, activationType, weaponClass, abilityModifier, attackBonus, ' +
           'proficient, equipped, reachFt, longRangeFt, properties, saveOnSave, ' +
           'sourceRules, sourceBook, sourcePage\n\n' +
-
           '• aura — automatic-damage area, no to-hit, no save (all creatures in range take damage).\n' +
           '  Required: actorIdentifier, featureName, damageParts, areaType, areaSize\n' +
           '  Optional: description, activationType, areaUnits, affectsType, ' +
           'sourceRules, sourceBook, sourcePage\n\n' +
-
           '• spellcasting — configure spell slots and casting ability. ' +
           'Run this BEFORE featureType "spells".\n' +
           '  Required: actorIdentifier, spellcastingClass, spellcastingLevel\n' +
           '  Optional: spellcastingAbility (default per class: wizard/artificer→INT, ' +
           'cleric/druid/ranger→WIS, sorcerer/warlock/bard/paladin→CHA), sourceRules\n\n' +
-
           '• spells — import named spells from compendium. Names must be in English.\n' +
           '  Required: actorIdentifier, spellNames (max 50)\n' +
           '  Optional: compendiumPacks (default ["dnd5e.spells"])\n\n' +
-
           'Use list-characters or get-character first to find the actorIdentifier.',
 
         inputSchema: {
           type: 'object',
           properties: {
-
             // ── Discriminator ─────────────────────────────────────────────────
             featureType: {
               type: 'string',
-              enum: ['passive', 'save', 'attack', 'attack-with-save', 'aura', 'spellcasting', 'spells'],
+              enum: [
+                'passive',
+                'save',
+                'attack',
+                'attack-with-save',
+                'aura',
+                'spellcasting',
+                'spells',
+              ],
               description:
                 'Mode selector — determines which parameters are used and which Foundry handler is called.',
             },
@@ -141,7 +166,8 @@ export class DnD5eAddFeatureTool {
             // ── Common ────────────────────────────────────────────────────────
             actorIdentifier: {
               type: 'string',
-              description: 'Name or ID of the target actor (partial name match supported). Required for all featureTypes.',
+              description:
+                'Name or ID of the target actor (partial name match supported). Required for all featureTypes.',
             },
             featureName: {
               type: 'string',
@@ -151,13 +177,15 @@ export class DnD5eAddFeatureTool {
             },
             description: {
               type: 'string',
-              description: 'HTML description of the feature (optional). Used by: passive, save, attack, attack-with-save, aura.',
+              description:
+                'HTML description of the feature (optional). Used by: passive, save, attack, attack-with-save, aura.',
               default: '',
             },
             activationType: {
               type: 'string',
               enum: ['action', 'bonus', 'reaction', 'legendary', 'lair', 'special'],
-              description: 'Action economy type. Used by: save, attack, attack-with-save, aura. Default: "action".',
+              description:
+                'Action economy type. Used by: save, attack, attack-with-save, aura. Default: "action".',
               default: 'action',
             },
 
@@ -178,7 +206,8 @@ export class DnD5eAddFeatureTool {
             saveAbility: {
               type: 'string',
               enum: ['str', 'dex', 'con', 'int', 'wis', 'cha'],
-              description: 'Ability used for the saving throw. Required for: save, attack-with-save.',
+              description:
+                'Ability used for the saving throw. Required for: save, attack-with-save.',
             },
             saveDC: {
               type: 'number',
@@ -188,7 +217,8 @@ export class DnD5eAddFeatureTool {
             },
             halfOnSave: {
               type: 'boolean',
-              description: 'Whether the target takes half damage on a successful save. Used by: save. Default: true.',
+              description:
+                'Whether the target takes half damage on a successful save. Used by: save. Default: true.',
               default: true,
             },
             saveDamageParts: {
@@ -319,14 +349,25 @@ export class DnD5eAddFeatureTool {
             // ── Spellcasting parameters ───────────────────────────────────────
             spellcastingClass: {
               type: 'string',
-              enum: ['artificer', 'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard'],
+              enum: [
+                'artificer',
+                'bard',
+                'cleric',
+                'druid',
+                'paladin',
+                'ranger',
+                'sorcerer',
+                'warlock',
+                'wizard',
+              ],
               description:
                 'The spellcasting class — determines slot table and default casting ability. ' +
                 'Warlock uses Pact Magic. Required for: spellcasting.',
             },
             spellcastingLevel: {
               type: 'number',
-              description: 'Class level (1–20). Determines how many slots the actor receives. Required for: spellcasting.',
+              description:
+                'Class level (1–20). Determines how many slots the actor receives. Required for: spellcasting.',
               minimum: 1,
               maximum: 20,
             },
@@ -362,17 +403,20 @@ export class DnD5eAddFeatureTool {
             sourceRules: {
               type: 'string',
               enum: ['2014', '2024'],
-              description: 'Rules edition. Used by: passive, attack, attack-with-save, aura, spellcasting. Default: "2014".',
+              description:
+                'Rules edition. Used by: passive, attack, attack-with-save, aura, spellcasting. Default: "2014".',
               default: '2014',
             },
             sourceBook: {
               type: 'string',
-              description: "Source book abbreviation (e.g. \"MM'14\"). Used by: passive, attack, attack-with-save, aura.",
+              description:
+                'Source book abbreviation (e.g. "MM\'14"). Used by: passive, attack, attack-with-save, aura.',
               default: '',
             },
             sourcePage: {
               type: 'string',
-              description: 'Page number in the source book. Used by: passive, attack, attack-with-save, aura.',
+              description:
+                'Page number in the source book. Used by: passive, attack, attack-with-save, aura.',
               default: '',
             },
           },
@@ -389,18 +433,33 @@ export class DnD5eAddFeatureTool {
   async handleAddFeature(args: any): Promise<any> {
     const { featureType } = z
       .object({
-        featureType: z.enum(['passive', 'save', 'attack', 'attack-with-save', 'aura', 'spellcasting', 'spells']),
+        featureType: z.enum([
+          'passive',
+          'save',
+          'attack',
+          'attack-with-save',
+          'aura',
+          'spellcasting',
+          'spells',
+        ]),
       })
       .parse(args);
 
     switch (featureType) {
-      case 'passive':          return this.handlePassive(args);
-      case 'save':             return this.handleSave(args);
-      case 'attack':           return this.handleAttack(args);
-      case 'attack-with-save': return this.handleAttackWithSave(args);
-      case 'aura':             return this.handleAura(args);
-      case 'spellcasting':     return this.handleSpellcasting(args);
-      case 'spells':           return this.handleSpells(args);
+      case 'passive':
+        return this.handlePassive(args);
+      case 'save':
+        return this.handleSave(args);
+      case 'attack':
+        return this.handleAttack(args);
+      case 'attack-with-save':
+        return this.handleAttackWithSave(args);
+      case 'aura':
+        return this.handleAura(args);
+      case 'spellcasting':
+        return this.handleSpellcasting(args);
+      case 'spells':
+        return this.handleSpells(args);
     }
   }
 
@@ -410,20 +469,20 @@ export class DnD5eAddFeatureTool {
 
   private async handlePassive(args: any): Promise<any> {
     const schema = z.object({
-      featureType:     z.literal('passive'),
+      featureType: z.literal('passive'),
       actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-      featureName:     z.string().min(1, 'featureName cannot be empty'),
-      description:     z.string().default(''),
-      sourceRules:     z.enum(['2014', '2024']).default('2014'),
-      sourceBook:      z.string().default(''),
-      sourcePage:      z.string().default(''),
+      featureName: z.string().min(1, 'featureName cannot be empty'),
+      description: z.string().default(''),
+      sourceRules: z.enum(['2014', '2024']).default('2014'),
+      sourceBook: z.string().default(''),
+      sourcePage: z.string().default(''),
     });
 
     const parsed = schema.parse(args);
 
     this.logger.info('Adding passive feature to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      featureName:     parsed.featureName,
+      featureName: parsed.featureName,
     });
 
     try {
@@ -431,18 +490,18 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (passive) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
       const result = await this.foundryClient.query(
         'foundry-mcp-bridge.addPassiveFeatureToActor',
-        parsed,
+        parsed
       );
 
       this.logger.info('Passive feature added successfully', {
         actorId: result.actor?.id,
-        itemId:  result.item?.id,
+        itemId: result.item?.id,
       });
 
       return this.formatPassiveResponse(result, parsed);
@@ -459,7 +518,13 @@ export class DnD5eAddFeatureTool {
       `**Type:** passive / descriptive (no activity)`,
       `**Rules:** ${params.sourceRules}${params.sourceBook ? ` — ${params.sourceBook}` : ''}`,
     ].join('\n');
-    return { summary, success: true, item: result.item, actor: result.actor, message: `${summary}\n\n${details}` };
+    return {
+      summary,
+      success: true,
+      item: result.item,
+      actor: result.actor,
+      message: `${summary}\n\n${details}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -469,25 +534,29 @@ export class DnD5eAddFeatureTool {
   private async handleSave(args: any): Promise<any> {
     const schema = z
       .object({
-        featureType:     z.literal('save'),
+        featureType: z.literal('save'),
         actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-        featureName:     z.string().min(1, 'featureName cannot be empty'),
-        description:     z.string().default(''),
-        activationType:  z.enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special']).default('action'),
-        saveAbility:     z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']),
-        saveDC:          z.number().int().min(1).max(30),
-        damageParts:     z.array(damagePart).min(1, 'at least one damage part is required'),
-        halfOnSave:      z.boolean().default(true),
-        areaType:        z.enum(['cone', 'cube', 'cylinder', 'emanation', 'line', 'radius', 'sphere', '']).default(''),
-        areaSize:        z.number().positive().optional(),
-        areaUnits:       z.enum(['ft', 'm']).default('ft'),
-        affectsType:     z.enum(['creature', 'object', 'space', '']).default('creature'),
+        featureName: z.string().min(1, 'featureName cannot be empty'),
+        description: z.string().default(''),
+        activationType: z
+          .enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special'])
+          .default('action'),
+        saveAbility: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']),
+        saveDC: z.number().int().min(1).max(30),
+        damageParts: z.array(damagePart).min(1, 'at least one damage part is required'),
+        halfOnSave: z.boolean().default(true),
+        areaType: z
+          .enum(['cone', 'cube', 'cylinder', 'emanation', 'line', 'radius', 'sphere', ''])
+          .default(''),
+        areaSize: z.number().positive().optional(),
+        areaUnits: z.enum(['ft', 'm']).default('ft'),
+        affectsType: z.enum(['creature', 'object', 'space', '']).default('creature'),
       })
       .superRefine((data, ctx) => {
         if (data.areaType !== '' && data.areaSize === undefined) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['areaSize'],
+            code: z.ZodIssueCode.custom,
+            path: ['areaSize'],
             message: `areaSize is required when areaType is "${data.areaType}"`,
           });
         }
@@ -497,10 +566,10 @@ export class DnD5eAddFeatureTool {
 
     this.logger.info('Adding save feature to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      featureName:     parsed.featureName,
-      saveAbility:     parsed.saveAbility,
-      saveDC:          parsed.saveDC,
-      areaType:        parsed.areaType || 'none',
+      featureName: parsed.featureName,
+      saveAbility: parsed.saveAbility,
+      saveDC: parsed.saveDC,
+      areaType: parsed.areaType || 'none',
     });
 
     try {
@@ -508,18 +577,18 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (save) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
       const result = await this.foundryClient.query(
         'foundry-mcp-bridge.addSaveFeatureToActor',
-        parsed,
+        parsed
       );
 
       this.logger.info('Save feature added successfully', {
         actorId: result.actor?.id,
-        itemId:  result.item?.id,
+        itemId: result.item?.id,
       });
 
       return this.formatSaveResponse(result, parsed);
@@ -530,12 +599,14 @@ export class DnD5eAddFeatureTool {
 
   private formatSaveResponse(result: any, params: any): any {
     const damageDesc = (params.damageParts as any[])
-      .map((p) => `${p.number}d${p.denomination} ${p.type}`)
+      .map(p => `${p.number}d${p.denomination} ${p.type}`)
       .join(' + ');
-    const areaDesc   = params.areaType ? `, ${params.areaSize}${params.areaUnits} ${params.areaType}` : '';
-    const saveDesc   = `DC ${params.saveDC} ${String(params.saveAbility).toUpperCase()} save`;
+    const areaDesc = params.areaType
+      ? `, ${params.areaSize}${params.areaUnits} ${params.areaType}`
+      : '';
+    const saveDesc = `DC ${params.saveDC} ${String(params.saveAbility).toUpperCase()} save`;
     const onSaveDesc = params.halfOnSave ? 'half damage on save' : 'no damage on save';
-    const summary    = `✅ Feature "${result.item.name}" added to "${result.actor.name}"`;
+    const summary = `✅ Feature "${result.item.name}" added to "${result.actor.name}"`;
     const details = [
       `**Actor:** ${result.actor.name} (id: \`${result.actor.id}\`)`,
       `**Feature:** ${result.item.name} (id: \`${result.item.id}\`)`,
@@ -543,7 +614,13 @@ export class DnD5eAddFeatureTool {
       `**Damage:** ${damageDesc}${areaDesc}`,
       `**Activation:** ${params.activationType}`,
     ].join('\n');
-    return { summary, success: true, item: result.item, actor: result.actor, message: `${summary}\n\n${details}` };
+    return {
+      summary,
+      success: true,
+      item: result.item,
+      actor: result.actor,
+      message: `${summary}\n\n${details}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -553,42 +630,46 @@ export class DnD5eAddFeatureTool {
   private async handleAttack(args: any): Promise<any> {
     const schema = z
       .object({
-        featureType:     z.literal('attack'),
+        featureType: z.literal('attack'),
         actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-        featureName:     z.string().min(1, 'featureName cannot be empty'),
-        description:     z.string().default(''),
-        activationType:  z.enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special']).default('action'),
-        attackType:      z.enum(['melee', 'ranged']),
-        weaponClass:     z.enum(['natural', 'simpleM', 'martialM', 'simpleR', 'martialR']).default('natural'),
+        featureName: z.string().min(1, 'featureName cannot be empty'),
+        description: z.string().default(''),
+        activationType: z
+          .enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special'])
+          .default('action'),
+        attackType: z.enum(['melee', 'ranged']),
+        weaponClass: z
+          .enum(['natural', 'simpleM', 'martialM', 'simpleR', 'martialR'])
+          .default('natural'),
         abilityModifier: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']).optional(),
-        attackBonus:     z.number().int().min(0).max(10).default(0),
-        proficient:      z.boolean().default(true),
-        equipped:        z.boolean().default(true),
-        reachFt:         z.number().int().min(5).default(5),
-        rangeFt:         z.number().int().min(1).optional(),
-        longRangeFt:     z.number().int().min(1).optional(),
-        damageParts:     z.array(damagePart).min(1, 'at least one damage part is required'),
-        properties:      z.array(z.string()).default([]),
-        sourceRules:     z.enum(['2014', '2024']).default('2014'),
-        sourceBook:      z.string().default(''),
-        sourcePage:      z.string().default(''),
+        attackBonus: z.number().int().min(0).max(10).default(0),
+        proficient: z.boolean().default(true),
+        equipped: z.boolean().default(true),
+        reachFt: z.number().int().min(5).default(5),
+        rangeFt: z.number().int().min(1).optional(),
+        longRangeFt: z.number().int().min(1).optional(),
+        damageParts: z.array(damagePart).min(1, 'at least one damage part is required'),
+        properties: z.array(z.string()).default([]),
+        sourceRules: z.enum(['2014', '2024']).default('2014'),
+        sourceBook: z.string().default(''),
+        sourcePage: z.string().default(''),
       })
       .superRefine((data, ctx) => {
         if (data.attackType === 'ranged' && data.rangeFt === undefined) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['rangeFt'],
+            code: z.ZodIssueCode.custom,
+            path: ['rangeFt'],
             message: 'rangeFt is required when attackType is "ranged"',
           });
         }
         if (
           data.longRangeFt !== undefined &&
-          data.rangeFt    !== undefined &&
+          data.rangeFt !== undefined &&
           data.longRangeFt <= data.rangeFt
         ) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['longRangeFt'],
+            code: z.ZodIssueCode.custom,
+            path: ['longRangeFt'],
             message: `longRangeFt (${data.longRangeFt}) must be greater than rangeFt (${data.rangeFt})`,
           });
         }
@@ -616,10 +697,10 @@ export class DnD5eAddFeatureTool {
 
     this.logger.info('Adding attack feature to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      featureName:     parsed.featureName,
-      attackType:      parsed.attackType,
-      ability:         effectiveAbility,
-      warnings:        warnings.length,
+      featureName: parsed.featureName,
+      attackType: parsed.attackType,
+      ability: effectiveAbility,
+      warnings: warnings.length,
     });
 
     try {
@@ -627,18 +708,18 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (attack) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.addAttackToActor',
-        { ...parsed, effectiveAbility },
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.addAttackToActor', {
+        ...parsed,
+        effectiveAbility,
+      });
 
       this.logger.info('Attack feature added successfully', {
         actorId: result.actor?.id,
-        itemId:  result.item?.id,
+        itemId: result.item?.id,
       });
 
       return this.formatAttackResponse(result, { ...parsed, effectiveAbility }, warnings);
@@ -648,11 +729,14 @@ export class DnD5eAddFeatureTool {
   }
 
   private formatAttackResponse(result: any, params: any, warnings: string[]): any {
-    const bonusStr   = params.attackBonus > 0 ? ` +${params.attackBonus} to hit` : '';
-    const damageDesc = (params.damageParts as any[]).map((p) => `${p.number}d${p.denomination} ${p.type}`).join(' + ');
-    const rangeDesc  = params.attackType === 'melee'
-      ? `reach ${params.reachFt ?? 5} ft.`
-      : `range ${params.rangeFt}${params.longRangeFt ? `/${params.longRangeFt}` : ''} ft.`;
+    const bonusStr = params.attackBonus > 0 ? ` +${params.attackBonus} to hit` : '';
+    const damageDesc = (params.damageParts as any[])
+      .map(p => `${p.number}d${p.denomination} ${p.type}`)
+      .join(' + ');
+    const rangeDesc =
+      params.attackType === 'melee'
+        ? `reach ${params.reachFt ?? 5} ft.`
+        : `range ${params.rangeFt}${params.longRangeFt ? `/${params.longRangeFt}` : ''} ft.`;
     const summary = `✅ Attack "${result.item.name}" added to "${result.actor.name}"`;
     const details = [
       `**Actor:** ${result.actor.name} (id: \`${result.actor.id}\`)`,
@@ -662,10 +746,18 @@ export class DnD5eAddFeatureTool {
       `**Range/Reach:** ${rangeDesc}`,
       `**Weapon class:** ${params.weaponClass}`,
     ].join('\n');
-    const warningSection = warnings.length > 0
-      ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join('\n')}`
-      : '';
-    return { summary, success: true, item: result.item, actor: result.actor, warnings, message: `${summary}\n\n${details}${warningSection}` };
+    const warningSection =
+      warnings.length > 0
+        ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map(w => `- ${w}`).join('\n')}`
+        : '';
+    return {
+      summary,
+      success: true,
+      item: result.item,
+      actor: result.actor,
+      warnings,
+      message: `${summary}\n\n${details}${warningSection}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -675,46 +767,50 @@ export class DnD5eAddFeatureTool {
   private async handleAttackWithSave(args: any): Promise<any> {
     const schema = z
       .object({
-        featureType:     z.literal('attack-with-save'),
+        featureType: z.literal('attack-with-save'),
         actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-        featureName:     z.string().min(1, 'featureName cannot be empty'),
-        description:     z.string().default(''),
-        activationType:  z.enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special']).default('action'),
-        attackType:      z.enum(['melee', 'ranged']),
-        weaponClass:     z.enum(['natural', 'simpleM', 'martialM', 'simpleR', 'martialR']).default('natural'),
+        featureName: z.string().min(1, 'featureName cannot be empty'),
+        description: z.string().default(''),
+        activationType: z
+          .enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special'])
+          .default('action'),
+        attackType: z.enum(['melee', 'ranged']),
+        weaponClass: z
+          .enum(['natural', 'simpleM', 'martialM', 'simpleR', 'martialR'])
+          .default('natural'),
         abilityModifier: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']).optional(),
-        attackBonus:     z.number().int().min(0).max(10).default(0),
-        proficient:      z.boolean().default(true),
-        equipped:        z.boolean().default(true),
-        reachFt:         z.number().int().min(5).default(5),
-        rangeFt:         z.number().int().min(1).optional(),
-        longRangeFt:     z.number().int().min(1).optional(),
-        damageParts:     z.array(damagePart).min(1, 'at least one damage part is required'),
-        properties:      z.array(z.string()).default([]),
-        saveAbility:     z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']),
-        saveDC:          z.number().int().min(1).max(30),
+        attackBonus: z.number().int().min(0).max(10).default(0),
+        proficient: z.boolean().default(true),
+        equipped: z.boolean().default(true),
+        reachFt: z.number().int().min(5).default(5),
+        rangeFt: z.number().int().min(1).optional(),
+        longRangeFt: z.number().int().min(1).optional(),
+        damageParts: z.array(damagePart).min(1, 'at least one damage part is required'),
+        properties: z.array(z.string()).default([]),
+        saveAbility: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']),
+        saveDC: z.number().int().min(1).max(30),
         saveDamageParts: z.array(damagePart).min(1, 'at least one save damage part is required'),
-        saveOnSave:      z.enum(['half', 'none']).default('none'),
-        sourceRules:     z.enum(['2014', '2024']).default('2014'),
-        sourceBook:      z.string().default(''),
-        sourcePage:      z.string().default(''),
+        saveOnSave: z.enum(['half', 'none']).default('none'),
+        sourceRules: z.enum(['2014', '2024']).default('2014'),
+        sourceBook: z.string().default(''),
+        sourcePage: z.string().default(''),
       })
       .superRefine((data, ctx) => {
         if (data.attackType === 'ranged' && data.rangeFt === undefined) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['rangeFt'],
+            code: z.ZodIssueCode.custom,
+            path: ['rangeFt'],
             message: 'rangeFt is required when attackType is "ranged"',
           });
         }
         if (
           data.longRangeFt !== undefined &&
-          data.rangeFt    !== undefined &&
+          data.rangeFt !== undefined &&
           data.longRangeFt <= data.rangeFt
         ) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['longRangeFt'],
+            code: z.ZodIssueCode.custom,
+            path: ['longRangeFt'],
             message: `longRangeFt (${data.longRangeFt}) must be greater than rangeFt (${data.rangeFt})`,
           });
         }
@@ -735,11 +831,11 @@ export class DnD5eAddFeatureTool {
 
     this.logger.info('Adding attack+save feature to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      featureName:     parsed.featureName,
-      attackType:      parsed.attackType,
-      saveAbility:     parsed.saveAbility,
-      saveDC:          parsed.saveDC,
-      warnings:        warnings.length,
+      featureName: parsed.featureName,
+      attackType: parsed.attackType,
+      saveAbility: parsed.saveAbility,
+      saveDC: parsed.saveDC,
+      warnings: warnings.length,
     });
 
     try {
@@ -747,18 +843,18 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (attack-with-save) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.addAttackWithSaveToActor',
-        { ...parsed, effectiveAbility },
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.addAttackWithSaveToActor', {
+        ...parsed,
+        effectiveAbility,
+      });
 
       this.logger.info('Attack+save feature added successfully', {
         actorId: result.actor?.id,
-        itemId:  result.item?.id,
+        itemId: result.item?.id,
       });
 
       return this.formatAttackWithSaveResponse(result, { ...parsed, effectiveAbility }, warnings);
@@ -768,12 +864,17 @@ export class DnD5eAddFeatureTool {
   }
 
   private formatAttackWithSaveResponse(result: any, params: any, warnings: string[]): any {
-    const bonusStr         = params.attackBonus > 0 ? ` +${params.attackBonus} to hit` : '';
-    const attackDamageDesc = (params.damageParts as any[]).map((p) => `${p.number}d${p.denomination} ${p.type}`).join(' + ');
-    const saveDamageDesc   = (params.saveDamageParts as any[]).map((p) => `${p.number}d${p.denomination} ${p.type}`).join(' + ');
-    const rangeDesc        = params.attackType === 'melee'
-      ? `reach ${params.reachFt ?? 5} ft.`
-      : `range ${params.rangeFt}${params.longRangeFt ? `/${params.longRangeFt}` : ''} ft.`;
+    const bonusStr = params.attackBonus > 0 ? ` +${params.attackBonus} to hit` : '';
+    const attackDamageDesc = (params.damageParts as any[])
+      .map(p => `${p.number}d${p.denomination} ${p.type}`)
+      .join(' + ');
+    const saveDamageDesc = (params.saveDamageParts as any[])
+      .map(p => `${p.number}d${p.denomination} ${p.type}`)
+      .join(' + ');
+    const rangeDesc =
+      params.attackType === 'melee'
+        ? `reach ${params.reachFt ?? 5} ft.`
+        : `range ${params.rangeFt}${params.longRangeFt ? `/${params.longRangeFt}` : ''} ft.`;
     const summary = `✅ Attack+Save "${result.item.name}" added to "${result.actor.name}"`;
     const details = [
       `**Actor:** ${result.actor.name} (id: \`${result.actor.id}\`)`,
@@ -782,10 +883,18 @@ export class DnD5eAddFeatureTool {
       `**Attack damage:** ${attackDamageDesc}`,
       `**Save:** DC ${params.saveDC} ${String(params.saveAbility).toUpperCase()} — ${saveDamageDesc} (${params.saveOnSave === 'half' ? 'half on save' : 'no damage on save'})`,
     ].join('\n');
-    const warningSection = warnings.length > 0
-      ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join('\n')}`
-      : '';
-    return { summary, success: true, item: result.item, actor: result.actor, warnings, message: `${summary}\n\n${details}${warningSection}` };
+    const warningSection =
+      warnings.length > 0
+        ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map(w => `- ${w}`).join('\n')}`
+        : '';
+    return {
+      summary,
+      success: true,
+      item: result.item,
+      actor: result.actor,
+      warnings,
+      message: `${summary}\n\n${details}${warningSection}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -794,19 +903,21 @@ export class DnD5eAddFeatureTool {
 
   private async handleAura(args: any): Promise<any> {
     const schema = z.object({
-      featureType:     z.literal('aura'),
+      featureType: z.literal('aura'),
       actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-      featureName:     z.string().min(1, 'featureName cannot be empty'),
-      description:     z.string().default(''),
-      activationType:  z.enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special']).default('action'),
-      damageParts:     z.array(damagePart).min(1, 'at least one damage part is required'),
-      areaType:        z.enum(['cone', 'cube', 'cylinder', 'emanation', 'line', 'radius', 'sphere']),
-      areaSize:        z.number().positive('areaSize must be greater than 0'),
-      areaUnits:       z.enum(['ft', 'm']).default('ft'),
-      affectsType:     z.enum(['creature', 'object', 'space', '']).default('creature'),
-      sourceRules:     z.enum(['2014', '2024']).default('2014'),
-      sourceBook:      z.string().default(''),
-      sourcePage:      z.string().default(''),
+      featureName: z.string().min(1, 'featureName cannot be empty'),
+      description: z.string().default(''),
+      activationType: z
+        .enum(['action', 'bonus', 'reaction', 'legendary', 'lair', 'special'])
+        .default('action'),
+      damageParts: z.array(damagePart).min(1, 'at least one damage part is required'),
+      areaType: z.enum(['cone', 'cube', 'cylinder', 'emanation', 'line', 'radius', 'sphere']),
+      areaSize: z.number().positive('areaSize must be greater than 0'),
+      areaUnits: z.enum(['ft', 'm']).default('ft'),
+      affectsType: z.enum(['creature', 'object', 'space', '']).default('creature'),
+      sourceRules: z.enum(['2014', '2024']).default('2014'),
+      sourceBook: z.string().default(''),
+      sourcePage: z.string().default(''),
     });
 
     const parsed = schema.parse(args);
@@ -822,10 +933,10 @@ export class DnD5eAddFeatureTool {
 
     this.logger.info('Adding aura feature to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      featureName:     parsed.featureName,
-      areaType:        parsed.areaType,
-      areaSize:        parsed.areaSize,
-      warnings:        warnings.length,
+      featureName: parsed.featureName,
+      areaType: parsed.areaType,
+      areaSize: parsed.areaSize,
+      warnings: warnings.length,
     });
 
     try {
@@ -833,18 +944,15 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (aura) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.addAuraToActor',
-        parsed,
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.addAuraToActor', parsed);
 
       this.logger.info('Aura feature added successfully', {
         actorId: result.actor?.id,
-        itemId:  result.item?.id,
+        itemId: result.item?.id,
       });
 
       return this.formatAuraResponse(result, parsed, warnings);
@@ -854,9 +962,11 @@ export class DnD5eAddFeatureTool {
   }
 
   private formatAuraResponse(result: any, params: any, warnings: string[]): any {
-    const damageDesc = (params.damageParts as any[]).map((p) => `${p.number}d${p.denomination} ${p.type}`).join(' + ');
-    const areaDesc   = `${params.areaSize}${params.areaUnits} ${params.areaType}`;
-    const summary    = `✅ Aura "${result.item.name}" added to "${result.actor.name}"`;
+    const damageDesc = (params.damageParts as any[])
+      .map(p => `${p.number}d${p.denomination} ${p.type}`)
+      .join(' + ');
+    const areaDesc = `${params.areaSize}${params.areaUnits} ${params.areaType}`;
+    const summary = `✅ Aura "${result.item.name}" added to "${result.actor.name}"`;
     const details = [
       `**Actor:** ${result.actor.name} (id: \`${result.actor.id}\`)`,
       `**Feature:** ${result.item.name} (id: \`${result.item.id}\`)`,
@@ -864,10 +974,18 @@ export class DnD5eAddFeatureTool {
       `**Area:** ${areaDesc}, affects: ${params.affectsType || 'any'}`,
       `**Activation:** ${params.activationType}`,
     ].join('\n');
-    const warningSection = warnings.length > 0
-      ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join('\n')}`
-      : '';
-    return { summary, success: true, item: result.item, actor: result.actor, warnings, message: `${summary}\n\n${details}${warningSection}` };
+    const warningSection =
+      warnings.length > 0
+        ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map(w => `- ${w}`).join('\n')}`
+        : '';
+    return {
+      summary,
+      success: true,
+      item: result.item,
+      actor: result.actor,
+      warnings,
+      message: `${summary}\n\n${details}${warningSection}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -876,12 +994,22 @@ export class DnD5eAddFeatureTool {
 
   private async handleSpellcasting(args: any): Promise<any> {
     const schema = z.object({
-      featureType:         z.literal('spellcasting'),
-      actorIdentifier:     z.string().min(1, 'actorIdentifier cannot be empty'),
-      spellcastingClass:   z.enum(['artificer', 'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard']),
-      spellcastingLevel:   z.number().int().min(1).max(20),
+      featureType: z.literal('spellcasting'),
+      actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
+      spellcastingClass: z.enum([
+        'artificer',
+        'bard',
+        'cleric',
+        'druid',
+        'paladin',
+        'ranger',
+        'sorcerer',
+        'warlock',
+        'wizard',
+      ]),
+      spellcastingLevel: z.number().int().min(1).max(20),
       spellcastingAbility: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']).optional(),
-      sourceRules:         z.enum(['2014', '2024']).default('2014'),
+      sourceRules: z.enum(['2014', '2024']).default('2014'),
     });
 
     const parsed = schema.parse(args);
@@ -889,10 +1017,10 @@ export class DnD5eAddFeatureTool {
       parsed.spellcastingAbility ?? CLASS_DEFAULT_ABILITY[parsed.spellcastingClass];
 
     this.logger.info('Setting actor spellcasting', {
-      actorIdentifier:   parsed.actorIdentifier,
+      actorIdentifier: parsed.actorIdentifier,
       spellcastingClass: parsed.spellcastingClass,
       spellcastingLevel: parsed.spellcastingLevel,
-      ability:           effectiveAbility,
+      ability: effectiveAbility,
     });
 
     try {
@@ -900,14 +1028,14 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (spellcasting) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.setActorSpellcasting',
-        { ...parsed, effectiveAbility },
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.setActorSpellcasting', {
+        ...parsed,
+        effectiveAbility,
+      });
 
       this.logger.info('Actor spellcasting set successfully', { actorId: result.actor?.id });
 
@@ -932,10 +1060,18 @@ export class DnD5eAddFeatureTool {
       `**Ability:** ${String(params.effectiveAbility).toUpperCase()}`,
       `**Slots:** ${slotsDesc}`,
     ].join('\n');
-    const warningSection = (result.warnings as string[]).length > 0
-      ? `\n\n⚠️ **Warnings:**\n${(result.warnings as string[]).map((w: string) => `- ${w}`).join('\n')}`
-      : '';
-    return { summary, success: true, actor: result.actor, spellcasting: result.spellcasting, warnings: result.warnings, message: `${summary}\n\n${details}${warningSection}` };
+    const warningSection =
+      (result.warnings as string[]).length > 0
+        ? `\n\n⚠️ **Warnings:**\n${(result.warnings as string[]).map((w: string) => `- ${w}`).join('\n')}`
+        : '';
+    return {
+      summary,
+      success: true,
+      actor: result.actor,
+      spellcasting: result.spellcasting,
+      warnings: result.warnings,
+      message: `${summary}\n\n${details}${warningSection}`,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -944,9 +1080,9 @@ export class DnD5eAddFeatureTool {
 
   private async handleSpells(args: any): Promise<any> {
     const schema = z.object({
-      featureType:     z.literal('spells'),
+      featureType: z.literal('spells'),
       actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-      spellNames:      z.array(z.string().min(1)).min(1).max(50),
+      spellNames: z.array(z.string().min(1)).min(1).max(50),
       compendiumPacks: z.array(z.string().min(1)).default(['dnd5e.spells']),
     });
 
@@ -954,8 +1090,8 @@ export class DnD5eAddFeatureTool {
 
     this.logger.info('Adding spells to D&D 5e actor', {
       actorIdentifier: parsed.actorIdentifier,
-      spellCount:      parsed.spellNames.length,
-      packs:           parsed.compendiumPacks,
+      spellCount: parsed.spellNames.length,
+      packs: parsed.compendiumPacks,
     });
 
     try {
@@ -963,21 +1099,18 @@ export class DnD5eAddFeatureTool {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-feature (spells) requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.addSpellsToActor',
-        parsed,
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.addSpellsToActor', parsed);
 
       this.logger.info('Spells import complete', {
-        actorId:  result.actor?.id,
-        added:    result.added?.length,
-        skipped:  result.skipped?.length,
+        actorId: result.actor?.id,
+        added: result.added?.length,
+        skipped: result.skipped?.length,
         notFound: result.notFound?.length,
-        failed:   result.failed?.length,
+        failed: result.failed?.length,
       });
 
       return this.formatSpellsResponse(result, parsed);
@@ -987,20 +1120,25 @@ export class DnD5eAddFeatureTool {
   }
 
   private formatSpellsResponse(result: any, params: any): any {
-    const added    = result.added    as Array<{ name: string; packId: string; packLabel: string; itemId: string }>;
-    const skipped  = result.skipped  as Array<{ name: string; reason: string }>;
+    const added = result.added as Array<{
+      name: string;
+      packId: string;
+      packLabel: string;
+      itemId: string;
+    }>;
+    const skipped = result.skipped as Array<{ name: string; reason: string }>;
     const notFound = result.notFound as string[];
-    const failed   = result.failed   as Array<{ name: string; error: string }>;
+    const failed = result.failed as Array<{ name: string; error: string }>;
     const warnings = result.warnings as string[];
-    const total    = (params.spellNames as string[]).length;
+    const total = (params.spellNames as string[]).length;
 
     const parts: string[] = [];
-    if (added.length > 0)    parts.push(`${added.length} added`);
-    if (skipped.length > 0)  parts.push(`${skipped.length} skipped`);
+    if (added.length > 0) parts.push(`${added.length} added`);
+    if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
     if (notFound.length > 0) parts.push(`${notFound.length} not found`);
-    if (failed.length > 0)   parts.push(`${failed.length} failed`);
+    if (failed.length > 0) parts.push(`${failed.length} failed`);
 
-    const icon    = failed.length > 0 ? '⚠️' : notFound.length > 0 ? '🔍' : '✅';
+    const icon = failed.length > 0 ? '⚠️' : notFound.length > 0 ? '🔍' : '✅';
     const summary = `${icon} Spells imported to "${result.actor.name}" — ${parts.length > 0 ? parts.join(', ') : 'nothing changed'}`;
 
     const lines: string[] = [
@@ -1029,10 +1167,14 @@ export class DnD5eAddFeatureTool {
     }
     return {
       summary,
-      success:  added.length > 0 || (notFound.length === 0 && failed.length === 0),
-      actor:    result.actor,
-      added, skipped, notFound, failed, warnings,
-      message:  `${summary}\n\n${lines.join('\n')}`,
+      success: added.length > 0 || (notFound.length === 0 && failed.length === 0),
+      actor: result.actor,
+      added,
+      skipped,
+      notFound,
+      failed,
+      warnings,
+      message: `${summary}\n\n${lines.join('\n')}`,
     };
   }
 }

--- a/packages/mcp-server/src/tools/dnd5e/features.ts
+++ b/packages/mcp-server/src/tools/dnd5e/features.ts
@@ -93,16 +93,18 @@ export class DnD5eFeaturesFromCompendiumTools {
   async handleAddFeaturesFromCompendium(args: any): Promise<any> {
     const schema = z.object({
       actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
-      featureNames:    z.array(z.string().min(1)).min(1).max(50),
-      compendiumPacks: z.array(z.string().min(1)).default(['dnd5e.monsterfeatures', 'dnd5e.classfeatures']),
+      featureNames: z.array(z.string().min(1)).min(1).max(50),
+      compendiumPacks: z
+        .array(z.string().min(1))
+        .default(['dnd5e.monsterfeatures', 'dnd5e.classfeatures']),
     });
 
     const parsed = schema.parse(args);
 
     this.logger.info('Adding features to D&D 5e actor from compendium', {
       actorIdentifier: parsed.actorIdentifier,
-      featureCount:    parsed.featureNames.length,
-      packs:           parsed.compendiumPacks,
+      featureCount: parsed.featureNames.length,
+      packs: parsed.compendiumPacks,
     });
 
     try {
@@ -110,21 +112,21 @@ export class DnD5eFeaturesFromCompendiumTools {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-add-features-from-compendium requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
       const result = await this.foundryClient.query(
         'foundry-mcp-bridge.addFeaturesFromCompendium',
-        parsed,
+        parsed
       );
 
       this.logger.info('Features import complete', {
-        actorId:  result.actor?.id,
-        added:    result.added?.length,
-        skipped:  result.skipped?.length,
+        actorId: result.actor?.id,
+        added: result.added?.length,
+        skipped: result.skipped?.length,
         notFound: result.notFound?.length,
-        failed:   result.failed?.length,
+        failed: result.failed?.length,
       });
 
       return this.formatResponse(result, parsed);
@@ -132,26 +134,31 @@ export class DnD5eFeaturesFromCompendiumTools {
       this.errorHandler.handleToolError(
         error,
         'dnd5e-add-features-from-compendium',
-        'feature import',
+        'feature import'
       );
     }
   }
 
   private formatResponse(result: any, params: any): any {
-    const added    = result.added    as Array<{ name: string; packId: string; packLabel: string; itemId: string }>;
-    const skipped  = result.skipped  as Array<{ name: string; reason: string }>;
+    const added = result.added as Array<{
+      name: string;
+      packId: string;
+      packLabel: string;
+      itemId: string;
+    }>;
+    const skipped = result.skipped as Array<{ name: string; reason: string }>;
     const notFound = result.notFound as string[];
-    const failed   = result.failed   as Array<{ name: string; error: string }>;
+    const failed = result.failed as Array<{ name: string; error: string }>;
     const warnings = result.warnings as string[];
 
     const totalRequested = (params.featureNames as string[]).length;
 
     // ── Summary line ──────────────────────────────────────────────────────────
     const parts: string[] = [];
-    if (added.length > 0)    parts.push(`${added.length} added`);
-    if (skipped.length > 0)  parts.push(`${skipped.length} skipped`);
+    if (added.length > 0) parts.push(`${added.length} added`);
+    if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
     if (notFound.length > 0) parts.push(`${notFound.length} not found`);
-    if (failed.length > 0)   parts.push(`${failed.length} failed`);
+    if (failed.length > 0) parts.push(`${failed.length} failed`);
 
     const statusIcon = failed.length > 0 ? '⚠️' : notFound.length > 0 ? '🔍' : '✅';
     const summary =
@@ -201,14 +208,14 @@ export class DnD5eFeaturesFromCompendiumTools {
 
     return {
       summary,
-      success:  added.length > 0 || (notFound.length === 0 && failed.length === 0),
-      actor:    result.actor,
+      success: added.length > 0 || (notFound.length === 0 && failed.length === 0),
+      actor: result.actor,
       added,
       skipped,
       notFound,
       failed,
       warnings,
-      message:  `${summary}\n\n${lines.join('\n')}`,
+      message: `${summary}\n\n${lines.join('\n')}`,
     };
   }
 }

--- a/packages/mcp-server/src/tools/dnd5e/npc.ts
+++ b/packages/mcp-server/src/tools/dnd5e/npc.ts
@@ -9,14 +9,37 @@ import { detectGameSystem, getCachedSystemId } from '../../utils/system-detectio
 // ---------------------------------------------------------------------------
 
 const DAMAGE_CANONICAL = new Set([
-  'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
-  'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder',
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
 ]);
 
 const CONDITION_CANONICAL = new Set([
-  'blinded', 'charmed', 'deafened', 'exhaustion', 'frightened', 'grappled',
-  'incapacitated', 'invisible', 'paralyzed', 'petrified', 'poisoned',
-  'prone', 'restrained', 'stunned', 'unconscious',
+  'blinded',
+  'charmed',
+  'deafened',
+  'exhaustion',
+  'frightened',
+  'grappled',
+  'incapacitated',
+  'invisible',
+  'paralyzed',
+  'petrified',
+  'poisoned',
+  'prone',
+  'restrained',
+  'stunned',
+  'unconscious',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -39,10 +62,10 @@ function normalizeCR(input: string | number): number {
  * Formats a CR float back to the canonical display string.
  */
 function formatCR(value: number): string {
-  if (value === 0)     return '0';
+  if (value === 0) return '0';
   if (value === 0.125) return '1/8';
-  if (value === 0.25)  return '1/4';
-  if (value === 0.5)   return '1/2';
+  if (value === 0.25) return '1/4';
+  if (value === 0.5) return '1/2';
   return String(Math.round(value));
 }
 
@@ -93,9 +116,21 @@ export class DnD5eNpcTools {
             creatureType: {
               type: 'string',
               enum: [
-                'humanoid', 'undead', 'beast', 'dragon', 'aberration', 'construct',
-                'elemental', 'fey', 'fiend', 'giant', 'monstrosity', 'ooze',
-                'plant', 'celestial', 'swarm',
+                'humanoid',
+                'undead',
+                'beast',
+                'dragon',
+                'aberration',
+                'construct',
+                'elemental',
+                'fey',
+                'fiend',
+                'giant',
+                'monstrosity',
+                'ooze',
+                'plant',
+                'celestial',
+                'swarm',
               ],
               description: 'Creature type',
             },
@@ -247,16 +282,31 @@ export class DnD5eNpcTools {
                   skill: {
                     type: 'string',
                     enum: [
-                      'Acrobatics', 'Animal Handling', 'Arcana', 'Athletics', 'Deception',
-                      'History', 'Insight', 'Intimidation', 'Investigation', 'Medicine',
-                      'Nature', 'Perception', 'Performance', 'Persuasion', 'Religion',
-                      'Sleight of Hand', 'Stealth', 'Survival',
+                      'Acrobatics',
+                      'Animal Handling',
+                      'Arcana',
+                      'Athletics',
+                      'Deception',
+                      'History',
+                      'Insight',
+                      'Intimidation',
+                      'Investigation',
+                      'Medicine',
+                      'Nature',
+                      'Perception',
+                      'Performance',
+                      'Persuasion',
+                      'Religion',
+                      'Sleight of Hand',
+                      'Stealth',
+                      'Survival',
                     ],
                   },
                   proficiency: {
                     type: 'string',
                     enum: ['proficient', 'expert'],
-                    description: '"proficient" = proficiency bonus once; "expert" = double proficiency',
+                    description:
+                      '"proficient" = proficiency bonus once; "expert" = double proficiency',
                   },
                 },
                 required: ['skill', 'proficiency'],
@@ -276,13 +326,15 @@ export class DnD5eNpcTools {
             },
             damageResistances: {
               type: 'array',
-              description: 'Damage types the creature is resistant to. Same canonical set as damageImmunities.',
+              description:
+                'Damage types the creature is resistant to. Same canonical set as damageImmunities.',
               items: { type: 'string' },
               default: [],
             },
             damageVulnerabilities: {
               type: 'array',
-              description: 'Damage types the creature is vulnerable to. Same canonical set as damageImmunities.',
+              description:
+                'Damage types the creature is vulnerable to. Same canonical set as damageImmunities.',
               items: { type: 'string' },
               default: [],
             },
@@ -331,7 +383,16 @@ export class DnD5eNpcTools {
               default: '2014',
             },
           },
-          required: ['name', 'creatureType', 'size', 'cr', 'abilities', 'hpAverage', 'hpFormula', 'acMode'],
+          required: [
+            'name',
+            'creatureType',
+            'size',
+            'cr',
+            'abilities',
+            'hpAverage',
+            'hpFormula',
+            'acMode',
+          ],
         },
       },
     ];
@@ -341,27 +402,41 @@ export class DnD5eNpcTools {
     const schema = z
       .object({
         // Identity
-        name:            z.string().min(1, 'name cannot be empty'),
-        creatureType:    z.enum([
-          'humanoid', 'undead', 'beast', 'dragon', 'aberration', 'construct',
-          'elemental', 'fey', 'fiend', 'giant', 'monstrosity', 'ooze',
-          'plant', 'celestial', 'swarm',
+        name: z.string().min(1, 'name cannot be empty'),
+        creatureType: z.enum([
+          'humanoid',
+          'undead',
+          'beast',
+          'dragon',
+          'aberration',
+          'construct',
+          'elemental',
+          'fey',
+          'fiend',
+          'giant',
+          'monstrosity',
+          'ooze',
+          'plant',
+          'celestial',
+          'swarm',
         ]),
         creatureSubtype: z.string().default(''),
-        size:            z.enum(['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan']),
-        alignment:       z.string().default(''),
-        cr:              z.union([
-          z.string().regex(
-            /^\d+(\/[248])?$/,
-            'CR must be a whole number or fraction string (e.g. "0", "1/4", "1/2", "5")',
-          ),
+        size: z.enum(['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan']),
+        alignment: z.string().default(''),
+        cr: z.union([
+          z
+            .string()
+            .regex(
+              /^\d+(\/[248])?$/,
+              'CR must be a whole number or fraction string (e.g. "0", "1/4", "1/2", "5")'
+            ),
           z.number().finite().min(0),
         ]),
         // HP
         hpAverage: z.number().int().min(1),
         hpFormula: z.string().min(1, 'hpFormula cannot be empty'),
         // AC
-        acMode:  z.enum(['default', 'flat']),
+        acMode: z.enum(['default', 'flat']),
         acValue: z.number().int().min(0).max(30).optional(),
         // Abilities
         abilities: z.object({
@@ -372,55 +447,67 @@ export class DnD5eNpcTools {
           wis: z.number().int().min(1).max(30),
           cha: z.number().int().min(1).max(30),
         }),
-        savingThrows: z
-          .array(z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']))
-          .default([]),
+        savingThrows: z.array(z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha'])).default([]),
         // Movement
-        walkSpeed:   z.number().int().min(0).default(30),
-        flySpeed:    z.number().int().min(0).default(0),
-        swimSpeed:   z.number().int().min(0).default(0),
-        climbSpeed:  z.number().int().min(0).default(0),
+        walkSpeed: z.number().int().min(0).default(30),
+        flySpeed: z.number().int().min(0).default(0),
+        swimSpeed: z.number().int().min(0).default(0),
+        climbSpeed: z.number().int().min(0).default(0),
         burrowSpeed: z.number().int().min(0).default(0),
-        hover:       z.boolean().default(false),
+        hover: z.boolean().default(false),
         // Senses
-        darkvision:   z.number().int().min(0).default(0),
-        blindsight:   z.number().int().min(0).default(0),
-        tremorsense:  z.number().int().min(0).default(0),
-        truesight:    z.number().int().min(0).default(0),
+        darkvision: z.number().int().min(0).default(0),
+        blindsight: z.number().int().min(0).default(0),
+        tremorsense: z.number().int().min(0).default(0),
+        truesight: z.number().int().min(0).default(0),
         specialSenses: z.string().default(''),
         // Skills
         skills: z
           .array(
             z.object({
               skill: z.enum([
-                'Acrobatics', 'Animal Handling', 'Arcana', 'Athletics', 'Deception',
-                'History', 'Insight', 'Intimidation', 'Investigation', 'Medicine',
-                'Nature', 'Perception', 'Performance', 'Persuasion', 'Religion',
-                'Sleight of Hand', 'Stealth', 'Survival',
+                'Acrobatics',
+                'Animal Handling',
+                'Arcana',
+                'Athletics',
+                'Deception',
+                'History',
+                'Insight',
+                'Intimidation',
+                'Investigation',
+                'Medicine',
+                'Nature',
+                'Perception',
+                'Performance',
+                'Persuasion',
+                'Religion',
+                'Sleight of Hand',
+                'Stealth',
+                'Survival',
               ]),
               proficiency: z.enum(['proficient', 'expert']),
-            }),
+            })
           )
           .default([]),
         // Damage & condition traits
-        damageImmunities:      z.array(z.string()).default([]),
-        damageResistances:     z.array(z.string()).default([]),
+        damageImmunities: z.array(z.string()).default([]),
+        damageResistances: z.array(z.string()).default([]),
         damageVulnerabilities: z.array(z.string()).default([]),
-        conditionImmunities:   z.array(z.string()).default([]),
+        conditionImmunities: z.array(z.string()).default([]),
         // Languages
-        languages:       z.array(z.string()).default([]),
+        languages: z.array(z.string()).default([]),
         languagesCustom: z.string().default(''),
         // Biography & source
-        biography:   z.string().default(''),
-        sourceBook:  z.string().default(''),
-        sourcePage:  z.string().default(''),
+        biography: z.string().default(''),
+        sourceBook: z.string().default(''),
+        sourcePage: z.string().default(''),
         sourceRules: z.enum(['2014', '2024']).default('2014'),
       })
       .superRefine((data, ctx) => {
         if (data.acMode === 'flat' && data.acValue === undefined) {
           ctx.addIssue({
-            code:    z.ZodIssueCode.custom,
-            path:    ['acValue'],
+            code: z.ZodIssueCode.custom,
+            path: ['acValue'],
             message: 'acValue is required when acMode is "flat"',
           });
         }
@@ -434,9 +521,9 @@ export class DnD5eNpcTools {
     const warnings: string[] = [];
 
     const allDamageValues = [
-      ...parsed.damageImmunities.map((v) => ({ field: 'damageImmunities',      value: v })),
-      ...parsed.damageResistances.map((v) => ({ field: 'damageResistances',     value: v })),
-      ...parsed.damageVulnerabilities.map((v) => ({ field: 'damageVulnerabilities', value: v })),
+      ...parsed.damageImmunities.map(v => ({ field: 'damageImmunities', value: v })),
+      ...parsed.damageResistances.map(v => ({ field: 'damageResistances', value: v })),
+      ...parsed.damageVulnerabilities.map(v => ({ field: 'damageVulnerabilities', value: v })),
     ];
     for (const { field, value } of allDamageValues) {
       if (!DAMAGE_CANONICAL.has(value)) {
@@ -454,10 +541,10 @@ export class DnD5eNpcTools {
     }
 
     this.logger.info('Creating D&D 5e NPC', {
-      name:         parsed.name,
+      name: parsed.name,
       creatureType: parsed.creatureType,
-      cr:           parsed.cr,
-      warnings:     warnings.length,
+      cr: parsed.cr,
+      warnings: warnings.length,
     });
 
     try {
@@ -465,27 +552,20 @@ export class DnD5eNpcTools {
       if (system !== 'dnd5e') {
         throw new Error(
           `dnd5e-create-npc requires D&D 5e. ` +
-          `Detected system: "${getCachedSystemId() ?? 'unknown'}".`,
+            `Detected system: "${getCachedSystemId() ?? 'unknown'}".`
         );
       }
 
-      const result = await this.foundryClient.query(
-        'foundry-mcp-bridge.createNpcActor',
-        parsed,
-      );
+      const result = await this.foundryClient.query('foundry-mcp-bridge.createNpcActor', parsed);
 
       this.logger.info('NPC created successfully', {
-        actorId:   result.actor?.id,
+        actorId: result.actor?.id,
         actorName: result.actor?.name,
       });
 
       return this.formatResponse(result, parsed, warnings);
     } catch (error) {
-      this.errorHandler.handleToolError(
-        error,
-        'dnd5e-create-npc',
-        'NPC creation',
-      );
+      this.errorHandler.handleToolError(error, 'dnd5e-create-npc', 'NPC creation');
     }
   }
 
@@ -493,12 +573,10 @@ export class DnD5eNpcTools {
     const crStr = result.actor?.cr ?? formatCR(normalizeCR(params.cr));
 
     const abilityLine = (['str', 'dex', 'con', 'int', 'wis', 'cha'] as const)
-      .map((ab) => `${ab.toUpperCase()} ${params.abilities[ab]}`)
+      .map(ab => `${ab.toUpperCase()} ${params.abilities[ab]}`)
       .join(' / ');
 
-    const acDisplay = params.acMode === 'flat'
-      ? String(params.acValue)
-      : 'default (calculated)';
+    const acDisplay = params.acMode === 'flat' ? String(params.acValue) : 'default (calculated)';
 
     const summary = `✅ NPC "${result.actor.name}" created (CR ${crStr})`;
 
@@ -513,16 +591,17 @@ export class DnD5eNpcTools {
       lines.push(`**Folder:** ${result.actor.folder}`);
     }
 
-    const warningSection = warnings.length > 0
-      ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join('\n')}`
-      : '';
+    const warningSection =
+      warnings.length > 0
+        ? `\n\n⚠️ **Warnings (${warnings.length}):**\n${warnings.map(w => `- ${w}`).join('\n')}`
+        : '';
 
     return {
       summary,
-      success:  true,
-      actor:    result.actor,
+      success: true,
+      actor: result.actor,
       warnings,
-      message:  `${summary}\n\n${lines.join('\n')}${warningSection}`,
+      message: `${summary}\n\n${lines.join('\n')}${warningSection}`,
     };
   }
 }


### PR DESCRIPTION
Two housekeeping items folded into one PR — both pure cleanup, no behavior changes.

## Prettier sweep

Several recently-merged PRs (#41 dnd5e suite, #58 WFRP4e write tools, README updates) added or modified code without running prettier, accumulating ~1300 lines of formatting drift in the husky-enforced style. This runs \`npm run format\` across the codebase to bring everything back to the \`.prettierrc\` settings established in #39.

Affected files (10): \`data-access.ts\`, \`queries.ts\`, \`backend.ts\`, \`lock.ts\` + \`lock.test.ts\`, the three \`tools/dnd5e/\` files, \`README.md\`, \`docs/spec-create-npc.md\`.

\`format:check\` now passes across the whole codebase.

## dsa5/filters.test.ts converted to real vitest

This file has been failing with \"No test suite found\" since v0.6.1. On inspection it wasn't actually a vitest test — it was a standalone \`console.log\` script with the wrong file extension. Vitest's \`*.test.ts\` glob picked it up and rightly complained there were no test blocks.

Converted to real vitest tests covering the same cases the script was verifying via \`console.log\`:
- \`matchesDSA5Filters\` (6 cases)
- \`describeDSA5Filters\` (1)
- \`isValidDSA5Species\` (2)
- \`isValidExperienceLevel\` (2)

Net: vitest goes from \"1 failed file / 45 tests\" to **\"0 failed / 56 tests\"** with real coverage for those filter functions.

## Verification

- [x] \`npm run build\` passes
- [x] \`npm run typecheck\` passes
- [x] \`npm run format:check\` passes whole codebase
- [x] \`npm run test:mcp:schema\` passes
- [x] \`npx vitest run\`: 5/5 files pass, 56 tests, 0 failures