### PR TITLE
fix(module): honor configured serverPort for wss connections

### DIFF
--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -97,17 +97,17 @@ export class SocketBridge {
   private async connectWebSocket(): Promise<void> {
     this.activeConnectionType = 'websocket';
 
-    // Auto-detect protocol: wss for HTTPS pages, ws for HTTP
+    // Auto-detect protocol: wss for HTTPS pages, ws for HTTP.
+    // The port always comes from the configured serverPort setting, the same as
+    // the WebRTC path and everywhere else in the module. Reverse-proxy users set
+    // serverPort to whatever port their proxy exposes (e.g. 443).
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const host = this.config.serverHost;
-    // Behind a TLS reverse proxy the MCP path is served on the same origin as the page,
-    // so use the page's port. On plain HTTP (localhost) the MCP backend is a separate
-    // process on the configured port, so the page port must not be used there.
-    const sameOrigin = protocol === 'wss' && host === window.location.hostname;
-    const port = sameOrigin ? window.location.port || '443' : this.config.serverPort;
-    this.log(`Using WebSocket (${protocol}://${host}:${port}${this.config.namespace})`);
+    this.log(
+      `Using WebSocket (${protocol}://${host}:${this.config.serverPort}${this.config.namespace})`
+    );
 
-    const wsUrl = `${protocol}://${host}:${port}${this.config.namespace}`;
+    const wsUrl = `${protocol}://${host}:${this.config.serverPort}${this.config.namespace}`;
 
     return new Promise((resolve, reject) => {
       const connectTimeout = setTimeout(() => {


### PR DESCRIPTION
Follow-up to #49.

#49 added `wss://` auto-detection for HTTPS Foundry instances (good), but it also **inferred the WebSocket port from `window.location`** whenever the page hostname matched `serverHost` — silently ignoring an explicitly-configured `serverPort`.

Every other connection path in the module treats `serverPort` as the single source of truth for the port:
- WebRTC path (`socket-bridge.ts`) passes `config.serverPort` straight through
- the settings/config plumbing (`settings.ts`) does the same

Only the WebSocket path diverged. This keeps the useful half of #49 (`ws`/`wss` protocol auto-detection) and drops the port inference, so the WebSocket URL always uses `serverPort` like everywhere else.

### Behavior
- **Default localhost HTTP:** unchanged (`ws://host:serverPort`).
- **Reverse-proxy / TLS users:** set `serverPort` to whatever port the proxy exposes (e.g. `443`) via the existing setting — the same mechanism every other port in the module already uses. No new settings.
- Removes a case where an explicitly-set `serverPort` could be silently overridden.

### Notes
- No new config keys, no settings-UI changes.
- `connectWebSocket()` is only reached on HTTPS when `connectionType` is explicitly set to `websocket` (auto still routes HTTPS→WebRTC), so this targets exactly the reverse-proxy use case #49 was written for.
- Foundry module builds clean (`npm run build:foundry`).