### PR TITLE
fix(module): use ws:// for loopback hosts even on HTTPS pages (#74)

### DIFF
--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -97,12 +97,20 @@ export class SocketBridge {
   private async connectWebSocket(): Promise<void> {
     this.activeConnectionType = 'websocket';
 
-    // Auto-detect protocol: wss for HTTPS pages, ws for HTTP.
+    // Protocol selection follows the browser's mixed-content rules:
+    //   - ws:// to a loopback host (localhost / 127.0.0.1 / ::1) is allowed even
+    //     from an HTTPS page — loopback is a "potentially trustworthy" secure
+    //     context — and the local MCP server speaks plain ws, so a loopback host
+    //     must always use ws:// (#74: forcing wss on "WebSocket (Local Only)"
+    //     broke local setups behind an HTTPS Foundry page).
+    //   - ws:// to a remote host from an HTTPS page IS blocked as mixed content,
+    //     so a remote host on an HTTPS page must use wss:// (#49: TLS reverse-proxy).
     // The port always comes from the configured serverPort setting, the same as
-    // the WebRTC path and everywhere else in the module. Reverse-proxy users set
-    // serverPort to whatever port their proxy exposes (e.g. 443).
-    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    // the WebRTC path and everywhere else in the module.
     const host = this.config.serverHost;
+    const isLoopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(host);
+    const useSecure = window.location.protocol === 'https:' && !isLoopback;
+    const protocol = useSecure ? 'wss' : 'ws';
     this.log(
       `Using WebSocket (${protocol}://${host}:${this.config.serverPort}${this.config.namespace})`
     );


### PR DESCRIPTION
Addresses #74 — v0.8.3 bridge fails with `ERR_SSL_PROTOCOL_ERROR` on 'WebSocket (Local Only)'.

## Regression
The wss auto-detect from #49/#66 picks the WebSocket protocol purely from `window.location.protocol`. A user on an HTTPS Foundry page (proxy/FLC) with **Connection Type = WebSocket (Local Only)** therefore gets `wss://localhost:31415`, which fails — the local MCP server speaks plain `ws`. This worked on v0.8.2 (protocol was hardcoded `ws`), so the update broke it.

## Root cause / fix
Browsers treat loopback (`localhost`/`127.0.0.1`/`::1`) as a **secure context**, so `ws://` to loopback is allowed even from an HTTPS page. Only **remote** hosts on an HTTPS page require `wss` to satisfy mixed-content rules.

So choose `wss` only when the page is HTTPS **and** the host is not loopback:

| Page | Host | Protocol |
|---|---|---|
| HTTPS | localhost (loopback) | `ws` ✅ (was `wss` → #74) |
| HTTPS | remote domain | `wss` ✅ (#49 TLS proxy preserved) |
| HTTP | any | `ws` ✅ unchanged |

Fixes the local case (#74) without regressing the reverse-proxy case (#49).

## Verified
Module builds clean. Logic confirmed for all three rows above.
