### PR TITLE
fix: manifest drift + prepare v0.8.3 release (#69)

### DIFF
--- a/.github/workflows/build-complete-release.yml
+++ b/.github/workflows/build-complete-release.yml
@@ -473,7 +473,7 @@ jobs:
 
           **Foundry VTT Users:**
           - Install directly from Foundry's module browser
-          - Or use manifest: `https://raw.githubusercontent.com/adambdooley/foundry-vtt-mcp/master/packages/foundry-module/module.json`
+          - Or use manifest: `https://github.com/adambdooley/foundry-vtt-mcp/releases/latest/download/module.json`
 
           ### Quick Start
           1. Choose your installation method above

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-mcp-integration",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-mcp-integration",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -10864,7 +10864,7 @@
     },
     "packages/foundry-module": {
       "name": "@foundry-mcp/module",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "socket.io-client": "^4.7.0"
       },
@@ -10876,7 +10876,7 @@
     },
     "packages/mcp-server": {
       "name": "@foundry-mcp/server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@foundry-mcp/shared": "*",
         "@modelcontextprotocol/sdk": "^1.7.0",
@@ -10957,7 +10957,7 @@
     },
     "shared": {
       "name": "@foundry-mcp/shared",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "zod": "^3.22.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundry-mcp-integration",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "MCP server that bridges Foundry VTT game data with Claude Desktop",
   "private": true,
   "workspaces": [

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -30,7 +30,7 @@
     }
   ],
   "socket": true,
-  "manifest": "https://raw.githubusercontent.com/adambdooley/foundry-vtt-mcp/master/packages/foundry-module/module.json",
+  "manifest": "https://github.com/adambdooley/foundry-vtt-mcp/releases/latest/download/module.json",
   "download": "https://github.com/adambdooley/foundry-vtt-mcp/releases/latest/download/foundry-vtt-mcp.zip",
   "protected": false,
   "coreTranslation": false,

--- a/packages/foundry-module/package.json
+++ b/packages/foundry-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/module",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Foundry VTT module for MCP bridge integration",
   "type": "module",
   "scripts": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "MCP server for Foundry VTT integration with Claude Desktop",
   "type": "module",
   "main": "dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-mcp/shared",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Shared TypeScript types and constants for Foundry MCP Integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes #69 — module perpetually shows "update available" in Foundry's Add-On Modules screen.

## Root cause
`module.json`'s `manifest` field pointed at the **master branch**:
```
https://raw.githubusercontent.com/adambdooley/foundry-vtt-mcp/master/packages/foundry-module/module.json
```
Foundry re-fetches that URL to check for updates. The version on master was bumped to **0.8.3** (in PR #60), but the latest published release is still **0.8.2**, and the `download` URL serves the 0.8.2 zip. So every installed 0.8.2 client:

1. polls the manifest (master) → sees 0.8.3 → "update available"
2. updates → downloads latest release → gets 0.8.2 again
3. manifest still says 0.8.3 → loops forever

Verified against live URLs: manifest serves `0.8.3`, download zip contains `0.8.2`.

## Fix
Point `manifest` at `releases/latest/download/module.json` so the advertised version always comes from the **same release** as the download zip — they move together and can never drift. The release workflow already publishes `module.json` as a release asset, so the URL is valid. Also updated the release-notes manifest URL to match.

## Important: requires a release to fully resolve
This change alone does **not** clear the loop for existing 0.8.2 users — their installed `module.json` still points at master. The loop is cleared by **cutting a v0.8.3 release** (so the latest release matches what master advertises). This PR should ship in that 0.8.3 release; from then on the `releases/latest` manifest prevents recurrence.

## Follow-up worth considering
A CI check that flags any PR touching `module.json`'s `version` field, so version bumps are a deliberate release step rather than riding in on a feature PR (which is how 0.8.3 landed on master unreleased).