### PR TITLE
fix: repair scene background image after generate-map scene creation

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -3732,7 +3732,12 @@ export class FoundryDataAccess {
       id: scene.id,
       name: scene.name,
       img: scene.img || undefined,
-      background: scene._source?.background?.src || undefined,
+      // Foundry v14 removed Scene#background; the image now lives on the Scene's first
+      // Level document instead (see foundry.documents.Level / LevelData#background).
+      background:
+        scene._source?.background?.src ||
+        (scene as any).levels?.contents?.[0]?.background?.src ||
+        undefined,
       width: scene.width,
       height: scene.height,
       padding: scene.padding,
@@ -7186,7 +7191,13 @@ export class FoundryDataAccess {
           height: scene.dimensions?.height || scene.height || 0,
         },
         gridSize: scene.grid?.size || 100,
-        background: scene._source?.background?.src || scene.img || '',
+        // Foundry v14 removed Scene#background; the image now lives on the Scene's first
+        // Level document instead (see foundry.documents.Level / LevelData#background).
+        background:
+          scene._source?.background?.src ||
+          scene.levels?.contents?.[0]?.background?.src ||
+          scene.img ||
+          '',
         walls: scene.walls?.size || 0,
         tokens: scene.tokens?.size || 0,
         lighting: scene.lights?.size || 0,

--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -323,27 +323,57 @@ export class SocketBridge {
         console.log(`[foundry-mcp-bridge] Added folder ID to scene data`);
       }
 
+      // Capture the intended background path BEFORE calling Scene.create() - Foundry's
+      // Document constructor explicitly owns and may mutate the data object passed to it
+      // (its own JSDoc says so), and since `background` isn't a valid top-level Scene field
+      // on v14 it gets stripped from `sceneData` in place during schema cleaning. Reading
+      // this after create() would always see it as already-gone.
+      const expectedBackgroundSrc = sceneData.background?.src;
+
       // Create the scene using the complete payload from backend
       console.log(`[foundry-mcp-bridge] Attempting to create scene...`);
       const scene = await (globalThis as any).Scene.create(sceneData);
       console.log(`[foundry-mcp-bridge] Scene created successfully:`, scene);
 
-      // Verify the background image actually persisted. This module only supports
-      // Foundry v13+, which has no `img` field/getter on Scene (it was fully replaced
-      // by `background.src`), so checking `scene.img` here always reads as undefined
-      // and the old workaround based on it never reliably detected a missing image.
-      // Some Scene.create() calls silently fail to persist a nested `background`
-      // payload, so re-check `background.src` directly and repair it if needed.
-      const expectedBackgroundSrc = sceneData.background?.src;
-      if (expectedBackgroundSrc && scene.background?.src !== expectedBackgroundSrc) {
-        console.warn(
-          `[foundry-mcp-bridge] Scene background did not persist on create (got "${scene.background?.src}"), repairing via update()...`
-        );
-        await scene.update({ background: { src: expectedBackgroundSrc } });
-        console.log(
-          `[foundry-mcp-bridge] Scene background after repair:`,
-          scene.background?.src
-        );
+      // Set/verify the background image. Foundry v14 removed Scene#background entirely -
+      // the background image now lives on a Level document in the Scene's `levels`
+      // embedded collection instead (see foundry.documents.Level / LevelData#background).
+      // Foundry v13 and earlier still use the flat `background.src` field on the Scene
+      // itself, and some Scene.create() calls there silently fail to persist a nested
+      // `background` payload, so that path is verified and repaired if needed.
+      if (expectedBackgroundSrc) {
+        const foundryGeneration = (globalThis as any).game?.release?.generation ?? 0;
+        if (foundryGeneration >= 14) {
+          try {
+            const existingLevel = (scene as any).levels?.contents?.[0];
+            if (existingLevel) {
+              if (existingLevel.background?.src !== expectedBackgroundSrc) {
+                await existingLevel.update({ background: { src: expectedBackgroundSrc } });
+              }
+            } else {
+              await scene.createEmbeddedDocuments('Level', [
+                { name: 'Base', background: { src: expectedBackgroundSrc } },
+              ]);
+            }
+            console.log(
+              `[foundry-mcp-bridge] Scene background set via Level document (Foundry v${foundryGeneration}).`
+            );
+          } catch (levelError) {
+            console.error(
+              `[foundry-mcp-bridge] Failed to set background via Level document:`,
+              levelError
+            );
+          }
+        } else if (scene.background?.src !== expectedBackgroundSrc) {
+          console.warn(
+            `[foundry-mcp-bridge] Scene background did not persist on create (got "${scene.background?.src}"), repairing via update()...`
+          );
+          await scene.update({ background: { src: expectedBackgroundSrc } });
+          console.log(
+            `[foundry-mcp-bridge] Scene background after repair:`,
+            scene.background?.src
+          );
+        }
       }
 
       if (sceneData.walls && sceneData.walls.length > 0) {

--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -328,12 +328,22 @@ export class SocketBridge {
       const scene = await (globalThis as any).Scene.create(sceneData);
       console.log(`[foundry-mcp-bridge] Scene created successfully:`, scene);
 
-      // CRITICAL: Foundry v13 bug workaround (like working mapgen system)
-      if (!scene.img && sceneData.img) {
-        await scene.update({
-          img: sceneData.img,
-          background: { src: sceneData.img },
-        });
+      // Verify the background image actually persisted. This module only supports
+      // Foundry v13+, which has no `img` field/getter on Scene (it was fully replaced
+      // by `background.src`), so checking `scene.img` here always reads as undefined
+      // and the old workaround based on it never reliably detected a missing image.
+      // Some Scene.create() calls silently fail to persist a nested `background`
+      // payload, so re-check `background.src` directly and repair it if needed.
+      const expectedBackgroundSrc = sceneData.background?.src;
+      if (expectedBackgroundSrc && scene.background?.src !== expectedBackgroundSrc) {
+        console.warn(
+          `[foundry-mcp-bridge] Scene background did not persist on create (got "${scene.background?.src}"), repairing via update()...`
+        );
+        await scene.update({ background: { src: expectedBackgroundSrc } });
+        console.log(
+          `[foundry-mcp-bridge] Scene background after repair:`,
+          scene.background?.src
+        );
       }
 
       if (sceneData.walls && sceneData.walls.length > 0) {

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1061,8 +1061,9 @@ async function processMapGenerationInBackend(
     logger.info('Using scene name', { scene_name: sceneName });
     const sceneData = {
       name: sceneName,
-      img: webPath,
-      background: { src: webPath }, // Foundry v13 compatibility
+      // Foundry v13+ Scene documents have no top-level `img` field - the background
+      // image is set exclusively via `background.src`.
+      background: { src: webPath },
       width: sceneSize,
       height: sceneSize,
       padding: 0.25,


### PR DESCRIPTION
Fixes #78.

## Problem

`generate-map` reports success (valid generation time), and the resulting scene has correct name/dimensions/grid, but `background` is always `""` — no image ever gets attached.

## Root cause

Two compounding bugs, both in `handleJobCompleted()` in [socket-bridge.ts](packages/foundry-module/src/socket-bridge.ts):

1. **Foundry v14 removed `Scene#background` as a real schema field.** The background image now lives on a `Level` document in the Scene's `levels` embedded collection instead (see `foundry.documents.Level` / `LevelData#background`). `background` survives only as a deprecated compatibility getter/setter on `Scene` (removed in v16) that proxies through to the first Level — it is not a field `Scene.create()`/`update()` will actually persist. The module's `module.json` declares `verified: "14"`, `maximum: "14"`, so this is squarely in scope, but the existing code (and my first attempt at a fix) assumed the v13-style flat `background.src` field still worked.

2. **A read-after-mutation ordering bug in the repair logic.** The code read `sceneData.background?.src` *after* calling `Scene.create(sceneData)`. Foundry's `Document` constructor docs explicitly say it "owns" and may mutate the data object passed to it — and since `background` isn't a valid top-level Scene field on v14, `Scene.create()` strips it from `sceneData` in place during schema cleaning. By the time the old code read it, it was already gone, so the repair branch silently no-opped on every single run.

`list-scenes`/`get-current-scene` (in `data-access.ts`) compounded this: they read `scene._source?.background?.src`, which is v13-only, so they'd report an empty background even if the image *had* been correctly set via a v14 Level.

## Fix

- Capture `expectedBackgroundSrc` from `sceneData` **before** calling `Scene.create()`, not after.
- On Foundry v14+ (detected via `game.release.generation`), set the background on the Scene's first `Level` document via `level.update()` / `createEmbeddedDocuments('Level', ...)` instead of the nonexistent `Scene#background` field.
- Keep the v13-and-earlier flat `background.src` repair path for older Foundry versions.
- Fix `listScenes`/`getActiveScene` in `data-access.ts` to also check `scene.levels?.contents?.[0]?.background?.src` so they correctly report the image on v14.

## Testing

Verified end-to-end against a live Foundry v14.367 world (this module's own maximum verified version): `generate-map` now produces a scene whose background image actually renders on the canvas, and `list-scenes`/`get-current-scene` correctly report the image path. Confirmed via direct inspection of the persisted Scene document (`Level.background.src`) as well as visually.

Not tested against Foundry v13 — the v13 code path is preserved from the previous attempt but unverified live; would appreciate a v13 smoke-test from a maintainer before merge.

## Note: separate bug found along the way

While testing, I also hit a reproducible issue where `generate-map` called with a similar prompt shortly after a previous call returns the **same job ID** and the **stale `scene_name`** from the earlier job, even though it does generate a fresh image. This looks like a job-deduplication/caching bug in the MCP server's job queue, unrelated to the background-image issue this PR fixes. Happy to file it as a separate issue if useful — didn't want to scope-creep this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)