### PR TITLE
feat: add combat, world-time, and audio tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Unreleased
+
+### New Features
+
+- **Combat tools** — damage/healing, turn & initiative control, active effects, and combatant status
+  - `apply-damage` / `apply-healing` — adjust one or more targets' HP; damage respects the game system's resistances/immunities when available, healing clamps to max; returns HP before/after per target
+  - `advance-turn` — step the active combat forward a turn/round or back a turn
+  - `set-initiative` — set an explicit initiative value or roll it for a combatant
+  - `apply-active-effect` / `remove-active-effect` — apply/remove a status condition or a custom active effect (attribute changes + durations) on an actor
+  - `get-combatant-status` — read HP/AC/movement/conditions/effects/spell-slots/consumables for one actor or all combatants (read-only)
+
+- **World tools** — game-clock control and canvas pings
+  - `advance-game-time` / `get-game-time` — advance and read the world clock, with a human-readable formatted breakdown
+  - `ping-location` — ping a coordinate or token on the canvas, optionally pulling every player's camera
+
+- **Audio tools**
+  - `play-sound` — play an audio file for the table (or GM-only) via Foundry's AudioHelper
+
+---
+
 ## v0.8.3 (2026-06-11)
 
 ### New Features

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -9928,6 +9928,349 @@ export class FoundryDataAccess {
     return { deleted: existing, total: existing.length };
   }
 
+  // ─── Combat / world / audio ────────────────────────────────────────────────
+
+  /**
+   * Resolve a reference (id or name) to a token on the current canvas and/or an
+   * actor. Prefers a matching canvas token; falls back to a world actor.
+   */
+  private resolveTokenOrActor(ref: string): { token: any; actor: any } {
+    const placeables: any[] = (canvas as any)?.tokens?.placeables ?? [];
+    const token =
+      placeables.find(t => t.id === ref) ||
+      placeables.find(t => t.name?.toLowerCase() === String(ref).toLowerCase());
+    if (token) return { token, actor: token.actor };
+
+    const actor =
+      (game.actors as any)?.get(ref) ||
+      (game.actors as any)?.find((a: any) => a.name?.toLowerCase() === String(ref).toLowerCase());
+    if (!actor) throw new Error(`No token or actor found matching "${ref}"`);
+    return { token: null, actor };
+  }
+
+  private getActorHP(actor: any): any {
+    return actor?.system?.attributes?.hp ?? {};
+  }
+
+  /**
+   * Applies HP damage or healing. Uses the system's actor.applyDamage when
+   * available (so systems like dnd5e can apply resistances/immunities by type);
+   * otherwise clamps HP directly. Healing always clamps to max.
+   */
+  async applyDamageOrHealing(refs: string[], amount: number, damageType: string): Promise<any> {
+    const results: any[] = [];
+    for (const ref of refs) {
+      const { token, actor } = this.resolveTokenOrActor(ref);
+      const hp = this.getActorHP(actor);
+      const hpBefore = hp.value;
+      const isHealing = damageType === 'healing';
+
+      if (!isHealing && typeof actor.applyDamage === 'function') {
+        // Damages-array form lets dnd5e apply resistances/immunities by type
+        try {
+          await actor.applyDamage([{ value: amount, type: damageType }]);
+        } catch (_e) {
+          await actor.applyDamage(amount);
+        }
+      } else {
+        const max = hp.max ?? 0;
+        const delta = isHealing ? amount : -amount;
+        const newValue = Math.max(0, Math.min(max, (hp.value ?? 0) + delta));
+        await actor.update({ 'system.attributes.hp.value': newValue });
+      }
+
+      const hpAfter = this.getActorHP(actor).value;
+      results.push({
+        target: token?.name ?? actor.name,
+        applied: isHealing ? hpAfter - hpBefore : hpBefore - hpAfter,
+        hpBefore,
+        hpAfter,
+      });
+    }
+    return { results };
+  }
+
+  async advanceTurn(direction: 'next-turn' | 'next-round' | 'previous-turn'): Promise<any> {
+    const combat = (game as any).combat;
+    if (!combat) throw new Error('No active combat');
+    if (direction === 'next-round') await combat.nextRound();
+    else if (direction === 'previous-turn') await combat.previousTurn();
+    else await combat.nextTurn();
+
+    const active = combat.combatant;
+    return {
+      round: combat.round,
+      turn: combat.turn,
+      activeCombatant: active
+        ? {
+            name: active.name,
+            actorId: active.actorId,
+            tokenId: active.tokenId,
+            initiative: active.initiative,
+          }
+        : null,
+    };
+  }
+
+  async setInitiative(combatantRef: string, value?: number): Promise<any> {
+    const combat = (game as any).combat;
+    if (!combat) throw new Error('No active combat');
+    const ref = String(combatantRef).toLowerCase();
+    let combatant =
+      combat.combatants.get(combatantRef) ||
+      combat.combatants.find((ct: any) => ct.name?.toLowerCase() === ref) ||
+      combat.combatants.find((ct: any) => ct.actor?.name?.toLowerCase() === ref);
+    if (!combatant) throw new Error(`No combatant found matching "${combatantRef}"`);
+
+    if (value !== undefined && value !== null) {
+      await combat.setInitiative(combatant.id, value);
+    } else {
+      await combat.rollInitiative([combatant.id]);
+    }
+    combatant = combat.combatants.get(combatant.id) ?? combatant;
+    return { combatant: combatant.name, initiative: combatant.initiative };
+  }
+
+  async applyActiveEffect(data: {
+    actor: string;
+    condition?: string;
+    effect?: {
+      label: string;
+      icon?: string;
+      changes?: Array<{ key: string; mode?: number; value: string | number }>;
+      duration?: { rounds?: number; turns?: number; seconds?: number };
+    };
+  }): Promise<any> {
+    const { actor } = this.resolveTokenOrActor(data.actor);
+
+    if (data.condition) {
+      const validIds = ((CONFIG as any).statusEffects ?? []).map((s: any) => s.id);
+      if (!validIds.includes(data.condition)) {
+        throw new Error(
+          `Unknown condition "${data.condition}". Valid conditions: ${validIds.join(', ')}`
+        );
+      }
+      await actor.toggleStatusEffect(data.condition, { active: true });
+      return { actor: actor.name, applied: data.condition, type: 'condition' };
+    }
+
+    if (data.effect?.label) {
+      const addMode = (CONST as any).ACTIVE_EFFECT_MODES?.ADD ?? 2;
+      await actor.createEmbeddedDocuments('ActiveEffect', [
+        {
+          name: data.effect.label,
+          img: data.effect.icon ?? 'icons/svg/aura.svg',
+          changes: (data.effect.changes ?? []).map(c => ({
+            key: c.key,
+            mode: c.mode ?? addMode,
+            value: String(c.value),
+          })),
+          duration: data.effect.duration ?? {},
+        },
+      ]);
+      return { actor: actor.name, applied: data.effect.label, type: 'custom' };
+    }
+
+    throw new Error('Either condition or effect (with label) is required');
+  }
+
+  async removeActiveEffect(actorRef: string, effect: string): Promise<any> {
+    const { actor } = this.resolveTokenOrActor(actorRef);
+    const ref = String(effect).toLowerCase();
+
+    // Status conditions must go through toggleStatusEffect — dnd5e status
+    // effects use fixed synthetic ids and reject direct document deletion.
+    const validIds = ((CONFIG as any).statusEffects ?? []).map((s: any) => s.id);
+    const statusId = validIds.includes(effect) ? effect : validIds.includes(ref) ? ref : null;
+    if (statusId && actor.statuses?.has(statusId)) {
+      await actor.toggleStatusEffect(statusId, { active: false });
+      return { actor: actor.name, removed: statusId };
+    }
+
+    const effectDoc =
+      actor.effects.find((e: any) => e.name?.toLowerCase() === ref) ||
+      actor.effects.find((e: any) => e.statuses?.has(effect));
+    if (effectDoc) {
+      // Custom effect: delete the document; if it's status-backed, fall back to toggle
+      try {
+        await effectDoc.delete();
+      } catch (_e) {
+        const backing = Array.from(effectDoc.statuses ?? [])[0] as string | undefined;
+        if (!backing) throw _e;
+        await actor.toggleStatusEffect(backing, { active: false });
+      }
+      return { actor: actor.name, removed: effectDoc.name };
+    }
+
+    const current = actor.effects.map((e: any) => e.name).join(', ') || 'none';
+    throw new Error(`No effect "${effect}" found on "${actor.name}". Current effects: ${current}`);
+  }
+
+  private buildCombatantStatus(actor: any, token: any, combatant: any): any {
+    const hp = this.getActorHP(actor);
+    const attrs = actor?.system?.attributes ?? {};
+    const status: any = {
+      name: token?.name ?? actor.name,
+      actorId: actor.id,
+      hp: { value: hp.value, max: hp.max, temp: hp.temp },
+      ac: attrs.ac?.value,
+      movement: {},
+      conditions: Array.from(actor.statuses ?? []),
+      effects: actor.effects.map((e: any) => ({
+        name: e.name,
+        duration: e.duration?.remaining ?? e.duration?.rounds ?? undefined,
+      })),
+      consumables: [],
+    };
+    if (token) status.tokenId = token.id;
+
+    const movement = attrs.movement ?? {};
+    for (const key of ['walk', 'fly', 'swim']) {
+      if (movement[key]) status.movement[key] = movement[key];
+    }
+
+    const spells: Record<string, any> = actor?.system?.spells ?? {};
+    const spellSlots: Record<string, any> = {};
+    for (const [level, slot] of Object.entries(spells)) {
+      if (slot && typeof slot === 'object' && (slot.max ?? 0) > 0) {
+        spellSlots[level] = { value: slot.value, max: slot.max };
+      }
+    }
+    if (Object.keys(spellSlots).length > 0) status.spellSlots = spellSlots;
+
+    for (const item of actor.items) {
+      const usesMax = item.system?.uses?.max;
+      if (item.type === 'consumable' || usesMax) {
+        const entry: any = { name: item.name };
+        if (item.system?.quantity !== undefined) entry.quantity = item.system.quantity;
+        if (usesMax) entry.uses = { value: item.system.uses.value, max: usesMax };
+        status.consumables.push(entry);
+      }
+    }
+
+    if (combatant) {
+      status.initiative = combatant.initiative;
+      status.isCurrentTurn = (game as any).combat?.combatant?.id === combatant.id;
+    }
+    return status;
+  }
+
+  async getCombatantStatus(data: { actor?: string; all?: boolean }): Promise<any> {
+    if (data.all) {
+      const combat = (game as any).combat;
+      if (!combat) throw new Error('No active combat');
+      return {
+        round: combat.round,
+        turn: combat.turn,
+        combatants: combat.combatants
+          .filter((ct: any) => ct.actor)
+          .map((ct: any) => this.buildCombatantStatus(ct.actor, ct.token?.object ?? null, ct)),
+      };
+    }
+    if (!data.actor) throw new Error('Either actor or all: true is required');
+    const { token, actor } = this.resolveTokenOrActor(data.actor);
+    const combatant =
+      (game as any).combat?.combatants?.find(
+        (ct: any) => ct.actorId === actor.id || (token && ct.tokenId === token.id)
+      ) ?? null;
+    return this.buildCombatantStatus(actor, token, combatant);
+  }
+
+  private formatWorldTime(totalSeconds: number): string {
+    const seconds = Math.floor(Math.abs(totalSeconds));
+    const sign = totalSeconds < 0 ? '-' : '';
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    const parts: string[] = [];
+    if (d) parts.push(`${d}d`);
+    if (h) parts.push(`${h}h`);
+    if (m) parts.push(`${m}m`);
+    if (s || parts.length === 0) parts.push(`${s}s`);
+    return sign + parts.join(' ');
+  }
+
+  async advanceGameTime(
+    amount: number,
+    unit: 'seconds' | 'rounds' | 'minutes' | 'hours' | 'days'
+  ): Promise<any> {
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+      throw new Error('amount must be a positive number');
+    }
+    const unitSeconds: Record<string, number> = {
+      seconds: 1,
+      rounds: 6,
+      minutes: 60,
+      hours: 3600,
+      days: 86400,
+    };
+    if (!unitSeconds[unit]) {
+      throw new Error(`unit must be one of: ${Object.keys(unitSeconds).join(', ')}`);
+    }
+    const seconds = Math.round(amount * unitSeconds[unit]);
+    await (game as any).time.advance(seconds);
+    const worldTime = (game as any).time.worldTime;
+    return { advanced: seconds, worldTime, formatted: this.formatWorldTime(worldTime) };
+  }
+
+  getGameTime(): any {
+    const worldTime = (game as any).time.worldTime;
+    return { worldTime, formatted: this.formatWorldTime(worldTime) };
+  }
+
+  pingLocation(data: { x?: number; y?: number; token?: string; pull?: boolean }): any {
+    let x: number;
+    let y: number;
+    if (data?.token) {
+      const { token } = this.resolveTokenOrActor(data.token);
+      if (!token) {
+        throw new Error(`"${data.token}" matched an actor but no token on the current scene`);
+      }
+      x = token.center.x;
+      y = token.center.y;
+    } else if (typeof data?.x === 'number' && typeof data?.y === 'number') {
+      x = data.x;
+      y = data.y;
+    } else {
+      throw new Error('Provide either both x and y coordinates or a token reference');
+    }
+    const pull = data?.pull === true;
+    const c: any = canvas as any;
+    // Fire-and-forget: the ping promise resolves only when the ANIMATION
+    // completes, and animations pause in a backgrounded tab — awaiting hangs
+    // the query. The ping is broadcast immediately either way.
+    if (typeof c?.ping === 'function') {
+      Promise.resolve(c.ping({ x, y }, { pull })).catch(() => {});
+    } else if (typeof c?.controls?.ping === 'function') {
+      Promise.resolve(c.controls.ping({ x, y }, { pull })).catch(() => {});
+    } else {
+      throw new Error('Canvas ping is not available in this Foundry version');
+    }
+    return { pinged: { x, y } };
+  }
+
+  async playSound(data: { file: string; volume?: number; forEveryone?: boolean }): Promise<any> {
+    let volume = typeof data.volume === 'number' ? data.volume : 0.8;
+    volume = Math.min(Math.max(volume, 0), 1);
+    const forEveryone = data.forEveryone !== false;
+    // Foundry v13 namespaced AudioHelper with fallback for older versions
+    const AudioHelperClass =
+      (foundry as any)?.audio?.AudioHelper ?? (globalThis as any).AudioHelper;
+    if (!AudioHelperClass?.play) {
+      throw new Error('AudioHelper is not available in this Foundry version');
+    }
+    // Fire-and-forget: do not await playback. The browser can keep the audio
+    // context suspended until a user gesture, which would otherwise hang the
+    // request indefinitely. Mirrors ping-location's non-blocking approach.
+    void Promise.resolve(
+      AudioHelperClass.play({ src: data.file, volume, autoplay: true, loop: false }, forEveryone)
+    ).catch((err: unknown) => {
+      console.warn(`foundry-mcp-bridge play-sound failed: ${String(err)}`);
+    });
+    return { played: data.file };
+  }
+
   // ─── mgt2e ──────────────────────────────────────────────────────────────────
 }
 

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -69,6 +69,25 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.request-player-rolls`] =
       this.handleRequestPlayerRolls.bind(this);
 
+    // Core combat tools
+    CONFIG.queries[`${modulePrefix}.apply-damage`] = this.handleApplyDamage.bind(this);
+    CONFIG.queries[`${modulePrefix}.apply-healing`] = this.handleApplyHealing.bind(this);
+    CONFIG.queries[`${modulePrefix}.advance-turn`] = this.handleAdvanceTurn.bind(this);
+    CONFIG.queries[`${modulePrefix}.set-initiative`] = this.handleSetInitiative.bind(this);
+    CONFIG.queries[`${modulePrefix}.apply-active-effect`] = this.handleApplyActiveEffect.bind(this);
+    CONFIG.queries[`${modulePrefix}.remove-active-effect`] =
+      this.handleRemoveActiveEffect.bind(this);
+    CONFIG.queries[`${modulePrefix}.get-combatant-status`] =
+      this.handleGetCombatantStatus.bind(this);
+
+    // Core world tools
+    CONFIG.queries[`${modulePrefix}.advance-game-time`] = this.handleAdvanceGameTime.bind(this);
+    CONFIG.queries[`${modulePrefix}.get-game-time`] = this.handleGetGameTime.bind(this);
+    CONFIG.queries[`${modulePrefix}.ping-location`] = this.handlePingLocation.bind(this);
+
+    // Core audio tools
+    CONFIG.queries[`${modulePrefix}.play-sound`] = this.handlePlaySound.bind(this);
+
     // Enhanced creature index for campaign analysis
     CONFIG.queries[`${modulePrefix}.getEnhancedCreatureIndex`] =
       this.handleGetEnhancedCreatureIndex.bind(this);
@@ -2064,5 +2083,209 @@ export class QueryHandlers {
     if (!gmCheck.allowed) return { error: 'Access denied', success: false };
     this.dataAccess.validateFoundryState();
     return this.dataAccess.deleteActorItems(data.actorIdentifier, data.itemIds);
+  }
+
+  // ===== CORE COMBAT HANDLERS =====
+
+  private async handleApplyDamage(data: {
+    targets: string[];
+    amount: number;
+    damageType?: string;
+    half?: boolean;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!Array.isArray(data.targets) || data.targets.length === 0) {
+        throw new Error('targets is required');
+      }
+      if (typeof data.amount !== 'number' || data.amount <= 0) {
+        throw new Error('amount must be a positive number');
+      }
+      const amount = data.half ? Math.floor(data.amount / 2) : data.amount;
+      return await this.dataAccess.applyDamageOrHealing(
+        data.targets,
+        amount,
+        data.damageType ?? 'bludgeoning'
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to apply damage: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleApplyHealing(data: { targets: string[]; amount: number }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!Array.isArray(data.targets) || data.targets.length === 0) {
+        throw new Error('targets is required');
+      }
+      if (typeof data.amount !== 'number' || data.amount <= 0) {
+        throw new Error('amount must be a positive number');
+      }
+      return await this.dataAccess.applyDamageOrHealing(data.targets, data.amount, 'healing');
+    } catch (error) {
+      throw new Error(
+        `Failed to apply healing: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleAdvanceTurn(data: {
+    direction?: 'next-turn' | 'next-round' | 'previous-turn';
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      return await this.dataAccess.advanceTurn(data.direction ?? 'next-turn');
+    } catch (error) {
+      throw new Error(
+        `Failed to advance turn: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleSetInitiative(data: { combatant: string; value?: number }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!data.combatant) {
+        throw new Error('combatant is required');
+      }
+      return await this.dataAccess.setInitiative(data.combatant, data.value);
+    } catch (error) {
+      throw new Error(
+        `Failed to set initiative: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleApplyActiveEffect(data: {
+    actor: string;
+    condition?: string;
+    effect?: {
+      label: string;
+      icon?: string;
+      changes?: Array<{ key: string; mode?: number; value: string | number }>;
+      duration?: { rounds?: number; turns?: number; seconds?: number };
+    };
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!data.actor) {
+        throw new Error('actor is required');
+      }
+      return await this.dataAccess.applyActiveEffect(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to apply active effect: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleRemoveActiveEffect(data: { actor: string; effect: string }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!data.actor || !data.effect) {
+        throw new Error('actor and effect are required');
+      }
+      return await this.dataAccess.removeActiveEffect(data.actor, data.effect);
+    } catch (error) {
+      throw new Error(
+        `Failed to remove active effect: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  // Read-only: skip the GM gate (per contract, get-*/read tools are ungated).
+  private async handleGetCombatantStatus(data: { actor?: string; all?: boolean }): Promise<any> {
+    try {
+      this.dataAccess.validateFoundryState();
+      return await this.dataAccess.getCombatantStatus(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to get combatant status: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  // ===== CORE WORLD HANDLERS =====
+
+  private async handleAdvanceGameTime(data: {
+    amount: number;
+    unit: 'seconds' | 'rounds' | 'minutes' | 'hours' | 'days';
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      return await this.dataAccess.advanceGameTime(data.amount, data.unit);
+    } catch (error) {
+      throw new Error(
+        `Failed to advance game time: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  // Read-only: skip the GM gate (per contract, get-*/read tools are ungated).
+  private async handleGetGameTime(_data: unknown): Promise<any> {
+    try {
+      this.dataAccess.validateFoundryState();
+      return this.dataAccess.getGameTime();
+    } catch (error) {
+      throw new Error(
+        `Failed to get game time: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handlePingLocation(data: {
+    x?: number;
+    y?: number;
+    token?: string;
+    pull?: boolean;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      return this.dataAccess.pingLocation(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to ping location: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  // ===== CORE AUDIO HANDLERS =====
+
+  private async handlePlaySound(data: {
+    file: string;
+    volume?: number;
+    forEveryone?: boolean;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!data?.file || typeof data.file !== 'string') {
+        throw new Error('file parameter is required and must be a string');
+      }
+      return await this.dataAccess.playSound(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to play sound: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
   }
 }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -34,6 +34,9 @@ import { CampaignManagementTools } from './tools/campaign-management.js';
 import { OwnershipTools } from './tools/ownership.js';
 import { WFRP4eUpdateActorTools } from './tools/wfrp4e/update-actor.js';
 import { WFRP4eAddItemsTools } from './tools/wfrp4e/add-items.js';
+import { CombatTools } from './tools/combat-tools.js';
+import { WorldTools } from './tools/world-tools.js';
+import { AudioTools } from './tools/audio-tools.js';
 
 import { MapGenerationTools } from './tools/map-generation.js';
 
@@ -1216,6 +1219,10 @@ async function startBackend(): Promise<void> {
   const wfrp4eUpdateActorTools = new WFRP4eUpdateActorTools({ foundryClient, logger });
   const wfrp4eAddItemsTools = new WFRP4eAddItemsTools({ foundryClient, logger });
 
+  const combatTools = new CombatTools({ foundryClient, logger });
+  const worldTools = new WorldTools({ foundryClient, logger });
+  const audioTools = new AudioTools({ foundryClient, logger });
+
   // Initialize mapgen-style backend components for map generation
   let mapGenerationJobQueue: any = null;
   let mapGenerationComfyUIClient: any = null;
@@ -1443,6 +1450,12 @@ async function startBackend(): Promise<void> {
     ...tokenManipulationTools.getToolDefinitions(),
 
     ...mapGenerationTools.getToolDefinitions(),
+
+    ...combatTools.getToolDefinitions(),
+
+    ...worldTools.getToolDefinitions(),
+
+    ...audioTools.getToolDefinitions(),
   ];
 
   // Start Foundry connector (owns app port 31415)
@@ -1664,6 +1677,67 @@ async function startBackend(): Promise<void> {
 
                 case 'request-player-rolls':
                   result = await diceRollTools.handleRequestPlayerRolls(args);
+
+                  break;
+
+                // Core combat tools
+
+                case 'apply-damage':
+                  result = await combatTools.handleApplyDamage(args);
+
+                  break;
+
+                case 'apply-healing':
+                  result = await combatTools.handleApplyHealing(args);
+
+                  break;
+
+                case 'advance-turn':
+                  result = await combatTools.handleAdvanceTurn(args);
+
+                  break;
+
+                case 'set-initiative':
+                  result = await combatTools.handleSetInitiative(args);
+
+                  break;
+
+                case 'apply-active-effect':
+                  result = await combatTools.handleApplyActiveEffect(args);
+
+                  break;
+
+                case 'remove-active-effect':
+                  result = await combatTools.handleRemoveActiveEffect(args);
+
+                  break;
+
+                case 'get-combatant-status':
+                  result = await combatTools.handleGetCombatantStatus(args);
+
+                  break;
+
+                // Core world tools
+
+                case 'advance-game-time':
+                  result = await worldTools.handleAdvanceGameTime(args);
+
+                  break;
+
+                case 'get-game-time':
+                  result = await worldTools.handleGetGameTime(args);
+
+                  break;
+
+                case 'ping-location':
+                  result = await worldTools.handlePingLocation(args);
+
+                  break;
+
+                // Core audio tools
+
+                case 'play-sound':
+                  result = await audioTools.handlePlaySound(args);
 
                   break;
 

--- a/packages/mcp-server/src/tools/audio-tools.test.ts
+++ b/packages/mcp-server/src/tools/audio-tools.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Core audio tool — schema advertisement + bridge query-forwarding tests.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { AudioTools } from './audio-tools.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ ok: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new AudioTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('AudioTools.getToolDefinitions', () => {
+  it('advertises play-sound with a required file', () => {
+    const [def] = makeTools().tools.getToolDefinitions();
+    expect(def.name).toBe('play-sound');
+    expect(def.inputSchema.required).toEqual(['file']);
+  });
+});
+
+describe('AudioTools forwarding', () => {
+  it('forwards play-sound params to the bridge', async () => {
+    const { tools, query } = makeTools();
+    await tools.handlePlaySound({ file: 'sounds/cannon.ogg', volume: 0.5, forEveryone: false });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.play-sound', {
+      file: 'sounds/cannon.ogg',
+      volume: 0.5,
+      forEveryone: false,
+    });
+  });
+
+  it('rejects a missing file before querying', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handlePlaySound({})).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-range volume', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handlePlaySound({ file: 'a.ogg', volume: 5 })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/audio-tools.ts
+++ b/packages/mcp-server/src/tools/audio-tools.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+interface AudioToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+/**
+ * Audio tool: play a sound file to the GM or all clients via Foundry's AudioHelper.
+ */
+export class AudioTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor(options: AudioToolsOptions) {
+    this.foundryClient = options.foundryClient;
+    this.logger = options.logger.child({ component: 'AudioTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'play-sound',
+        description:
+          'Play an audio file — sound effect or music sting — for the table. By default everyone hears it; set forEveryone: false for a GM-only preview. Cosmetic/atmospheric only; failures never block game state.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            file: {
+              type: 'string',
+              description: 'Audio file path (e.g. "sounds/cannon-blast.ogg")',
+            },
+            volume: {
+              type: 'number',
+              minimum: 0,
+              maximum: 1,
+              description: 'Playback volume from 0 to 1 (default: 0.8)',
+            },
+            forEveryone: {
+              type: 'boolean',
+              description:
+                'If true, play for all connected players; if false, only for the GM (default: true)',
+            },
+          },
+          required: ['file'],
+        },
+      },
+    ];
+  }
+
+  async handlePlaySound(args: any) {
+    const schema = z.object({
+      file: z.string().min(1),
+      volume: z.number().min(0).max(1).optional(),
+      forEveryone: z.boolean().optional(),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Playing sound', {
+      file: parsed.file,
+      volume: parsed.volume,
+      forEveryone: parsed.forEveryone,
+    });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.play-sound', parsed);
+    } catch (error) {
+      this.logger.error('Failed to play sound', error);
+      throw new Error(
+        `Failed to play sound: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/combat-tools.test.ts
+++ b/packages/mcp-server/src/tools/combat-tools.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Core combat tools — schema advertisement + bridge query-forwarding tests.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { CombatTools } from './combat-tools.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ ok: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new CombatTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('CombatTools.getToolDefinitions', () => {
+  it('advertises the seven core combat tools', () => {
+    const names = makeTools()
+      .tools.getToolDefinitions()
+      .map(d => d.name);
+    expect(names).toEqual([
+      'apply-damage',
+      'apply-healing',
+      'advance-turn',
+      'set-initiative',
+      'apply-active-effect',
+      'remove-active-effect',
+      'get-combatant-status',
+    ]);
+  });
+
+  it('requires targets and amount for apply-damage', () => {
+    const [def] = makeTools().tools.getToolDefinitions();
+    expect(def.inputSchema.required).toEqual(['targets', 'amount']);
+  });
+});
+
+describe('CombatTools forwarding', () => {
+  it('forwards apply-damage params to the bridge', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleApplyDamage({
+      targets: ['Goblin'],
+      amount: 7,
+      damageType: 'fire',
+      half: true,
+    });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.apply-damage', {
+      targets: ['Goblin'],
+      amount: 7,
+      damageType: 'fire',
+      half: true,
+    });
+  });
+
+  it('rejects non-positive damage amounts before querying', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handleApplyDamage({ targets: ['Goblin'], amount: -1 })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('forwards apply-healing params to the bridge', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleApplyHealing({ targets: ['Hero'], amount: 5 });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.apply-healing', {
+      targets: ['Hero'],
+      amount: 5,
+    });
+  });
+
+  it('defaults advance-turn direction to undefined (bridge applies next-turn)', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleAdvanceTurn({});
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.advance-turn', { direction: undefined });
+  });
+
+  it('forwards set-initiative with an explicit value', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleSetInitiative({ combatant: 'Goblin', value: 15 });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.set-initiative', {
+      combatant: 'Goblin',
+      value: 15,
+    });
+  });
+
+  it('forwards a condition on apply-active-effect', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleApplyActiveEffect({ actor: 'Hero', condition: 'prone' });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.apply-active-effect', {
+      actor: 'Hero',
+      condition: 'prone',
+    });
+  });
+
+  it('rejects apply-active-effect with both condition and effect', async () => {
+    const { tools, query } = makeTools();
+    await expect(
+      tools.handleApplyActiveEffect({ actor: 'Hero', condition: 'prone', effect: { label: 'X' } })
+    ).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('forwards remove-active-effect', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleRemoveActiveEffect({ actor: 'Hero', effect: 'prone' });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.remove-active-effect', {
+      actor: 'Hero',
+      effect: 'prone',
+    });
+  });
+
+  it('forwards get-combatant-status for a single actor', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleGetCombatantStatus({ actor: 'Hero' });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.get-combatant-status', {
+      actor: 'Hero',
+    });
+  });
+
+  it('rejects get-combatant-status with neither actor nor all', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handleGetCombatantStatus({})).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/combat-tools.ts
+++ b/packages/mcp-server/src/tools/combat-tools.ts
@@ -1,0 +1,373 @@
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+interface CombatToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+/**
+ * Combat tools: damage/healing, turn and initiative control, active-effect
+ * management, and combatant status. Mutating tools are GM-gated in the bridge;
+ * get-combatant-status is read-only.
+ */
+export class CombatTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor(options: CombatToolsOptions) {
+    this.foundryClient = options.foundryClient;
+    this.logger = options.logger.child({ component: 'CombatTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'apply-damage',
+        description:
+          'Apply a flat amount of damage to one or more targets, respecting resistances, immunities, and vulnerabilities via the game system when available. Use for environmental damage, traps, narrative damage, or manual adjustments. Returns HP before/after per target.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            targets: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Target token/actor references (IDs or names)',
+            },
+            amount: {
+              type: 'number',
+              description: 'Damage amount before resistances (positive number)',
+            },
+            damageType: {
+              type: 'string',
+              description:
+                'Damage type for resistance/immunity calculation, e.g. "fire", "slashing", "necrotic" (default: "bludgeoning")',
+            },
+            half: {
+              type: 'boolean',
+              description:
+                'If true, apply half damage rounded down (e.g. a successful save against a breath weapon)',
+            },
+          },
+          required: ['targets', 'amount'],
+        },
+      },
+      {
+        name: 'apply-healing',
+        description:
+          'Apply healing to one or more targets, clamped to their HP maximum. Returns HP before/after per target. Use for potions, spells resolved narratively, short-rest recovery, or manual corrections.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            targets: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Target token/actor references (IDs or names)',
+            },
+            amount: {
+              type: 'number',
+              description: 'Healing amount (positive number)',
+            },
+          },
+          required: ['targets', 'amount'],
+        },
+      },
+      {
+        name: 'advance-turn',
+        description:
+          'Advance the active combat encounter to the next turn, next round, or back to the previous turn. Turn-based effect durations tick automatically. Returns the new round, turn index, and the now-active combatant. Errors if no combat is active.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            direction: {
+              type: 'string',
+              enum: ['next-turn', 'next-round', 'previous-turn'],
+              description: 'Which way to advance (default: "next-turn")',
+            },
+          },
+        },
+      },
+      {
+        name: 'set-initiative',
+        description:
+          "Set or roll initiative for a combatant in the active combat. Provide a value to set it directly; omit the value to roll initiative using the combatant's own modifiers. Returns the resulting initiative score.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            combatant: {
+              type: 'string',
+              description: 'Combatant reference: combatant name, combatant ID, or actor name',
+            },
+            value: {
+              type: 'number',
+              description: 'Initiative score to set. Omit to roll initiative automatically.',
+            },
+          },
+          required: ['combatant'],
+        },
+      },
+      {
+        name: 'apply-active-effect',
+        description:
+          'Apply a condition or custom active effect to an actor. Provide exactly one of "condition" or "effect". Conditions (e.g. "prone", "poisoned", "restrained") are system status effects. Custom effects support attribute changes (via active-effect change keys) and round/turn/second durations that expire with combat tracking.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actor: {
+              type: 'string',
+              description: 'Target actor: token ID, token name, actor ID, or actor name',
+            },
+            condition: {
+              type: 'string',
+              description:
+                'Status effect ID to apply (e.g. "prone", "poisoned", "restrained"). Mutually exclusive with "effect". Invalid ids return an error listing the valid ones.',
+            },
+            effect: {
+              type: 'object',
+              description: 'Custom active effect definition. Mutually exclusive with "condition".',
+              properties: {
+                label: { type: 'string', description: 'Display name of the effect' },
+                icon: {
+                  type: 'string',
+                  description: 'Icon image path (default: "icons/svg/aura.svg")',
+                },
+                changes: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      key: {
+                        type: 'string',
+                        description: 'Attribute key to modify, e.g. "system.attributes.ac.bonus"',
+                      },
+                      mode: {
+                        type: 'number',
+                        description: 'Active effect mode (default: 2 = ADD)',
+                      },
+                      value: { description: 'Change value (string or number)' },
+                    },
+                    required: ['key', 'value'],
+                  },
+                  description: 'Attribute changes applied while the effect is active',
+                },
+                duration: {
+                  type: 'object',
+                  properties: {
+                    rounds: { type: 'number', description: 'Duration in combat rounds' },
+                    turns: { type: 'number', description: 'Duration in combat turns' },
+                    seconds: { type: 'number', description: 'Duration in world-time seconds' },
+                  },
+                  description: 'Effect duration; omit for indefinite',
+                },
+              },
+              required: ['label'],
+            },
+          },
+          required: ['actor'],
+        },
+      },
+      {
+        name: 'remove-active-effect',
+        description:
+          'Remove a condition or active effect from an actor by effect name (case-insensitive) or status effect ID (e.g. "prone"). Returns what was removed.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actor: {
+              type: 'string',
+              description: 'Target actor: token ID, token name, actor ID, or actor name',
+            },
+            effect: {
+              type: 'string',
+              description: 'Effect label (case-insensitive) or status effect ID to remove',
+            },
+          },
+          required: ['actor', 'effect'],
+        },
+      },
+      {
+        name: 'get-combatant-status',
+        description:
+          'The sensor tool: read the full tactical state of one actor or every combatant before deciding an action. Returns HP (value/max/temp), AC, movement, active conditions and effects (with remaining durations), spell slots, consumable items, initiative, and whose turn it is. Provide exactly one of "actor" (any actor, combat not required) or "all: true" (requires an active combat; also returns round and turn).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actor: {
+              type: 'string',
+              description:
+                'Single actor to inspect: token ID, token name, actor ID, or actor name. Mutually exclusive with "all".',
+            },
+            all: {
+              type: 'boolean',
+              description:
+                'If true, return status for every combatant in the active combat plus round/turn info. Mutually exclusive with "actor".',
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  async handleApplyDamage(args: any) {
+    const schema = z.object({
+      targets: z.array(z.string().min(1)).min(1),
+      amount: z.number().positive('amount must be a positive number'),
+      damageType: z.string().optional(),
+      half: z.boolean().optional(),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Applying damage', {
+      targetCount: parsed.targets.length,
+      amount: parsed.amount,
+      damageType: parsed.damageType,
+      half: parsed.half,
+    });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.apply-damage', parsed);
+    } catch (error) {
+      this.logger.error('Failed to apply damage', error);
+      throw new Error(
+        `Failed to apply damage: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleApplyHealing(args: any) {
+    const schema = z.object({
+      targets: z.array(z.string().min(1)).min(1),
+      amount: z.number().positive('amount must be a positive number'),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Applying healing', {
+      targetCount: parsed.targets.length,
+      amount: parsed.amount,
+    });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.apply-healing', parsed);
+    } catch (error) {
+      this.logger.error('Failed to apply healing', error);
+      throw new Error(
+        `Failed to apply healing: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleAdvanceTurn(args: any) {
+    const schema = z.object({
+      direction: z.enum(['next-turn', 'next-round', 'previous-turn']).optional(),
+    });
+    const { direction } = schema.parse(args ?? {});
+    this.logger.info('Advancing turn', { direction: direction || 'next-turn' });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.advance-turn', { direction });
+    } catch (error) {
+      this.logger.error('Failed to advance turn', error);
+      throw new Error(
+        `Failed to advance turn: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleSetInitiative(args: any) {
+    const schema = z.object({
+      combatant: z.string().min(1),
+      value: z.number().optional(),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Setting initiative', { combatant: parsed.combatant, value: parsed.value });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.set-initiative', parsed);
+    } catch (error) {
+      this.logger.error('Failed to set initiative', error);
+      throw new Error(
+        `Failed to set initiative for "${parsed.combatant}": ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleApplyActiveEffect(args: any) {
+    const schema = z
+      .object({
+        actor: z.string().min(1),
+        condition: z.string().min(1).optional(),
+        effect: z
+          .object({
+            label: z.string().min(1),
+            icon: z.string().optional(),
+            changes: z
+              .array(
+                z.object({
+                  key: z.string().min(1),
+                  mode: z.number().optional(),
+                  value: z.union([z.string(), z.number()]),
+                })
+              )
+              .optional(),
+            duration: z
+              .object({
+                rounds: z.number().optional(),
+                turns: z.number().optional(),
+                seconds: z.number().optional(),
+              })
+              .optional(),
+          })
+          .optional(),
+      })
+      .refine(data => (data.condition !== undefined) !== (data.effect !== undefined), {
+        message: 'Provide exactly one of "condition" or "effect"',
+      });
+    const parsed = schema.parse(args);
+    this.logger.info('Applying active effect', {
+      actor: parsed.actor,
+      condition: parsed.condition,
+      effectLabel: parsed.effect?.label,
+    });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.apply-active-effect', parsed);
+    } catch (error) {
+      this.logger.error('Failed to apply active effect', error);
+      throw new Error(
+        `Failed to apply active effect to "${parsed.actor}": ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleRemoveActiveEffect(args: any) {
+    const schema = z.object({
+      actor: z.string().min(1),
+      effect: z.string().min(1),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Removing active effect', { actor: parsed.actor, effect: parsed.effect });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.remove-active-effect', parsed);
+    } catch (error) {
+      this.logger.error('Failed to remove active effect', error);
+      throw new Error(
+        `Failed to remove effect "${parsed.effect}" from "${parsed.actor}": ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleGetCombatantStatus(args: any) {
+    const schema = z
+      .object({
+        actor: z.string().min(1).optional(),
+        all: z.boolean().optional(),
+      })
+      .refine(data => (data.actor !== undefined) !== (data.all === true), {
+        message: 'Provide exactly one of "actor" or "all: true"',
+      });
+    const parsed = schema.parse(args ?? {});
+    this.logger.info('Getting combatant status', { actor: parsed.actor, all: parsed.all });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.get-combatant-status', parsed);
+    } catch (error) {
+      this.logger.error('Failed to get combatant status', error);
+      throw new Error(
+        `Failed to get combatant status: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/world-tools.test.ts
+++ b/packages/mcp-server/src/tools/world-tools.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Core world tools — schema advertisement + bridge query-forwarding tests.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { WorldTools } from './world-tools.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ ok: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new WorldTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('WorldTools.getToolDefinitions', () => {
+  it('advertises the three core world tools', () => {
+    const names = makeTools()
+      .tools.getToolDefinitions()
+      .map(d => d.name);
+    expect(names).toEqual(['advance-game-time', 'get-game-time', 'ping-location']);
+  });
+});
+
+describe('WorldTools forwarding', () => {
+  it('forwards advance-game-time params to the bridge', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleAdvanceGameTime({ amount: 10, unit: 'minutes' });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.advance-game-time', {
+      amount: 10,
+      unit: 'minutes',
+    });
+  });
+
+  it('rejects a non-positive amount before querying', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handleAdvanceGameTime({ amount: 0, unit: 'hours' })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('forwards get-game-time with an empty payload', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleGetGameTime({});
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.get-game-time', {});
+  });
+
+  it('forwards ping-location by token', async () => {
+    const { tools, query } = makeTools();
+    await tools.handlePingLocation({ token: 'Hero', pull: true });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.ping-location', {
+      token: 'Hero',
+      pull: true,
+    });
+  });
+
+  it('forwards ping-location by coordinates', async () => {
+    const { tools, query } = makeTools();
+    await tools.handlePingLocation({ x: 100, y: 200 });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.ping-location', { x: 100, y: 200 });
+  });
+
+  it('rejects a partial coordinate + token mix', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handlePingLocation({ x: 100, token: 'Hero' })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/world-tools.ts
+++ b/packages/mcp-server/src/tools/world-tools.ts
@@ -1,0 +1,155 @@
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+interface WorldToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+/**
+ * World tools: game-clock control (advance and read world time) and canvas pings.
+ */
+export class WorldTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor(options: WorldToolsOptions) {
+    this.foundryClient = options.foundryClient;
+    this.logger = options.logger.child({ component: 'WorldTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'advance-game-time',
+        description:
+          'Advance the world clock by a positive amount of seconds, rounds (6s each), minutes, hours, or days — for rests, travel legs, or downtime. Returns the seconds advanced, the new world time, and a human-readable formatted string.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            amount: {
+              type: 'number',
+              description: 'How much time to advance (must be positive)',
+            },
+            unit: {
+              type: 'string',
+              enum: ['seconds', 'rounds', 'minutes', 'hours', 'days'],
+              description: 'Unit of the amount (rounds = 6 seconds each)',
+            },
+          },
+          required: ['amount', 'unit'],
+        },
+      },
+      {
+        name: 'get-game-time',
+        description:
+          'Read the current world clock: raw world time in seconds plus a human-readable days/hours/minutes/seconds breakdown. Use before advance-game-time to know where the clock stands, or to report in-game elapsed time to the table.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'ping-location',
+        description:
+          "Ping a spot on the canvas to direct player attention — the animated ripple every player sees. Target it with exact pixel coordinates (x + y) OR a token reference (pings the token's center) — provide exactly one of the two. Set pull: true to also drag every player's camera to the pinged spot.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            x: {
+              type: 'number',
+              description:
+                'X pixel coordinate to ping. Must be provided together with "y". Mutually exclusive with "token".',
+            },
+            y: {
+              type: 'number',
+              description:
+                'Y pixel coordinate to ping. Must be provided together with "x". Mutually exclusive with "token".',
+            },
+            token: {
+              type: 'string',
+              description:
+                'Token reference (ID or name) — pings the token\'s center. Mutually exclusive with "x"/"y".',
+            },
+            pull: {
+              type: 'boolean',
+              description:
+                "If true, pull every player's view to the pinged location (default: false)",
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  async handleAdvanceGameTime(args: any) {
+    const schema = z.object({
+      amount: z.number().positive(),
+      unit: z.enum(['seconds', 'rounds', 'minutes', 'hours', 'days']),
+    });
+    const parsed = schema.parse(args);
+    this.logger.info('Advancing game time', { amount: parsed.amount, unit: parsed.unit });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.advance-game-time', parsed);
+    } catch (error) {
+      this.logger.error('Failed to advance game time', error);
+      throw new Error(
+        `Failed to advance game time: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleGetGameTime(args: any) {
+    const schema = z.object({});
+    const parsed = schema.parse(args ?? {});
+    this.logger.info('Getting game time');
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.get-game-time', parsed);
+    } catch (error) {
+      this.logger.error('Failed to get game time', error);
+      throw new Error(
+        `Failed to get game time: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handlePingLocation(args: any) {
+    const schema = z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+        token: z.string().min(1).optional(),
+        pull: z.boolean().optional(),
+      })
+      .refine(
+        data => {
+          const hasCoords = data.x !== undefined && data.y !== undefined;
+          const anyCoord = data.x !== undefined || data.y !== undefined;
+          const hasToken = data.token !== undefined;
+          // exactly one targeting mode; partial coords are never valid
+          if (anyCoord && hasToken) return false;
+          if (anyCoord && !hasCoords) return false;
+          return hasCoords !== hasToken;
+        },
+        {
+          message: 'Provide exactly one of: both "x" and "y", or "token" (not a partial mix)',
+        }
+      );
+    const parsed = schema.parse(args);
+    this.logger.info('Pinging location', {
+      x: parsed.x,
+      y: parsed.y,
+      token: parsed.token,
+      pull: parsed.pull,
+    });
+    try {
+      return await this.foundryClient.query('foundry-mcp-bridge.ping-location', parsed);
+    } catch (error) {
+      this.logger.error('Failed to ping location', error);
+      throw new Error(
+        `Failed to ping location: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds MCP tools built on core Foundry APIs, covering common GM combat, world-time, and audio actions.

- **Combat:** `apply-damage`, `apply-healing`, `advance-turn`, `set-initiative`, `apply-active-effect`, `remove-active-effect`, `get-combatant-status`
- **World:** `advance-game-time`, `get-game-time`, `ping-location`
- **Audio:** `play-sound`

## Approach

- Follows the existing tool pattern (`dice-roll.ts` / `handleMoveToken`): JSON-Schema tool definitions + `zod` runtime parse in the server, delegating to GM-gated bridge handlers in `queries.ts` and new methods in `data-access.ts`.
- Uses core Foundry APIs (`game.combat`, actor HP/effects, `game.time`, `canvas.ping`, `AudioHelper`); damage/effect handling defers to the game system where it exposes it (e.g. `actor.applyDamage` for resistances).
- **GM-gating:** mutating tools gate via `validateGMAccess()`; read-only `get-*` tools skip the gate.

## Tests & verification

- 23 new co-located Vitest tests (schema advertisement + `foundry-mcp-bridge.<name>` forwarding + negative/validation paths).
- Full pipeline green: `build:shared`, `typecheck`, `npm test` (140 tests), `test:mcp:schema`, `build:release`.
- Lint: **0 new errors** over the repo baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
