### PR TITLE
Add extended roll, combat, and resilient WebRTC transport

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -9928,6 +9928,331 @@ export class FoundryDataAccess {
     return { deleted: existing, total: existing.length };
   }
 
+  // ─── Dice rolls and chat roll history ──────────────────────────────────────
+
+  private rollModeForVisibility(visibility: 'public' | 'gm' | 'blind' | 'self'): string {
+    return {
+      public: 'publicroll',
+      gm: 'gmroll',
+      blind: 'blindroll',
+      self: 'selfroll',
+    }[visibility];
+  }
+
+  private serializeRollMessage(message: any): any | null {
+    const rolls = Array.from(message?.rolls ?? (message?.roll ? [message.roll] : [])) as any[];
+    if (rolls.length === 0) return null;
+
+    const whisper = Array.from(message.whisper ?? []) as string[];
+    let visibility: 'public' | 'gm' | 'blind' | 'self' | 'private' = 'public';
+    if (message.blind) visibility = 'blind';
+    else if (whisper.length > 0) {
+      const activeGmIds = Array.from((game as any).users?.contents ?? [])
+        .filter((u: any) => u.isGM && u.active)
+        .map((u: any) => u.id);
+      visibility = whisper.every(id => activeGmIds.includes(id)) ? 'gm' : 'private';
+    }
+
+    const serializedRolls = rolls.map(roll => ({
+      formula: roll.formula ?? roll._formula ?? '',
+      total: roll.total ?? roll._total ?? null,
+      evaluated: Boolean(roll._evaluated ?? roll.evaluated ?? true),
+      dice: Array.from(roll.dice ?? []).map((die: any) => ({
+        faces: die.faces ?? null,
+        number: die.number ?? null,
+        results: Array.from(die.results ?? []).map((result: any) => ({
+          result: result.result,
+          active: result.active !== false,
+          discarded: Boolean(result.discarded),
+        })),
+      })),
+    }));
+    const primaryRoll = serializedRolls[0];
+
+    return {
+      chatMessageId: message.id,
+      timestamp: message.timestamp ?? message._source?.timestamp ?? null,
+      speaker: {
+        alias: message.speaker?.alias ?? message.alias ?? null,
+        actorId: message.speaker?.actor ?? null,
+        tokenId: message.speaker?.token ?? null,
+        sceneId: message.speaker?.scene ?? null,
+      },
+      flavor: message.flavor ?? '',
+      visibility,
+      blind: Boolean(message.blind),
+      whisperUserIds: whisper,
+      formula: primaryRoll?.formula ?? '',
+      total: primaryRoll?.total ?? null,
+      dice: primaryRoll?.dice ?? [],
+      rolls: serializedRolls,
+    };
+  }
+
+  async rollDice(data: {
+    formula: string;
+    flavor?: string;
+    actorIdentifier?: string;
+    visibility: 'public' | 'gm' | 'blind' | 'self';
+  }): Promise<any> {
+    const formula = data.formula.trim();
+    if (!formula || formula.length > 200) throw new Error('Invalid roll formula length');
+
+    const RollClass = (globalThis as any).Roll;
+    if (!RollClass) throw new Error('Foundry Roll API is unavailable');
+    if (typeof RollClass.validate === 'function' && !RollClass.validate(formula)) {
+      throw new Error(`Invalid Foundry roll formula: ${formula}`);
+    }
+
+    const actor = data.actorIdentifier
+      ? this.findActorByIdentifier(data.actorIdentifier)
+      : undefined;
+    if (data.actorIdentifier && !actor) {
+      throw new Error(`Actor not found: ${data.actorIdentifier}`);
+    }
+
+    const roll = new RollClass(formula);
+    await roll.evaluate();
+
+    const message = await roll.toMessage(
+      {
+        speaker: (globalThis as any).ChatMessage.getSpeaker(actor ? { actor } : {}),
+        flavor: data.flavor ?? '',
+      },
+      { create: true, rollMode: this.rollModeForVisibility(data.visibility) }
+    );
+    if (!message?.id) throw new Error('Foundry did not persist the roll chat message');
+
+    const serialized = this.serializeRollMessage(message);
+    this.auditLog(
+      'rollDice',
+      { chatMessageId: message.id, formula, actorId: actor?.id, visibility: data.visibility },
+      'success'
+    );
+    return { success: true, roll: serialized };
+  }
+
+  async getRecentRolls(data: { limit?: number; actorIdentifier?: string }): Promise<any> {
+    const limit = Math.max(1, Math.min(100, data.limit ?? 20));
+    const actor = data.actorIdentifier
+      ? this.findActorByIdentifier(data.actorIdentifier)
+      : undefined;
+    if (data.actorIdentifier && !actor) throw new Error(`Actor not found: ${data.actorIdentifier}`);
+
+    const messages = Array.from((game as any).messages?.contents ?? []) as any[];
+    const rolls = messages
+      .slice()
+      .sort(
+        (a, b) =>
+          (b.timestamp ?? b._source?.timestamp ?? 0) - (a.timestamp ?? a._source?.timestamp ?? 0)
+      )
+      .filter(message => !actor || message.speaker?.actor === actor.id)
+      .map(message => this.serializeRollMessage(message))
+      .filter(Boolean)
+      .slice(0, limit);
+
+    return { success: true, count: rolls.length, rolls };
+  }
+
+  async getRollResult(chatMessageId: string): Promise<any> {
+    const message = (game as any).messages?.get(chatMessageId);
+    if (!message) throw new Error(`Chat message not found: ${chatMessageId}`);
+    const roll = this.serializeRollMessage(message);
+    if (!roll) throw new Error(`Chat message ${chatMessageId} does not contain a roll`);
+    return { success: true, roll };
+  }
+
+  // ─── Combat tracker ────────────────────────────────────────────────────────
+
+  private resolveCombat(combatId?: string): any {
+    const combats: any = (game as any).combats;
+    if (combatId) return combats?.get?.(combatId) ?? null;
+    return (game as any).combat ?? combats?.active ?? combats?.find?.((c: any) => c.active) ?? null;
+  }
+
+  private serializeCombat(combat: any): any {
+    const turns = Array.from(combat?.turns ?? []) as any[];
+    const current = combat?.combatant ?? turns[combat?.turn] ?? null;
+    const sceneId = combat?.scene?.id ?? combat?.scene ?? null;
+    const scene = sceneId ? (game as any).scenes?.get(sceneId) : null;
+
+    return {
+      id: combat.id,
+      active: Boolean(combat.active),
+      started: Boolean(combat.started ?? (combat.round ?? 0) > 0),
+      scene: { id: sceneId, name: scene?.name ?? null },
+      round: combat.round ?? 0,
+      turn: combat.turn ?? null,
+      currentCombatantId: current?.id ?? null,
+      combatants: turns.map((combatant: any, index: number) => ({
+        id: combatant.id,
+        order: index,
+        name: combatant.name ?? combatant.token?.name ?? combatant.actor?.name ?? null,
+        actorId: combatant.actorId ?? combatant.actor?.id ?? null,
+        tokenId: combatant.tokenId ?? combatant.token?.id ?? null,
+        initiative: combatant.initiative ?? null,
+        hidden: Boolean(combatant.hidden),
+        defeated: Boolean(combatant.defeated ?? combatant.isDefeated),
+        isCurrent: combatant.id === current?.id,
+      })),
+    };
+  }
+
+  async getCombatState(combatId?: string): Promise<any> {
+    const combat = this.resolveCombat(combatId);
+    if (!combat) {
+      return { success: true, activeCombat: null, message: 'No active combat tracker.' };
+    }
+    return { success: true, activeCombat: this.serializeCombat(combat) };
+  }
+
+  async manageCombat(data: Record<string, any>): Promise<any> {
+    const action = data.action as string;
+    let combat = this.resolveCombat(data.combatId);
+
+    if (action === 'create') {
+      const scene = data.sceneId
+        ? (game as any).scenes?.get(data.sceneId)
+        : (game as any).scenes?.active;
+      if (!scene) throw new Error('Scene not found or no active scene is available');
+      const CombatClass = (globalThis as any).Combat;
+      if (!CombatClass?.create) throw new Error('Foundry Combat API is unavailable');
+      combat = await CombatClass.create({ scene: scene.id, active: data.activate !== false });
+      if (!combat) throw new Error('Foundry did not create the combat tracker');
+    } else {
+      if (!combat)
+        throw new Error(
+          data.combatId ? `Combat not found: ${data.combatId}` : 'No active combat tracker'
+        );
+
+      switch (action) {
+        case 'activate':
+          if (typeof combat.activate === 'function') await combat.activate();
+          else await combat.update({ active: true });
+          break;
+
+        case 'add-combatants': {
+          const sceneId = combat.scene?.id ?? combat.scene;
+          const scene = (game as any).scenes?.get(sceneId);
+          if (!scene) throw new Error('Combat scene not found');
+          const tokens = Array.from(scene.tokens?.contents ?? scene.tokens ?? []) as any[];
+          const existingTokenIds = new Set(
+            Array.from(combat.combatants?.contents ?? []).map((c: any) => c.tokenId)
+          );
+          const selected: any[] = [];
+          const missing: string[] = [];
+
+          for (const identifier of data.tokenIdentifiers ?? []) {
+            const needle = String(identifier).toLowerCase();
+            const token = tokens.find(
+              candidate =>
+                candidate.id === identifier ||
+                candidate.name?.toLowerCase() === needle ||
+                candidate.actor?.name?.toLowerCase() === needle
+            );
+            if (!token) missing.push(identifier);
+            else if (!existingTokenIds.has(token.id) && !selected.some(t => t.id === token.id)) {
+              selected.push(token);
+            }
+          }
+          if (missing.length > 0) throw new Error(`Tokens not found: ${missing.join(', ')}`);
+          if (selected.length === 0) throw new Error('No new combatants were selected');
+
+          await combat.createEmbeddedDocuments(
+            'Combatant',
+            selected.map(token => ({
+              tokenId: token.id,
+              actorId: token.actor?.id ?? token.actorId,
+              sceneId,
+              hidden: Boolean(token.hidden),
+            }))
+          );
+          break;
+        }
+
+        case 'remove-combatants': {
+          const existing = (data.combatantIds ?? []).filter((id: string) =>
+            combat.combatants?.get(id)
+          );
+          if (existing.length !== data.combatantIds.length) {
+            throw new Error('One or more combatant IDs were not found');
+          }
+          await combat.deleteEmbeddedDocuments('Combatant', existing);
+          break;
+        }
+
+        case 'roll-initiative': {
+          const ids = data.combatantIds?.length
+            ? data.combatantIds
+            : Array.from(combat.combatants?.contents ?? []).map((c: any) => c.id);
+          if (ids.length === 0) throw new Error('Combat has no combatants');
+          if (ids.some((id: string) => !combat.combatants?.get(id))) {
+            throw new Error('One or more combatant IDs were not found');
+          }
+          await combat.rollInitiative(ids, {
+            updateTurn: true,
+            messageOptions: { rollMode: this.rollModeForVisibility(data.visibility ?? 'public') },
+          });
+          break;
+        }
+
+        case 'set-initiative':
+          if (!combat.combatants?.get(data.combatantId)) throw new Error('Combatant not found');
+          await combat.setInitiative(data.combatantId, data.initiative);
+          break;
+
+        case 'update-combatant': {
+          const combatant = combat.combatants?.get(data.combatantId);
+          if (!combatant) throw new Error('Combatant not found');
+          const patch: Record<string, any> = {};
+          if (data.hidden !== undefined) patch.hidden = data.hidden;
+          if (data.defeated !== undefined) patch.defeated = data.defeated;
+          if (Object.keys(patch).length === 0) throw new Error('hidden or defeated is required');
+          await combatant.update(patch);
+          break;
+        }
+
+        case 'start':
+          await combat.startCombat();
+          break;
+        case 'next-turn':
+          await combat.nextTurn();
+          break;
+        case 'previous-turn':
+          await combat.previousTurn();
+          break;
+        case 'next-round':
+          await combat.nextRound();
+          break;
+        case 'set-turn': {
+          const turnCount = Array.from(combat.turns ?? []).length;
+          if (turnCount > 0 && data.turn >= turnCount) {
+            throw new Error(
+              `Turn ${data.turn} is outside the combatant order (0-${turnCount - 1})`
+            );
+          }
+          await combat.update({ round: data.round, turn: data.turn });
+          break;
+        }
+        case 'end':
+          await combat.endCombat();
+          break;
+        case 'delete': {
+          if (data.confirmDelete !== true) throw new Error('confirmDelete=true is required');
+          const deletedId = combat.id;
+          await combat.delete();
+          this.auditLog('manageCombat', { action, combatId: deletedId }, 'success');
+          return { success: true, action, deletedCombatId: deletedId, activeCombat: null };
+        }
+        default:
+          throw new Error(`Unsupported combat action: ${action}`);
+      }
+    }
+
+    this.auditLog('manageCombat', { action, combatId: combat.id }, 'success');
+    return { success: true, action, activeCombat: this.serializeCombat(combat) };
+  }
+
   // ─── mgt2e ──────────────────────────────────────────────────────────────────
 }
 

--- a/packages/foundry-module/src/permissions.ts
+++ b/packages/foundry-module/src/permissions.ts
@@ -63,6 +63,20 @@ export class PermissionManager {
       settingKey: 'allowWriteOperations',
       requiresGM: true,
     },
+    rollDice: {
+      name: 'Roll Dice',
+      level: PERMISSION_LEVELS.LOW_RISK,
+      description: 'Execute and persist a dice roll in Foundry chat',
+      settingKey: 'allowWriteOperations',
+      requiresGM: true,
+    },
+    manageCombat: {
+      name: 'Manage Combat',
+      level: PERMISSION_LEVELS.MEDIUM_RISK,
+      description: 'Change the active combat tracker, turns, initiative, or combatants',
+      settingKey: 'allowWriteOperations',
+      requiresGM: true,
+    },
   };
 
   /**

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -1,6 +1,7 @@
 import { MODULE_ID } from './constants.js';
 import { FoundryDataAccess } from './data-access.js';
 import { ComfyUIManager } from './comfyui-manager.js';
+import { permissionManager } from './permissions.js';
 
 export class QueryHandlers {
   public dataAccess: FoundryDataAccess;
@@ -68,6 +69,13 @@ export class QueryHandlers {
     // Phase 4: Dice roll queries
     CONFIG.queries[`${modulePrefix}.request-player-rolls`] =
       this.handleRequestPlayerRolls.bind(this);
+    CONFIG.queries[`${modulePrefix}.roll-dice`] = this.handleRollDice.bind(this);
+    CONFIG.queries[`${modulePrefix}.get-recent-rolls`] = this.handleGetRecentRolls.bind(this);
+    CONFIG.queries[`${modulePrefix}.get-roll-result`] = this.handleGetRollResult.bind(this);
+
+    // Combat tracker queries
+    CONFIG.queries[`${modulePrefix}.get-combat-state`] = this.handleGetCombatState.bind(this);
+    CONFIG.queries[`${modulePrefix}.manage-combat`] = this.handleManageCombat.bind(this);
 
     // Enhanced creature index for campaign analysis
     CONFIG.queries[`${modulePrefix}.getEnhancedCreatureIndex`] =
@@ -731,6 +739,95 @@ export class QueryHandlers {
     } catch (error) {
       throw new Error(
         `Failed to request player rolls: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleRollDice(data: {
+    formula: string;
+    flavor?: string;
+    actorIdentifier?: string;
+    visibility: 'public' | 'gm' | 'blind' | 'self';
+    userConfirmedVisibility: true;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+
+      const writeCheck = permissionManager.checkWritePermission('rollDice');
+      if (!writeCheck.allowed) return { error: writeCheck.reason, success: false };
+      if (!data?.formula || data.userConfirmedVisibility !== true) {
+        throw new Error('formula and confirmed visibility are required');
+      }
+      return await this.dataAccess.rollDice(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to execute dice roll: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleGetRecentRolls(data: {
+    limit?: number;
+    actorIdentifier?: string;
+  }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      return await this.dataAccess.getRecentRolls(data ?? {});
+    } catch (error) {
+      throw new Error(
+        `Failed to read recent rolls: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleGetRollResult(data: { chatMessageId: string }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      if (!data?.chatMessageId) throw new Error('chatMessageId is required');
+      return await this.dataAccess.getRollResult(data.chatMessageId);
+    } catch (error) {
+      throw new Error(
+        `Failed to read roll result: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleGetCombatState(data: { combatId?: string }): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+      return await this.dataAccess.getCombatState(data?.combatId);
+    } catch (error) {
+      throw new Error(
+        `Failed to read combat state: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleManageCombat(data: Record<string, any>): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) return { error: 'Access denied', success: false };
+      this.dataAccess.validateFoundryState();
+
+      const operation = data?.action === 'delete' ? 'deleteData' : 'manageCombat';
+      const writeCheck = permissionManager.checkWritePermission(operation);
+      if (!writeCheck.allowed) return { error: writeCheck.reason, success: false };
+      if (!data?.action) throw new Error('action is required');
+      if (data.action === 'delete' && data.confirmDelete !== true) {
+        throw new Error('confirmDelete=true is required for permanent combat deletion');
+      }
+      return await this.dataAccess.manageCombat(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to manage combat: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/foundry-module/src/webrtc-connection.ts
+++ b/packages/foundry-module/src/webrtc-connection.ts
@@ -19,6 +19,7 @@ export class WebRTCConnection {
   private dataChannel: RTCDataChannel | null = null;
   private connectionState: string = CONNECTION_STATES.DISCONNECTED;
   private messageHandler: ((message: any) => Promise<void>) | null = null;
+  private sendQueue: Promise<void> = Promise.resolve();
 
   constructor(private config: WebRTCConfig) {}
 
@@ -43,7 +44,6 @@ export class WebRTCConnection {
       // Step 2: Create data channel
       this.dataChannel = this.peerConnection.createDataChannel('foundry-mcp', {
         ordered: true,
-        maxRetransmits: 10,
       });
 
       this.setupDataChannelHandlers();
@@ -193,9 +193,50 @@ export class WebRTCConnection {
   }
 
   sendMessage(message: any): void {
-    if (!this.dataChannel || this.dataChannel.readyState !== 'open') {
-      this.log('Cannot send message - data channel not open');
-      return;
+    // Serialize all outbound messages. This prevents a ping or a second query
+    // response from interleaving with the chunks of a large response.
+    this.sendQueue = this.sendQueue
+      .then(() => this.sendMessageNow(message))
+      .catch(error => {
+        this.log(`Failed to send WebRTC message: ${error}`);
+      });
+  }
+
+  private async waitForSendBuffer(dataChannel: RTCDataChannel): Promise<void> {
+    const HIGH_WATER_MARK = 64 * 1024;
+    const LOW_WATER_MARK = 32 * 1024;
+    const BUFFER_TIMEOUT_MS = 10000;
+
+    if (dataChannel.bufferedAmount <= HIGH_WATER_MARK) return;
+
+    dataChannel.bufferedAmountLowThreshold = LOW_WATER_MARK;
+
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timeout);
+        dataChannel.removeEventListener('bufferedamountlow', onBufferedAmountLow);
+      };
+      const onBufferedAmountLow = () => {
+        cleanup();
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error(`WebRTC send buffer did not drain below ${LOW_WATER_MARK} bytes`));
+      }, BUFFER_TIMEOUT_MS);
+
+      dataChannel.addEventListener('bufferedamountlow', onBufferedAmountLow);
+
+      // Avoid missing the event if the buffer drained between the initial
+      // check and installing the listener.
+      if (dataChannel.bufferedAmount <= LOW_WATER_MARK) onBufferedAmountLow();
+    });
+  }
+
+  private async sendMessageNow(message: any): Promise<void> {
+    const dataChannel = this.dataChannel;
+    if (!dataChannel || dataChannel.readyState !== 'open') {
+      throw new Error('Cannot send message - data channel not open');
     }
 
     try {
@@ -204,7 +245,9 @@ export class WebRTCConnection {
 
       // WebRTC SCTP constants (keep in sync with server config.ts WEBRTC_CONSTANTS)
       const MAX_MESSAGE_SIZE = 65536; // 64KB - SCTP hard limit
-      const CHUNK_SIZE = 50 * 1024; // 50KB - safe threshold for chunking
+      // Smaller application chunks plus send-buffer backpressure avoid
+      // overwhelming Chromium's SCTP queue with large actor responses.
+      const CHUNK_SIZE = 16 * 1024;
 
       if (size > CHUNK_SIZE) {
         // Split large message into chunks
@@ -241,14 +284,19 @@ export class WebRTCConnection {
             );
           }
 
-          this.dataChannel.send(chunkJson);
+          await this.waitForSendBuffer(dataChannel);
+          if (dataChannel.readyState !== 'open') {
+            throw new Error('WebRTC data channel closed during chunked send');
+          }
+          dataChannel.send(chunkJson);
           this.log(`Sent chunk ${i + 1}/${totalChunks} (${chunkJson.length} bytes)`);
         }
 
         this.log(`Successfully sent all ${totalChunks} chunks for ${message.type}`);
       } else {
         // Send as single message
-        this.dataChannel.send(json);
+        await this.waitForSendBuffer(dataChannel);
+        dataChannel.send(json);
         this.log(`Sent WebRTC message: ${message.type} (${size} bytes)`);
       }
     } catch (error) {

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -28,6 +28,7 @@ import { ActorManagementTools } from './tools/actor-management.js';
 import { QuestCreationTools } from './tools/quest-creation.js';
 
 import { DiceRollTools } from './tools/dice-roll.js';
+import { CombatTools } from './tools/combat.js';
 
 import { CampaignManagementTools } from './tools/campaign-management.js';
 
@@ -1206,6 +1207,7 @@ async function startBackend(): Promise<void> {
   const questCreationTools = new QuestCreationTools({ foundryClient, logger });
 
   const diceRollTools = new DiceRollTools({ foundryClient, logger });
+  const combatTools = new CombatTools({ foundryClient, logger });
 
   const campaignManagementTools = new CampaignManagementTools(foundryClient, logger);
 
@@ -1431,6 +1433,7 @@ async function startBackend(): Promise<void> {
     ...questCreationTools.getToolDefinitions(),
 
     ...diceRollTools.getToolDefinitions(),
+    ...combatTools.getToolDefinitions(),
 
     ...campaignManagementTools.getToolDefinitions(),
 
@@ -1664,6 +1667,33 @@ async function startBackend(): Promise<void> {
 
                 case 'request-player-rolls':
                   result = await diceRollTools.handleRequestPlayerRolls(args);
+
+                  break;
+
+                case 'roll-dice':
+                  result = await diceRollTools.handleRollDice(args);
+
+                  break;
+
+                case 'get-recent-rolls':
+                  result = await diceRollTools.handleGetRecentRolls(args);
+
+                  break;
+
+                case 'get-roll-result':
+                  result = await diceRollTools.handleGetRollResult(args);
+
+                  break;
+
+                // Combat tracker tools
+
+                case 'get-combat-state':
+                  result = await combatTools.handleGetCombatState(args);
+
+                  break;
+
+                case 'manage-combat':
+                  result = await combatTools.handleManageCombat(args);
 
                   break;
 

--- a/packages/mcp-server/src/tools/combat.test.ts
+++ b/packages/mcp-server/src/tools/combat.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CombatTools } from './combat.js';
+
+function makeTools(response: any = { success: true }) {
+  const query = vi.fn(async () => response);
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  return { tools: new CombatTools({ foundryClient, logger }), query };
+}
+
+describe('CombatTools definitions', () => {
+  it('advertises read and mutation tools', () => {
+    const names = makeTools()
+      .tools.getToolDefinitions()
+      .map(def => def.name);
+    expect(names).toEqual(['get-combat-state', 'manage-combat']);
+  });
+});
+
+describe('CombatTools validation', () => {
+  it('forwards a normal turn advance', async () => {
+    const response = { success: true, action: 'next-turn' };
+    const { tools, query } = makeTools(response);
+    const result = await tools.handleManageCombat({ action: 'next-turn', combatId: 'c1' });
+    expect(result).toEqual(response);
+    expect(query).toHaveBeenCalledWith(
+      'foundry-mcp-bridge.manage-combat',
+      expect.objectContaining({ action: 'next-turn', combatId: 'c1' })
+    );
+  });
+
+  it('requires token identifiers when adding combatants', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleManageCombat({ action: 'add-combatants' });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit confirmation for permanent deletion', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleManageCombat({ action: 'delete', combatId: 'c1' });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('accepts a confirmed delete', async () => {
+    const { tools, query } = makeTools({ success: true, deletedCombatId: 'c1' });
+    await tools.handleManageCombat({ action: 'delete', combatId: 'c1', confirmDelete: true });
+    expect(query).toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/combat.ts
+++ b/packages/mcp-server/src/tools/combat.ts
@@ -1,0 +1,220 @@
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+interface CombatToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+const visibilitySchema = z.enum(['public', 'gm', 'blind', 'self']);
+
+export class CombatTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor(options: CombatToolsOptions) {
+    this.foundryClient = options.foundryClient;
+    this.logger = options.logger;
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'get-combat-state',
+        description:
+          'Read the active Foundry combat tracker or a specified combat. Returns scene, round, turn, current combatant, and the ordered combatant list with initiative, actor, token, hidden, and defeated state.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            combatId: {
+              type: 'string',
+              description: 'Optional Combat document ID. Defaults to the active combat.',
+            },
+          },
+        },
+      },
+      {
+        name: 'manage-combat',
+        description:
+          'Manage the Foundry combat tracker. Supports creating or activating combat, adding/removing scene tokens, rolling initiative, setting initiative or combatant status, advancing or rewinding turns/rounds, setting an exact round/turn, ending combat, and confirmed deletion. Read get-combat-state before and after consequential changes.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              type: 'string',
+              enum: [
+                'create',
+                'activate',
+                'add-combatants',
+                'remove-combatants',
+                'roll-initiative',
+                'set-initiative',
+                'update-combatant',
+                'start',
+                'next-turn',
+                'previous-turn',
+                'next-round',
+                'set-turn',
+                'end',
+                'delete',
+              ],
+            },
+            combatId: { type: 'string', description: 'Combat ID. Defaults to active combat.' },
+            sceneId: {
+              type: 'string',
+              description: 'Scene ID for create. Defaults to active scene.',
+            },
+            activate: { type: 'boolean', default: true },
+            tokenIdentifiers: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 100,
+              description: 'Token IDs or exact token/actor names for add-combatants.',
+            },
+            combatantIds: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 100,
+              description:
+                'Combatant IDs for removal or initiative rolling. Omit when rolling all.',
+            },
+            combatantId: { type: 'string', description: 'Combatant ID for a single update.' },
+            initiative: { type: 'number', description: 'Initiative value for set-initiative.' },
+            hidden: { type: 'boolean', description: 'Hidden state for update-combatant.' },
+            defeated: { type: 'boolean', description: 'Defeated state for update-combatant.' },
+            round: { type: 'integer', minimum: 0, description: 'Round for set-turn.' },
+            turn: { type: 'integer', minimum: 0, description: 'Turn index for set-turn.' },
+            visibility: {
+              type: 'string',
+              enum: ['public', 'gm', 'blind', 'self'],
+              default: 'public',
+              description: 'Visibility for initiative roll chat messages.',
+            },
+            confirmDelete: {
+              type: 'boolean',
+              const: true,
+              description: 'Required only for permanent deletion of the Combat document.',
+            },
+          },
+          required: ['action'],
+        },
+      },
+    ];
+  }
+
+  async handleGetCombatState(args: any) {
+    const schema = z.object({ combatId: z.string().trim().min(1).optional() });
+    try {
+      const params = schema.parse(args ?? {});
+      const response = await this.foundryClient.query(
+        'foundry-mcp-bridge.get-combat-state',
+        params
+      );
+      if (!response?.success) throw new Error(response?.error || 'Failed to read combat state');
+      return response;
+    } catch (error) {
+      this.logger.error('Error reading Foundry combat state', error);
+      if (error instanceof z.ZodError) {
+        return {
+          success: false,
+          error: `Parameter error: ${error.errors.map(e => e.message).join(', ')}`,
+        };
+      }
+      throw error;
+    }
+  }
+
+  async handleManageCombat(args: any) {
+    const schema = z
+      .object({
+        action: z.enum([
+          'create',
+          'activate',
+          'add-combatants',
+          'remove-combatants',
+          'roll-initiative',
+          'set-initiative',
+          'update-combatant',
+          'start',
+          'next-turn',
+          'previous-turn',
+          'next-round',
+          'set-turn',
+          'end',
+          'delete',
+        ]),
+        combatId: z.string().trim().min(1).optional(),
+        sceneId: z.string().trim().min(1).optional(),
+        activate: z.boolean().default(true),
+        tokenIdentifiers: z.array(z.string().trim().min(1)).max(100).optional(),
+        combatantIds: z.array(z.string().trim().min(1)).max(100).optional(),
+        combatantId: z.string().trim().min(1).optional(),
+        initiative: z.number().finite().optional(),
+        hidden: z.boolean().optional(),
+        defeated: z.boolean().optional(),
+        round: z.number().int().min(0).optional(),
+        turn: z.number().int().min(0).optional(),
+        visibility: visibilitySchema.default('public'),
+        confirmDelete: z.literal(true).optional(),
+      })
+      .superRefine((value, ctx) => {
+        const requireField = (condition: boolean, field: string, message: string) => {
+          if (!condition) ctx.addIssue({ code: z.ZodIssueCode.custom, path: [field], message });
+        };
+        if (value.action === 'add-combatants') {
+          requireField(
+            Boolean(value.tokenIdentifiers?.length),
+            'tokenIdentifiers',
+            'tokenIdentifiers are required'
+          );
+        }
+        if (value.action === 'remove-combatants') {
+          requireField(
+            Boolean(value.combatantIds?.length),
+            'combatantIds',
+            'combatantIds are required'
+          );
+        }
+        if (value.action === 'set-initiative') {
+          requireField(Boolean(value.combatantId), 'combatantId', 'combatantId is required');
+          requireField(value.initiative !== undefined, 'initiative', 'initiative is required');
+        }
+        if (value.action === 'update-combatant') {
+          requireField(Boolean(value.combatantId), 'combatantId', 'combatantId is required');
+          requireField(
+            value.hidden !== undefined || value.defeated !== undefined,
+            'combatantId',
+            'hidden or defeated is required'
+          );
+        }
+        if (value.action === 'set-turn') {
+          requireField(value.round !== undefined, 'round', 'round is required');
+          requireField(value.turn !== undefined, 'turn', 'turn is required');
+        }
+        if (value.action === 'delete') {
+          requireField(
+            value.confirmDelete === true,
+            'confirmDelete',
+            'confirmDelete=true is required'
+          );
+        }
+      });
+
+    try {
+      const params = schema.parse(args);
+      const response = await this.foundryClient.query('foundry-mcp-bridge.manage-combat', params);
+      if (!response?.success) throw new Error(response?.error || 'Failed to manage combat');
+      return response;
+    } catch (error) {
+      this.logger.error('Error managing Foundry combat', error);
+      if (error instanceof z.ZodError) {
+        return {
+          success: false,
+          error: `Parameter error: ${error.errors.map(e => e.message).join(', ')}`,
+        };
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/dice-roll.test.ts
+++ b/packages/mcp-server/src/tools/dice-roll.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DiceRollTools } from './dice-roll.js';
+
+function makeTools(response: any = { success: true }) {
+  const query = vi.fn(async () => response);
+  const logger: any = { info: vi.fn(), error: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  return { tools: new DiceRollTools({ foundryClient, logger }), query };
+}
+
+describe('DiceRollTools definitions', () => {
+  it('advertises direct and readable roll tools', () => {
+    const names = makeTools()
+      .tools.getToolDefinitions()
+      .map(def => def.name);
+    expect(names).toEqual([
+      'roll-dice',
+      'get-recent-rolls',
+      'get-roll-result',
+      'request-player-rolls',
+    ]);
+  });
+});
+
+describe('DiceRollTools direct rolls', () => {
+  it('forwards an explicitly visible roll', async () => {
+    const response = { success: true, roll: { chatMessageId: 'm1', total: 17 } };
+    const { tools, query } = makeTools(response);
+    const result = await tools.handleRollDice({
+      formula: '1d20 + 5',
+      flavor: 'Perception',
+      actorIdentifier: 'Aragorn',
+      visibility: 'public',
+      userConfirmedVisibility: true,
+    });
+
+    expect(result).toEqual(response);
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.roll-dice', {
+      formula: '1d20 + 5',
+      flavor: 'Perception',
+      actorIdentifier: 'Aragorn',
+      visibility: 'public',
+      userConfirmedVisibility: true,
+    });
+  });
+
+  it('rejects a roll without confirmed visibility', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleRollDice({ formula: '1d20', visibility: 'public' });
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('DiceRollTools roll reads', () => {
+  it('reads recent rolls with defaults', async () => {
+    const { tools, query } = makeTools({ success: true, rolls: [] });
+    await tools.handleGetRecentRolls({});
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.get-recent-rolls', {
+      limit: 20,
+    });
+  });
+
+  it('requires a chat message ID for exact lookup', async () => {
+    const { tools, query } = makeTools();
+    const result = await tools.handleGetRollResult({});
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/dice-roll.ts
+++ b/packages/mcp-server/src/tools/dice-roll.ts
@@ -19,6 +19,80 @@ export class DiceRollTools {
   getToolDefinitions() {
     return [
       {
+        name: 'roll-dice',
+        description:
+          'Execute a dice formula directly in Foundry VTT, persist the result as a Foundry chat roll, and return the exact total and chat message ID. Use for GM-controlled rolls or when the player has already declared the action. Visibility must be explicitly determined before calling.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            formula: {
+              type: 'string',
+              description: 'Foundry roll formula, for example "1d20 + 5" or "2d6 + 3".',
+              minLength: 1,
+              maxLength: 200,
+            },
+            flavor: {
+              type: 'string',
+              description: 'Optional player-facing description stored with the roll.',
+              default: '',
+              maxLength: 500,
+            },
+            actorIdentifier: {
+              type: 'string',
+              description: 'Optional actor name or ID to use as the roll speaker.',
+            },
+            visibility: {
+              type: 'string',
+              enum: ['public', 'gm', 'blind', 'self'],
+              description:
+                'Roll visibility: public to everyone, gm to active GMs, blind to GMs without exposing the result to players, or self to the executing GM only.',
+            },
+            userConfirmedVisibility: {
+              type: 'boolean',
+              const: true,
+              description: 'Confirms that roll visibility was explicitly supplied or established.',
+            },
+          },
+          required: ['formula', 'visibility', 'userConfirmedVisibility'],
+        },
+      },
+      {
+        name: 'get-recent-rolls',
+        description:
+          'Read recent persisted Foundry chat rolls visible to the connected GM. Returns chat message IDs, speakers, formulas, totals, dice, flavor, visibility, and timestamps.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 20,
+              description: 'Maximum number of recent rolls to return.',
+            },
+            actorIdentifier: {
+              type: 'string',
+              description: 'Optional actor name or ID filter.',
+            },
+          },
+        },
+      },
+      {
+        name: 'get-roll-result',
+        description:
+          'Read one persisted Foundry roll by its chat message ID and return its exact formula, total, dice, speaker, flavor, visibility, and timestamp.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            chatMessageId: {
+              type: 'string',
+              description: 'Foundry ChatMessage ID returned by roll-dice or get-recent-rolls.',
+            },
+          },
+          required: ['chatMessageId'],
+        },
+      },
+      {
         name: 'request-player-rolls',
         description:
           'Request dice rolls from players with interactive buttons. Creates roll buttons in Foundry chat that players can click. VISIBILITY WORKFLOW: Before calling this function, ensure the user has specified whether they want a public or private roll. If they have already specified "public" or "private" in their request (e.g., "public performance check", "private stealth roll"), you can proceed directly. If the visibility is ambiguous or unspecified, ask: "Do you want this to be a PUBLIC roll (visible to all players) or PRIVATE roll (visible to player and GM only)?" and wait for their answer. Supports character-to-player resolution and GM fallback.',
@@ -72,6 +146,78 @@ export class DiceRollTools {
         },
       },
     ];
+  }
+
+  async handleRollDice(args: any) {
+    const schema = z.object({
+      formula: z.string().trim().min(1).max(200),
+      flavor: z.string().max(500).default(''),
+      actorIdentifier: z.string().trim().min(1).optional(),
+      visibility: z.enum(['public', 'gm', 'blind', 'self']),
+      userConfirmedVisibility: z.literal(true),
+    });
+
+    try {
+      const params = schema.parse(args);
+      const response = await this.foundryClient.query('foundry-mcp-bridge.roll-dice', params);
+      if (!response?.success) throw new Error(response?.error || 'Failed to execute roll');
+      return response;
+    } catch (error) {
+      this.logger.error('Error executing Foundry roll', error);
+      if (error instanceof z.ZodError) {
+        return {
+          success: false,
+          error: `Parameter error: ${error.errors.map(e => e.message).join(', ')}`,
+        };
+      }
+      throw error;
+    }
+  }
+
+  async handleGetRecentRolls(args: any) {
+    const schema = z.object({
+      limit: z.number().int().min(1).max(100).default(20),
+      actorIdentifier: z.string().trim().min(1).optional(),
+    });
+
+    try {
+      const params = schema.parse(args ?? {});
+      const response = await this.foundryClient.query(
+        'foundry-mcp-bridge.get-recent-rolls',
+        params
+      );
+      if (!response?.success) throw new Error(response?.error || 'Failed to read recent rolls');
+      return response;
+    } catch (error) {
+      this.logger.error('Error reading recent Foundry rolls', error);
+      if (error instanceof z.ZodError) {
+        return {
+          success: false,
+          error: `Parameter error: ${error.errors.map(e => e.message).join(', ')}`,
+        };
+      }
+      throw error;
+    }
+  }
+
+  async handleGetRollResult(args: any) {
+    const schema = z.object({ chatMessageId: z.string().trim().min(1) });
+
+    try {
+      const params = schema.parse(args);
+      const response = await this.foundryClient.query('foundry-mcp-bridge.get-roll-result', params);
+      if (!response?.success) throw new Error(response?.error || 'Failed to read roll result');
+      return response;
+    } catch (error) {
+      this.logger.error('Error reading Foundry roll result', error);
+      if (error instanceof z.ZodError) {
+        return {
+          success: false,
+          error: `Parameter error: ${error.errors.map(e => e.message).join(', ')}`,
+        };
+      }
+      throw error;
+    }
   }
 
   async handleRequestPlayerRolls(args: any) {

--- a/packages/mcp-server/src/webrtc-peer.test.ts
+++ b/packages/mcp-server/src/webrtc-peer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebRTCPeer } from './webrtc-peer.js';
+
+function createLogger() {
+  const logger: any = {
+    child: vi.fn(() => logger),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return logger;
+}
+
+function createBufferedAmountEvent() {
+  const listeners = new Set<() => void>();
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return { unSubscribe: () => listeners.delete(listener) };
+    },
+    emit() {
+      for (const listener of [...listeners]) listener();
+    },
+  };
+}
+
+describe('WebRTCPeer outbound transport', () => {
+  it('serializes concurrent sends until Werift drains each message', async () => {
+    const logger = createLogger();
+    const peer = new WebRTCPeer({
+      config: { stunServers: [] },
+      logger,
+      onMessage: vi.fn(),
+    } as any);
+    const bufferedAmountLow = createBufferedAmountEvent();
+    const sent: string[] = [];
+    let sendsInFlight = 0;
+    let maxSendsInFlight = 0;
+
+    const dataChannel: any = {
+      readyState: 'open',
+      bufferedAmount: 0,
+      bufferedAmountLowThreshold: 0,
+      bufferedAmountLow,
+      send(payload: string) {
+        sendsInFlight++;
+        maxSendsInFlight = Math.max(maxSendsInFlight, sendsInFlight);
+        sent.push(JSON.parse(payload).id);
+        this.bufferedAmount += payload.length;
+
+        setTimeout(() => {
+          this.bufferedAmount = 0;
+          sendsInFlight--;
+          bufferedAmountLow.emit();
+        }, 5);
+      },
+    };
+
+    (peer as any).dataChannel = dataChannel;
+    (peer as any).isConnected = true;
+
+    await Promise.all([
+      peer.sendMessage({ type: 'mcp-query', id: 'query-1' }),
+      peer.sendMessage({ type: 'mcp-query', id: 'query-2' }),
+      peer.sendMessage({ type: 'mcp-query', id: 'query-3' }),
+      peer.sendMessage({ type: 'mcp-query', id: 'query-4' }),
+    ]);
+
+    expect(sent).toEqual(['query-1', 'query-2', 'query-3', 'query-4']);
+    expect(maxSendsInFlight).toBe(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/webrtc-peer.ts
+++ b/packages/mcp-server/src/webrtc-peer.ts
@@ -20,6 +20,7 @@ export class WebRTCPeer {
   private config: Config['foundry']['webrtc'];
   private onMessageHandler: (message: any) => Promise<void>;
   private isConnected = false;
+  private outboundSendQueue: Promise<void> = Promise.resolve();
   private pendingChunks: Map<
     string,
     {
@@ -177,18 +178,61 @@ export class WebRTCPeer {
     };
   }
 
-  sendMessage(message: any): void {
-    if (!this.dataChannel || !this.isConnected) {
+  sendMessage(message: any): Promise<void> {
+    const send = this.outboundSendQueue.then(() => this.sendMessageNow(message));
+
+    // Keep the queue usable after a failed send. Callers historically treated
+    // this method as fire-and-forget, so failures remain logged rather than
+    // becoming unhandled promise rejections.
+    this.outboundSendQueue = send.catch(error => {
+      this.logger.error('Failed to send WebRTC message', error);
+    });
+
+    return this.outboundSendQueue;
+  }
+
+  private async sendMessageNow(message: any): Promise<void> {
+    const dataChannel = this.dataChannel;
+    if (!dataChannel || !this.isConnected || dataChannel.readyState !== 'open') {
       this.logger.warn('Cannot send message - data channel not open');
       return;
     }
 
-    try {
-      this.dataChannel.send(JSON.stringify(message));
-      this.logger.debug('Sent WebRTC message', { type: message.type });
-    } catch (error) {
-      this.logger.error('Failed to send WebRTC message', error);
-    }
+    dataChannel.bufferedAmountLowThreshold = 0;
+    dataChannel.send(JSON.stringify(message));
+    await this.waitForSendBufferToDrain(dataChannel);
+    this.logger.debug('Sent WebRTC message', { type: message.type });
+  }
+
+  private async waitForSendBufferToDrain(dataChannel: any): Promise<void> {
+    if (dataChannel.bufferedAmount <= 0) return;
+
+    const timeoutMs = 10000;
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const subscriptionState: { current?: { unSubscribe: () => void } } = {};
+
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        subscriptionState.current?.unSubscribe();
+        if (error) reject(error);
+        else resolve();
+      };
+
+      const timeout = setTimeout(() => {
+        finish(new Error(`WebRTC send buffer did not drain within ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      subscriptionState.current = dataChannel.bufferedAmountLow.subscribe(() => {
+        if (dataChannel.bufferedAmount <= 0) finish();
+      });
+
+      // Avoid missing the event if Werift drained the queue between the first
+      // bufferedAmount check and installing the subscription.
+      if (dataChannel.bufferedAmount <= 0) finish();
+    });
   }
 
   /**
@@ -390,6 +434,7 @@ export class WebRTCPeer {
     }
 
     this.isConnected = false;
+    this.outboundSendQueue = Promise.resolve();
     this.pendingChunks.clear();
     this.logger.info('WebRTC peer disconnected');
   }

--- a/scripts/mcp-schema-smoke-test.mjs
+++ b/scripts/mcp-schema-smoke-test.mjs
@@ -6,24 +6,41 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distDir = path.join(repoRoot, 'packages', 'mcp-server', 'dist');
 
-const fail = (message) => {
+const fail = message => {
   console.error(`\n[MCP Schema Smoke Test] ${message}`);
   process.exit(1);
 };
 
 if (!fs.existsSync(distDir)) {
   fail(
-    `Build output not found at ${distDir}. Run "npm -w @foundry-mcp/server run build" and re-run this test.`,
+    `Build output not found at ${distDir}. Run "npm -w @foundry-mcp/server run build" and re-run this test.`
   );
 }
 
-const importDist = async (relativePath) =>
+const importDist = async relativePath =>
   import(pathToFileURL(path.join(distDir, relativePath)).href);
 
-const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { CompendiumTools }, { SceneTools },
-  { ActorCreationTools }, { QuestCreationTools }, { DiceRollTools }, { CampaignManagementTools },
-  { OwnershipTools }, { TokenManipulationTools }, { MapGenerationTools }, { getSystemRegistry },
-  { DnD5eAdapter }, { PF2eAdapter }, { DSA5Adapter }, { CosmereRpgAdapter }] = await Promise.all([
+const [
+  { config },
+  { Logger },
+  { FoundryClient },
+  { CharacterTools },
+  { CompendiumTools },
+  { SceneTools },
+  { ActorCreationTools },
+  { QuestCreationTools },
+  { DiceRollTools },
+  { CombatTools },
+  { CampaignManagementTools },
+  { OwnershipTools },
+  { TokenManipulationTools },
+  { MapGenerationTools },
+  { getSystemRegistry },
+  { DnD5eAdapter },
+  { PF2eAdapter },
+  { DSA5Adapter },
+  { CosmereRpgAdapter },
+] = await Promise.all([
   importDist('config.js'),
   importDist('logger.js'),
   importDist('foundry-client.js'),
@@ -33,6 +50,7 @@ const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { Compendi
   importDist('tools/actor-creation.js'),
   importDist('tools/quest-creation.js'),
   importDist('tools/dice-roll.js'),
+  importDist('tools/combat.js'),
   importDist('tools/campaign-management.js'),
   importDist('tools/ownership.js'),
   importDist('tools/token-manipulation.js'),
@@ -60,10 +78,15 @@ const tools = [
   ...new ActorCreationTools({ foundryClient, logger }).getToolDefinitions(),
   ...new QuestCreationTools({ foundryClient, logger }).getToolDefinitions(),
   ...new DiceRollTools({ foundryClient, logger }).getToolDefinitions(),
+  ...new CombatTools({ foundryClient, logger }).getToolDefinitions(),
   ...new CampaignManagementTools(foundryClient, logger).getToolDefinitions(),
   ...new OwnershipTools({ foundryClient, logger }).getToolDefinitions(),
   ...new TokenManipulationTools({ foundryClient, logger }).getToolDefinitions(),
-  ...new MapGenerationTools({ foundryClient, logger, backendComfyUIHandlers: {} }).getToolDefinitions(),
+  ...new MapGenerationTools({
+    foundryClient,
+    logger,
+    backendComfyUIHandlers: {},
+  }).getToolDefinitions(),
 ];
 
 if (!tools.length) {
@@ -79,24 +102,26 @@ for (const tool of tools) {
 }
 
 const additionalPropertiesFalseCount = objectSchemas.filter(
-  ({ schema }) => schema.additionalProperties === false,
+  ({ schema }) => schema.additionalProperties === false
 ).length;
 
 if (additionalPropertiesFalseCount === objectSchemas.length) {
   fail(
-    'Every tool schema has additionalProperties=false. This indicates schema normalization is forcing strictness globally.',
+    'Every tool schema has additionalProperties=false. This indicates schema normalization is forcing strictness globally.'
   );
 }
 
-const switchSceneSchema = tools.find((tool) => tool.name === 'switch-scene')?.inputSchema;
+const switchSceneSchema = tools.find(tool => tool.name === 'switch-scene')?.inputSchema;
 if (!switchSceneSchema) {
   fail('Expected tool "switch-scene" to be present but it was not found.');
 }
 
 if (switchSceneSchema.additionalProperties === false) {
   fail(
-    'Tool "switch-scene" schema sets additionalProperties=false. This can reject alias parameters like "sceneId" and breaks client compatibility.',
+    'Tool "switch-scene" schema sets additionalProperties=false. This can reject alias parameters like "sceneId" and breaks client compatibility.'
   );
 }
 
-console.log('[MCP Schema Smoke Test] PASS: tool schemas load, use object input, and do not enforce global additionalProperties=false.');
+console.log(
+  '[MCP Schema Smoke Test] PASS: tool schemas load, use object input, and do not enforce global additionalProperties=false.'
+);


### PR DESCRIPTION
## Summary
- add GM-gated extended dice rolling, recent-roll history, and roll-result lookup
- add combat tracker inspection and managed combat mutations
- serialize WebRTC sends and apply buffer backpressure to prevent concurrent large-response transport failures
- extend MCP schema smoke coverage and add dice, combat, and transport regression tests

## Validation
- npm.cmd test: 128 tests passed
- npm.cmd run typecheck: passed across all workspaces
- npm.cmd run build:release: passed
- npm.cmd run test:mcp:schema: passed
- scoped Prettier check: passed
- secret-pattern scan: passed

## Remaining acceptance
- reload the Foundry GM client with the deployed module and repeat the live parallel extended-roll/combat transport check

## Repository hygiene
Repository-wide lint and formatting checks have unrelated pre-existing failures outside this change. All changed files pass the scoped formatting check; newly added tool and test files have no error-level ESLint findings.