### PR TITLE
chore: correct release-notes tool count and system list

### DIFF
--- a/.github/workflows/build-complete-release.yml
+++ b/.github/workflows/build-complete-release.yml
@@ -482,8 +482,9 @@ jobs:
           4. Start creating AI-powered campaigns!
 
           ### Features
-          - 40 MCP tools for comprehensive Foundry VTT integration
-          - Multi-system support: D&D 5e, Pathfinder 2e, DSA5, Cosmere RPG, and WFRP4e
+          - 43 MCP tools for comprehensive Foundry VTT integration
+          - Multi-system support: D&D 5e, Pathfinder 2e, DSA5, Cosmere RPG, WFRP4e, and Mongoose Traveller 2e
+          - Generic actor CRUD (create/update/delete actors and embedded items) across all systems
           - D&D 5e NPC creation suite: stat blocks, attacks, saves, auras, and spellcasting
           - Actor creation with natural language processing
           - Quest management with HTML generation and updates


### PR DESCRIPTION
Follow-up to the v0.8.3 release. The workflow's hardcoded release notes advertised **40 MCP tools** and omitted **Mongoose Traveller 2e** (added in #60).

- 40 → **43** tools (verified count on master)
- Added Mongoose Traveller 2e to the supported-systems line
- Noted the generic actor CRUD capability

This corrects the source so **future** releases publish accurate info. The v0.8.3 release notes themselves are being corrected directly on the published release.