### PR TITLE
feat: DSA5 adapter support (normalizePayload, describeActorSchema) + system detection + replace-journal-page tool

### DIFF
--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -1650,6 +1650,11 @@ async function startBackend(): Promise<void> {
 
                   break;
 
+                case 'replace-journal-page':
+                  result = await questCreationTools.handleReplaceJournalPage(args);
+
+                  break;
+
                 case 'list-journals':
                   result = await questCreationTools.handleListJournals(args);
 

--- a/packages/mcp-server/src/systems/dsa5/adapter.ts
+++ b/packages/mcp-server/src/systems/dsa5/adapter.ts
@@ -390,6 +390,37 @@ export class DSA5Adapter implements SystemAdapter {
     return stats;
   }
 
+  describeActorSchema(): string {
+    return [
+      '=== DSA5 Actor Schema Reference ===',
+      '',
+      'ACTOR TYPES: character, npc, creature',
+      '',
+      'EIGENSCHAFTEN (characteristics) — system.characteristics:',
+      '  Shorthand: { MU:13, KL:12, IN:14, CH:11, FF:10, GE:11, KO:12, KK:13 }',
+      '    (uppercase or lowercase; naked number → {value, initial}, or {value, initial, advances?})',
+      '  Full:      { mu:{initial:13,value:13}, kl:{initial:12,value:12}, ... }',
+      '  Keys: mu, kl, in, ch, ff, ge, ko, kk  (value is derived; writing `initial` suffices)',
+      '',
+      'LEBENSKRAFT / ENERGIE (status) — system.status:',
+      '  LeP:  { lifePoints:{current, max} } or {status:{lifePoints:{...}}} → status.wounds.{current,max}',
+      '  AsP:  { astralenergy:{current,max} } or {status:{astralenergy:{...}}} → status.astralenergy',
+      '  KaP:  { karmaenergy:{current,max} } or {status:{karmaenergy:{...}}} → status.karmaenergy',
+      '  Note: status.wounds.max is derived at runtime (initial + KO×2 + advances); a hard max may be overwritten.',
+      '',
+      'DETAILS (identity / details) — system.details:',
+      '  species/culture/career accept a string or {value}: { species:"Mensch", culture:"Mittelreich", profession:"Krieger" }',
+      '  `profession` → details.career.value; `identity.*` → details.*; experience.{total,spent,available}',
+      '',
+      'KAMPF / STATUS (optional shorthands) —',
+      '  initiative, speed, dodge, size, armour|armor → status.<key>.value  (size:string → {value}, armour→armour)',
+      '  tradition → system.tradition (object passed through)',
+      '',
+      'ACTOR TYPES: character (Held), npc (NSC), creature (Tier/Kreatur).',
+      'ITEMS: advantage, disadvantage, combatskill, talent, spell, liturgy, equipment, weapon, armor, etc.',
+    ].join('\n');
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // normalizePayload – map caller-friendly DSA5 shorthands onto the real
   // Foundry DSA5 system paths before the payload is sent to the server.

--- a/packages/mcp-server/src/systems/dsa5/adapter.ts
+++ b/packages/mcp-server/src/systems/dsa5/adapter.ts
@@ -389,4 +389,275 @@ export class DSA5Adapter implements SystemAdapter {
 
     return stats;
   }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // normalizePayload – map caller-friendly DSA5 shorthands onto the real
+  // Foundry DSA5 system paths before the payload is sent to the server.
+  // Receives ONLY the `system` sub-object and returns a normalised `system`
+  // object.  Unknown keys are left untouched.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Valid Eigenschaft keys in lowercase (the canonical Foundry form).
+   */
+  private static readonly EIGENSCHAFT_KEYS = [
+    'mu',
+    'kl',
+    'in',
+    'ch',
+    'ff',
+    'ge',
+    'ko',
+    'kk',
+  ] as const;
+
+  /**
+   * Normalise a single Eigenschaft entry to {value, initial?, advances?}.
+   * Accepts:
+   *   - naked number  →  { value: n, initial: n }
+   *   - { value, initial?, advances? }
+   * If `value` is missing but `advances` is present, value = (initial ?? 8) + advances.
+   * `value` is ALWAYS set after normalisation.
+   */
+  private normalizeEigenschaft(raw: any): { value: number; initial?: number; advances?: number } {
+    if (typeof raw === 'number') {
+      return { value: raw, initial: raw };
+    }
+    if (raw && typeof raw === 'object') {
+      const result: any = {};
+      const initial = raw.initial ?? 8;
+      if (raw.value !== undefined) {
+        result.value = raw.value;
+      } else if (raw.advances !== undefined) {
+        result.value = initial + raw.advances;
+      } else {
+        result.value = initial;
+      }
+      if (raw.initial !== undefined) result.initial = raw.initial;
+      if (raw.advances !== undefined) result.advances = raw.advances;
+      return result;
+    }
+    // Fallback
+    return { value: 8, initial: 8 };
+  }
+
+  /**
+   * Helper: normalise a resource block (LeP/AsP/KaP/fatePoints).
+   * Accepts {current, max}, {value, max}, or a naked number.
+   * Returns a minimal {value, max} object (or {current, max} for wounds).
+   */
+  private normalizeResource(
+    raw: any,
+    opts?: { useCurrent?: boolean }
+  ): Record<string, number> | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw === 'number') {
+      return { value: raw, max: raw };
+    }
+    if (typeof raw === 'object') {
+      const result: any = {};
+      const current = raw.current ?? raw.value;
+      if (current !== undefined) {
+        result[opts?.useCurrent ? 'current' : 'value'] = current;
+      }
+      if (raw.max !== undefined) result.max = raw.max;
+      if (raw.initial !== undefined) result.initial = raw.initial;
+      return result;
+    }
+    return undefined;
+  }
+
+  /**
+   * Helper: normalise a detail field that may arrive as a string or {value}.
+   * Always returns {value: string}.
+   */
+  private normalizeDetail(raw: any): { value: string } | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw === 'string') return { value: raw };
+    if (typeof raw === 'object' && raw.value !== undefined) {
+      return { value: String(raw.value) };
+    }
+    return undefined;
+  }
+
+  /**
+   * Deep-merge helper: copy values from `src` into `dst` for keys that exist
+   * in `src`, creating intermediate objects as needed.  Does not overwrite
+   * keys that already exist in `dst` with higher priority — src wins for
+   * keys it explicitly provides.
+   */
+  private static mergeInto(dst: Record<string, any>, src: Record<string, any> | undefined): void {
+    if (!src) return;
+    for (const [key, val] of Object.entries(src)) {
+      if (val && typeof val === 'object' && !Array.isArray(val)) {
+        if (typeof dst[key] !== 'object' || dst[key] === null || Array.isArray(dst[key])) {
+          dst[key] = {};
+        }
+        DSA5Adapter.mergeInto(dst[key], val);
+      } else {
+        dst[key] = val;
+      }
+    }
+  }
+
+  normalizePayload(system: Record<string, any>): Record<string, any> {
+    // Work on the caller's object but only add/overwrite normalised paths.
+    // We collect changes in a separate object and merge at the end to avoid
+    // intermediate corruption.
+    const out: Record<string, any> = {};
+
+    // ── 1. Eigenschaften (characteristics) ──────────────────────────────
+    // Accept MU/KL/... (uppercase) or mu/kl/... (lowercase) keys, each as
+    // a naked number or {value, initial?, advances?}.
+    const charSource = system.characteristics ?? system.eigenschaften;
+    if (charSource && typeof charSource === 'object') {
+      const normalized: Record<string, any> = {};
+      for (const [key, raw] of Object.entries(charSource)) {
+        const lower = key.toLowerCase();
+        if (DSA5Adapter.EIGENSCHAFT_KEYS.includes(lower as any)) {
+          normalized[lower] = this.normalizeEigenschaft(raw);
+        }
+      }
+      if (Object.keys(normalized).length > 0) {
+        out.characteristics = normalized;
+      }
+    }
+
+    // ── 2. LeP (wounds / lifePoints) ────────────────────────────────────
+    // If system.status.wounds already exists, leave it untouched.
+    // Otherwise map from system.lifePoints or system.status.lifePoints.
+    const existingWounds = system.status?.wounds;
+    if (!existingWounds) {
+      const lp = system.lifePoints ?? system.status?.lifePoints;
+      const lpNormalized = this.normalizeResource(lp, { useCurrent: true });
+      if (lpNormalized) {
+        // Fallback: if max missing, derive from KO
+        if (lpNormalized.max === undefined) {
+          const koVal =
+            out.characteristics?.ko?.value ??
+            system.characteristics?.ko?.value ??
+            system.characteristics?.KO?.value ??
+            8;
+          const initial = (lpNormalized as any).initial ?? 8;
+          lpNormalized.max = initial + koVal * 2;
+        }
+        out.status = out.status ?? {};
+        out.status.wounds = lpNormalized;
+      }
+    }
+
+    // ── 3. AsP / KaP / fatePoints ───────────────────────────────────────
+    const asp = system.astralEnergy ?? system.status?.astralEnergy ?? system.status?.astralenergy;
+    const aspNorm = this.normalizeResource(asp);
+    if (aspNorm) {
+      out.status = out.status ?? {};
+      out.status.astralenergy = aspNorm;
+    }
+
+    const kap = system.karmaEnergy ?? system.status?.karmaEnergy ?? system.status?.karmaenergy;
+    const kapNorm = this.normalizeResource(kap);
+    if (kapNorm) {
+      out.status = out.status ?? {};
+      out.status.karmaenergy = kapNorm;
+    }
+
+    const fate = system.fatePoints ?? system.status?.fatePoints;
+    const fateNorm = this.normalizeResource(fate);
+    if (fateNorm) {
+      out.status = out.status ?? {};
+      out.status.fatePoints = fateNorm;
+    }
+
+    // ── 4. Details (species / culture / career / socialstate / experience) ─
+    const details: Record<string, any> = {};
+
+    // Direct system.details.* (may already be correct or use string shorthand)
+    const srcDetails = system.details;
+    const species = this.normalizeDetail(srcDetails?.species ?? system.species);
+    if (species) details.species = species;
+
+    const culture = this.normalizeDetail(srcDetails?.culture ?? system.culture);
+    if (culture) details.culture = culture;
+
+    // career — accept career, profession, or identity.profession
+    const career = this.normalizeDetail(
+      srcDetails?.career ??
+        srcDetails?.profession ??
+        system.career ??
+        system.profession ??
+        system.identity?.profession
+    );
+    if (career) details.career = career;
+
+    const social = this.normalizeDetail(srcDetails?.socialstate ?? system.socialstate);
+    if (social) details.socialstate = social;
+
+    // Experience (AP)
+    const exp = srcDetails?.experience ?? system.experience;
+    if (exp && typeof exp === 'object') {
+      details.experience = {
+        ...(exp.total !== undefined ? { total: exp.total } : {}),
+        ...(exp.spent !== undefined ? { spent: exp.spent } : {}),
+        ...(exp.available !== undefined ? { available: exp.available } : {}),
+      };
+    }
+
+    // identity.* → details.*  (profession→career already handled above)
+    if (system.identity?.species && !details.species) {
+      const idSpecies = this.normalizeDetail(system.identity.species);
+      if (idSpecies) details.species = idSpecies;
+    }
+    if (system.identity?.culture && !details.culture) {
+      const idCulture = this.normalizeDetail(system.identity.culture);
+      if (idCulture) details.culture = idCulture;
+    }
+
+    if (Object.keys(details).length > 0) {
+      out.details = details;
+    }
+
+    // ── 5. Status / Kampf values ────────────────────────────────────────
+    const status: Record<string, any> = {};
+
+    const init = system.initiative ?? system.status?.initiative;
+    if (init !== undefined) {
+      status.initiative = typeof init === 'number' ? { value: init } : init;
+    }
+
+    const speed = system.speed ?? system.status?.speed;
+    if (speed !== undefined) {
+      status.speed = typeof speed === 'number' ? { value: speed } : speed;
+    }
+
+    const dodge = system.dodge ?? system.status?.dodge;
+    if (dodge !== undefined) {
+      status.dodge = typeof dodge === 'number' ? { value: dodge } : dodge;
+    }
+
+    const armour = system.armour ?? system.armor ?? system.status?.armour ?? system.status?.armor;
+    if (armour !== undefined) {
+      status.armour = typeof armour === 'number' ? { value: armour } : armour;
+    }
+
+    const size = system.size ?? system.status?.size;
+    if (size !== undefined) {
+      status.size = typeof size === 'string' ? { value: size } : size;
+    }
+
+    if (Object.keys(status).length > 0) {
+      out.status = out.status ?? {};
+      DSA5Adapter.mergeInto(out.status, status);
+    }
+
+    // ── 6. Tradition ────────────────────────────────────────────────────
+    if (system.tradition) {
+      out.tradition = system.tradition;
+    }
+
+    // ── Merge normalised paths back into the original system object ──────
+    // This preserves unknown keys and only overwrites/adds the normalised ones.
+    DSA5Adapter.mergeInto(system, out);
+
+    return system;
+  }
 }

--- a/packages/mcp-server/src/systems/dsa5/normalize-payload.test.ts
+++ b/packages/mcp-server/src/systems/dsa5/normalize-payload.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for DSA5Adapter.normalizePayload
+ *
+ * Validates that caller-friendly DSA5 shorthands (uppercase Eigenschaft keys,
+ * naked numbers, lifePoints, identity.*, etc.) are correctly mapped onto the
+ * real Foundry DSA5 system paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DSA5Adapter } from './adapter.js';
+
+const adapter = new DSA5Adapter();
+
+describe('DSA5Adapter.normalizePayload', () => {
+  // ── Eigenschaften ──────────────────────────────────────────────────────
+
+  describe('Eigenschaften', () => {
+    it('maps uppercase keys to lowercase and wraps naked numbers in {value, initial}', () => {
+      const system = {
+        characteristics: {
+          MU: 13,
+          KL: 12,
+          IN: 11,
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.mu).toEqual({ value: 13, initial: 13 });
+      expect(result.characteristics.kl).toEqual({ value: 12, initial: 12 });
+      expect(result.characteristics.in).toEqual({ value: 11, initial: 11 });
+    });
+
+    it('preserves lowercase keys and passes through {value, initial}', () => {
+      const system = {
+        characteristics: {
+          mu: { value: 14, initial: 10 },
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.mu).toEqual({ value: 14, initial: 10 });
+    });
+
+    it('computes value from initial + advances when value is missing', () => {
+      const system = {
+        characteristics: {
+          mu: { initial: 8, advances: 5 },
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.mu.value).toBe(13);
+      expect(result.characteristics.mu.initial).toBe(8);
+      expect(result.characteristics.mu.advances).toBe(5);
+    });
+
+    it('uses default initial=8 when advances present but no initial', () => {
+      const system = {
+        characteristics: {
+          kk: { advances: 4 },
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.kk.value).toBe(12); // 8 + 4
+    });
+
+    it('always sets value even for bare {initial} object', () => {
+      const system = {
+        characteristics: {
+          ko: { initial: 10 },
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.ko.value).toBe(10);
+    });
+
+    it('accepts system.eigenschaften as alternative source', () => {
+      const system = {
+        eigenschaften: {
+          MU: 15,
+        },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.characteristics.mu).toEqual({ value: 15, initial: 15 });
+    });
+  });
+
+  // ── LeP (wounds) ───────────────────────────────────────────────────────
+
+  describe('LeP / wounds', () => {
+    it('maps system.lifePoints {current,max} to system.status.wounds', () => {
+      const system = {
+        lifePoints: { current: 20, max: 30 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.wounds.current).toBe(20);
+      expect(result.status.wounds.max).toBe(30);
+    });
+
+    it('accepts value as synonym for current in lifePoints', () => {
+      const system = {
+        lifePoints: { value: 15, max: 25 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.wounds.current).toBe(15);
+      expect(result.status.wounds.max).toBe(25);
+    });
+
+    it('does not overwrite existing system.status.wounds', () => {
+      const system = {
+        status: { wounds: { current: 5, max: 10 } },
+        lifePoints: { current: 99, max: 99 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.wounds.current).toBe(5);
+      expect(result.status.wounds.max).toBe(10);
+    });
+
+    it('derives max from initial + KO*2 when max missing', () => {
+      const system = {
+        characteristics: { KO: 12 },
+        lifePoints: { current: 20, initial: 8 },
+      };
+      const result = adapter.normalizePayload(system);
+      // initial=8, KO=12 → max = 8 + 12*2 = 32
+      expect(result.status.wounds.max).toBe(32);
+    });
+
+    it('uses fallback initial=8, KO=8 when deriving max', () => {
+      const system = {
+        lifePoints: { current: 10 },
+      };
+      const result = adapter.normalizePayload(system);
+      // initial=8, KO=8 → max = 8 + 16 = 24
+      expect(result.status.wounds.max).toBe(24);
+    });
+
+    it('accepts system.status.lifePoints as source', () => {
+      const system = {
+        status: { lifePoints: { current: 12, max: 18 } },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.wounds.current).toBe(12);
+      expect(result.status.wounds.max).toBe(18);
+    });
+  });
+
+  // ── AsP / KaP / fatePoints ─────────────────────────────────────────────
+
+  describe('AsP / KaP / fatePoints', () => {
+    it('normalises astralEnergy to system.status.astralenergy', () => {
+      const system = {
+        astralEnergy: { value: 10, max: 20 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.astralenergy.value).toBe(10);
+      expect(result.status.astralenergy.max).toBe(20);
+    });
+
+    it('normalises karmaEnergy to system.status.karmaenergy', () => {
+      const system = {
+        karmaEnergy: { current: 5, max: 15 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.karmaenergy.value).toBe(5);
+      expect(result.status.karmaenergy.max).toBe(15);
+    });
+
+    it('normalises fatePoints', () => {
+      const system = {
+        fatePoints: { value: 3, max: 3 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.fatePoints.value).toBe(3);
+      expect(result.status.fatePoints.max).toBe(3);
+    });
+
+    it('accepts naked number for astralEnergy', () => {
+      const system = {
+        astralEnergy: 25,
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.astralenergy.value).toBe(25);
+      expect(result.status.astralenergy.max).toBe(25);
+    });
+  });
+
+  // ── Details ────────────────────────────────────────────────────────────
+
+  describe('Details', () => {
+    it('maps string species/culture/career to {value} objects', () => {
+      const system = {
+        species: 'Mensch',
+        culture: 'Bornland',
+        career: 'Krieger',
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.species).toEqual({ value: 'Mensch' });
+      expect(result.details.culture).toEqual({ value: 'Bornland' });
+      expect(result.details.career).toEqual({ value: 'Krieger' });
+    });
+
+    it('maps profession to career (not profession)', () => {
+      const system = {
+        profession: 'Magier',
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.career).toEqual({ value: 'Magier' });
+      expect(result.details.profession).toBeUndefined();
+    });
+
+    it('maps identity.profession to details.career', () => {
+      const system = {
+        identity: { profession: 'Geweihter' },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.career).toEqual({ value: 'Geweihter' });
+    });
+
+    it('maps identity.species/culture to details.*', () => {
+      const system = {
+        identity: { species: 'Elf', culture: 'Firnelfen' },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.species).toEqual({ value: 'Elf' });
+      expect(result.details.culture).toEqual({ value: 'Firnelfen' });
+    });
+
+    it('passes through {value} objects in details', () => {
+      const system = {
+        details: { species: { value: 'Zwerg' } },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.species).toEqual({ value: 'Zwerg' });
+    });
+
+    it('maps socialstate', () => {
+      const system = {
+        socialstate: 'Bauer',
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.socialstate).toEqual({ value: 'Bauer' });
+    });
+
+    it('maps experience fields', () => {
+      const system = {
+        experience: { total: 1500, spent: 800, available: 700 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.details.experience.total).toBe(1500);
+      expect(result.details.experience.spent).toBe(800);
+      expect(result.details.experience.available).toBe(700);
+    });
+  });
+
+  // ── Status / Kampf ─────────────────────────────────────────────────────
+
+  describe('Status / Kampf', () => {
+    it('wraps naked-number initiative/speed/dodge/armour in {value}', () => {
+      const system = {
+        initiative: 15,
+        speed: 8,
+        dodge: 6,
+        armour: 5,
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.initiative).toEqual({ value: 15 });
+      expect(result.status.speed).toEqual({ value: 8 });
+      expect(result.status.dodge).toEqual({ value: 6 });
+      expect(result.status.armour).toEqual({ value: 5 });
+    });
+
+    it('accepts armor (American) as synonym for armour', () => {
+      const system = { armor: 3 };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.armour).toEqual({ value: 3 });
+    });
+
+    it('wraps string size in {value}', () => {
+      const system = { size: 'mittel' };
+      const result = adapter.normalizePayload(system);
+      expect(result.status.size).toEqual({ value: 'mittel' });
+    });
+  });
+
+  // ── Tradition ──────────────────────────────────────────────────────────
+
+  describe('Tradition', () => {
+    it('passes tradition through', () => {
+      const system = {
+        tradition: { magical: 'Gildenmagier', clerical: 'Rondra' },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.tradition).toEqual({ magical: 'Gildenmagier', clerical: 'Rondra' });
+    });
+  });
+
+  // ── Unknown keys ───────────────────────────────────────────────────────
+
+  describe('Unknown keys', () => {
+    it('preserves unknown keys unchanged', () => {
+      const system = {
+        someUnknownKey: 'hello',
+        anotherKey: { nested: 42 },
+      };
+      const result = adapter.normalizePayload(system);
+      expect(result.someUnknownKey).toBe('hello');
+      expect(result.anotherKey).toEqual({ nested: 42 });
+    });
+  });
+
+  // ── Full integration ───────────────────────────────────────────────────
+
+  describe('Full payload', () => {
+    it('normalises a mixed payload correctly', () => {
+      const system = {
+        characteristics: {
+          MU: 13,
+          KL: { value: 12, initial: 10 },
+          KO: { initial: 8, advances: 4 },
+        },
+        lifePoints: { current: 25, max: 30 },
+        astralEnergy: { value: 10, max: 20 },
+        species: 'Mensch',
+        profession: 'Krieger',
+        initiative: 14,
+        unknownField: 'preserved',
+      };
+      const result = adapter.normalizePayload(system);
+
+      // Eigenschaften
+      expect(result.characteristics.mu).toEqual({ value: 13, initial: 13 });
+      expect(result.characteristics.kl).toEqual({ value: 12, initial: 10 });
+      expect(result.characteristics.ko.value).toBe(12); // 8 + 4
+
+      // LeP
+      expect(result.status.wounds.current).toBe(25);
+      expect(result.status.wounds.max).toBe(30);
+
+      // AsP
+      expect(result.status.astralenergy.value).toBe(10);
+      expect(result.status.astralenergy.max).toBe(20);
+
+      // Details
+      expect(result.details.species).toEqual({ value: 'Mensch' });
+      expect(result.details.career).toEqual({ value: 'Krieger' });
+
+      // Kampf
+      expect(result.status.initiative).toEqual({ value: 14 });
+
+      // Unknown
+      expect(result.unknownField).toBe('preserved');
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/quest-creation.ts
+++ b/packages/mcp-server/src/tools/quest-creation.ts
@@ -187,6 +187,36 @@ export class QuestCreationTools {
         },
       },
       {
+        name: 'replace-journal-page',
+        description:
+          'Replace the ENTIRE content of a specific journal page. Use this to overwrite/rewrite a page. For appending progress, use update-quest-journal instead.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            journalId: {
+              type: 'string',
+              description: 'ID of the journal containing the page to replace',
+            },
+            pageId: {
+              type: 'string',
+              description:
+                'ID of the page whose content will be replaced. Get page IDs from list-journals.',
+            },
+            newContent: {
+              type: 'string',
+              description:
+                'The new content for the page. Quest-style HTML or plain text is supported. Plain text gets wrapped in <p> tags. Markdown will be stripped.',
+            },
+            newPageName: {
+              type: 'string',
+              description:
+                'Optional new name for the page (rename the page while replacing its content).',
+            },
+          },
+          required: ['journalId', 'pageId', 'newContent'],
+        },
+      },
+      {
         name: 'list-journals',
         description:
           "List all journal entries, or read a specific journal/page. Without parameters: lists all journals with their pages (id, name, type). With journalId: reads the journal's first text page content and shows all available pages. With journalId + pageId: reads a specific page's full content.",
@@ -505,6 +535,80 @@ export class QuestCreationTools {
       };
     } catch (error) {
       this.errorHandler.handleToolError(error, 'update-quest-journal', 'journal update');
+    }
+  }
+
+  /**
+   * Handle replace journal page request
+   * Replaces the ENTIRE content of a specific journal page (no append).
+   */
+  async handleReplaceJournalPage(args: any): Promise<any> {
+    try {
+      const requestSchema = z.object({
+        journalId: z.string().min(1, 'Journal ID is required'),
+        pageId: z.string().min(1, 'Page ID is required'),
+        newContent: z.string().min(1, 'New content is required'),
+        newPageName: z.string().optional(),
+      });
+
+      const request = requestSchema.parse(args);
+
+      // Auto-convert Markdown to plain text with warning (don't block)
+      request.newContent = this.convertMarkdownToPlainText(request.newContent);
+
+      // Format the replacement content for Foundry
+      const replacementContent = this.formatUpdateContentForFoundry(request.newContent);
+
+      // Send the replacement via the module handler (Mode 2 replaces, no concat)
+      const result = await this.foundryClient.query('foundry-mcp-bridge.updateJournalContent', {
+        journalId: request.journalId,
+        content: replacementContent,
+        pageId: request.pageId,
+      });
+
+      if (!result) {
+        throw new Error('Failed to replace journal page: No response from Foundry');
+      }
+
+      if (result.error) {
+        throw new Error(`Failed to replace journal page: ${result.error}`);
+      }
+
+      if (!result.success) {
+        throw new Error('Failed to replace journal page: Update operation returned failure');
+      }
+
+      // Optionally rename the page after replacing content
+      if (request.newPageName) {
+        await this.foundryClient.query('foundry-mcp-bridge.updateJournalContent', {
+          journalId: request.journalId,
+          pageId: request.pageId,
+          content: replacementContent,
+          newPageName: request.newPageName,
+        });
+      }
+
+      // Verify the replacement by reading the content back
+      const verifyResult = await this.foundryClient.query(
+        'foundry-mcp-bridge.getJournalPageContent',
+        {
+          journalId: request.journalId,
+          pageId: request.pageId,
+        }
+      );
+      const verifyContent = verifyResult?.content || '';
+
+      return {
+        success: true,
+        message: `Page content replaced successfully`,
+        pageId: result.pageId,
+        pageName: request.newPageName || result.pageName,
+        verified: verifyContent.length > 0,
+        details: `Page content replaced. New content length: ${verifyContent.length} characters.`,
+        updatedContent: verifyContent,
+      };
+    } catch (error) {
+      this.errorHandler.handleToolError(error, 'replace-journal-page', 'journal page replacement');
     }
   }
 

--- a/packages/mcp-server/src/utils/system-detection.ts
+++ b/packages/mcp-server/src/utils/system-detection.ts
@@ -11,7 +11,7 @@ import { Logger } from '../logger.js';
 /**
  * Supported game systems
  */
-export type GameSystem = 'dnd5e' | 'pf2e' | 'cosmere-rpg' | 'mgt2e' | 'other';
+export type GameSystem = 'dnd5e' | 'pf2e' | 'cosmere-rpg' | 'dsa5' | 'wfrp4e' | 'mgt2e' | 'other';
 
 /**
  * Cache for system detection (avoid repeated queries)
@@ -49,6 +49,10 @@ export async function detectGameSystem(
       cachedSystem = 'cosmere-rpg';
     } else if (systemId === 'mgt2e') {
       cachedSystem = 'mgt2e';
+    } else if (systemId === 'dsa5') {
+      cachedSystem = 'dsa5';
+    } else if (systemId === 'wfrp4e') {
+      cachedSystem = 'wfrp4e';
     } else {
       cachedSystem = 'other';
     }


### PR DESCRIPTION
Dear Adam,

## Summary

Four small, self-contained changes that make the DSA5 adapter fully functional and add one generic journal tool. All changes follow the existing 4-layer architecture (server tool class → backend registration → query handler → data access) and keep `update-quest-journal`'s append semantics intact.

## Changes

### 1. Fix system detection for dsa5 and wfrp4e
`detectGameSystem()` in `system-detection.ts` did not recognize `dsa5` or `wfrp4e` — both fell through to `'other'`, even though `SystemId` in `types.ts` already includes both. As a result, the registered DSA5/WFRP4e adapters were never resolved, so adapter-specific logic (e.g. `normalizePayload`) was silently skipped on those worlds. This adds both to the `GameSystem` type union and two `else if` branches. 6-line change, non-breaking (all callers have an `other`/default fallback).

### 2. DSA5 normalizePayload
Implements the optional `SystemAdapter.normalizePayload()` in the DSA5 adapter. Maps caller-friendly shorthands onto the real DSA5 data-model paths before the payload reaches Foundry:
- `MU: 13` (or `mu: 13`) → `system.characteristics.mu.value`
- `lifePoints: 30` → `system.status.wounds.current`
- `astralEnergy` / `karmaEnergy` → `system.status.astralenergy/karmaenergy.current`
- `identity.*` → `system.details.*`

Unrecognised keys pass through unchanged (no data loss). Includes unit tests (`normalize-payload.test.ts`).

### 3. DSA5 describeActorSchema
Implements the optional `SystemAdapter.describeActorSchema()` in the DSA5 adapter, so `manage-actors describe` returns DSA5-specific field guidance (actor types, the 8 Eigenschaften, status values, identity fields) instead of a generic "no schema available" message.

### 4. New replace-journal-page tool
Adds a new MCP tool that replaces the **entire content** of a specific journal page. This complements `update-quest-journal` (which appends progress) and closes the gap raised in issue #25 (individual page read/write). Reuses the existing `updateJournalContent` query handler — no Foundry-module changes needed.

## Architecture compliance
- All DSA5-specific logic lives inside `packages/mcp-server/src/systems/dsa5/adapter.ts` (per the pattern requested in the mgt2e PR review: "system-specific code needs to live in the adapter, not in shared files").
- No changes to shared files, no interface changes.
- No version bump (0.8.4 left for upstream).

## Testing
- `npm run typecheck` — clean
- `npm test` — 146 tests pass (including the 29 new `normalize-payload` tests)
- Verified live on a DSA5 world (Foundry v14.367): `manage-actors create` with shorthands now resolves the DSA5 adapter and applies `normalizePayload`; `manage-actors describe` returns the DSA5 schema; `replace-journal-page` fully replaces page content while `update-quest-journal` still appends.
