### PR TITLE
ci: guard against version drift across manifests

### DIFF
--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,36 @@
+name: Version Consistency
+
+# Guards against the class of bug behind #69: a version bump that lands in one
+# manifest but not the others, or that drifts ahead of a release. Runs on every
+# PR to master — no build needed, it only reads JSON.
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.12.2'
+
+      - name: Check version consistency across manifests
+        run: node scripts/check-version-consistency.mjs
+
+      - name: Flag version changes for review
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          FILES="package.json packages/mcp-server/package.json packages/foundry-module/package.json shared/package.json packages/foundry-module/module.json"
+          if git diff "$BASE" HEAD -- $FILES | grep -qE '^[+-][[:space:]]*"version":'; then
+            echo "::notice title=Version bump detected::This PR changes a package version. Make sure it is an intentional release bump (chore(release): prepare vX.Y.Z) and that a matching tag/release will follow — an unreleased bump on master triggers the update loop from #69."
+          else
+            echo "No version fields changed in this PR."
+          fi

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:release": "npm run build:shared && npm run build:server && npm run bundle:server && npm run build:foundry",
     "installer:stage": "node installer/build-nsis.js --skip-download --skip-nsis",
     "test": "npm run test --workspaces --if-present",
+    "version:check": "node scripts/check-version-consistency.mjs",
     "lint": "eslint . --ext .ts,.js",
     "lint:fix": "eslint . --ext .ts,.js --fix",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+// Every manifest that carries a version. These must always agree: the module.json
+// version is what Foundry advertises for updates, and the package.json versions are
+// what the server artifacts report. When they drift (as in #69, where module.json
+// was bumped to 0.8.3 in a feature PR while the packages stayed 0.8.2), releases
+// ship inconsistent version numbers and the Foundry update check misbehaves.
+const FILES = [
+  'package.json',
+  'packages/mcp-server/package.json',
+  'packages/foundry-module/package.json',
+  'shared/package.json',
+  'packages/foundry-module/module.json',
+];
+
+const entries = FILES.map((file) => {
+  const full = path.join(repoRoot, file);
+  const version = JSON.parse(fs.readFileSync(full, 'utf8')).version;
+  return { file, version };
+});
+
+for (const { file, version } of entries) {
+  console.log(`  ${String(version).padEnd(10)} ${file}`);
+}
+
+const distinct = [...new Set(entries.map((e) => e.version))];
+
+if (distinct.length === 1) {
+  console.log(`\n[version-check] OK — all ${entries.length} manifests agree: ${distinct[0]}`);
+  process.exit(0);
+}
+
+console.error(
+  `\n[version-check] FAIL — found ${distinct.length} distinct versions: ${distinct.join(', ')}`,
+);
+console.error(
+  '  All package.json files and module.json must share one version. Bump them together',
+);
+console.error('  in a single "chore(release): prepare vX.Y.Z" commit before tagging a release.');
+process.exit(1);


### PR DESCRIPTION
Follow-up to #69. Adds a lightweight **Version Consistency** workflow that runs on every PR to master (no build — it only reads JSON).

## What it does
- **Hard gate:** fails if the `version` field disagrees across the four `package.json` files and `module.json`. This would have caught #60, where `module.json` was bumped to 0.8.3 while the packages stayed 0.8.2.
- **Soft flag:** emits a `::notice::` annotation whenever a PR changes any version field, so bumps are a conscious release decision rather than a line that rides in on a feature.
- Also runnable locally: `npm run version:check`.

## Why
#69's update loop traced back to exactly this drift: an unreleased version bump on master, surfaced to users because the manifest pointed at `master`. #70 fixed the manifest side; this closes the other half by making version drift a CI failure.

## Verified
- All-aligned tree (0.8.3) → passes
- Simulated drift (module.json → 0.8.4) → fails with exit 1 and a clear message