### PR TITLE
fix: register getPackIndex query for list-dsa5-archetypes (#77)

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -3804,6 +3804,34 @@ export class FoundryDataAccess {
   }
 
   /**
+   * Return a compendium pack's index entries as a plain array.
+   * `fields` requests extra (dot-notation) fields be included in the index —
+   * e.g. ['type', 'system.details.species.value'] — so callers can filter
+   * without loading every full document. Mirrors the getIndex({ fields })
+   * pattern used elsewhere, with a fallback for older Foundry APIs.
+   */
+  async getPackIndex(packId: string, fields?: string[]): Promise<any[]> {
+    const pack = game.packs.get(packId);
+    if (!pack) {
+      throw new Error(`Compendium pack not found: ${packId}`);
+    }
+
+    let packIndex: any;
+    try {
+      packIndex = await (pack as any).getIndex(
+        fields && fields.length > 0 ? { fields } : undefined
+      );
+    } catch {
+      // Fallback: older Foundry API without the fields option
+      packIndex = await (pack as any).getIndex();
+    }
+
+    const source =
+      packIndex && typeof packIndex.values === 'function' ? packIndex : (pack as any).index;
+    return Array.from((source as any).values()).map((entry: any) => this.sanitizeData(entry));
+  }
+
+  /**
    * Sanitize data to remove sensitive information and make it JSON-safe
    */
   private sanitizeData(data: any): any {

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -37,6 +37,7 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.listCreaturesByCriteria`] =
       this.handleListCreaturesByCriteria.bind(this);
     CONFIG.queries[`${modulePrefix}.getAvailablePacks`] = this.handleGetAvailablePacks.bind(this);
+    CONFIG.queries[`${modulePrefix}.getPackIndex`] = this.handleGetPackIndex.bind(this);
 
     // Scene queries
     CONFIG.queries[`${modulePrefix}.getActiveScene`] = this.handleGetActiveScene.bind(this);
@@ -338,6 +339,31 @@ export class QueryHandlers {
     } catch (error) {
       throw new Error(
         `Failed to get available packs: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Handle get pack index request. Returns a compendium pack's index entries,
+   * optionally including extra system fields (e.g. dsa5 species/career) so callers
+   * can filter without loading every full document. Used by list-dsa5-archetypes.
+   */
+  private async handleGetPackIndex(data: { packId: string; fields?: string[] }): Promise<any> {
+    try {
+      // SECURITY: Silent GM validation
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+
+      this.dataAccess.validateFoundryState();
+      if (!data?.packId) {
+        throw new Error('packId is required');
+      }
+      return await this.dataAccess.getPackIndex(data.packId, data.fields);
+    } catch (error) {
+      throw new Error(
+        `Failed to get pack index: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/mcp-server/src/systems/dsa5/character-creator.ts
+++ b/packages/mcp-server/src/systems/dsa5/character-creator.ts
@@ -252,6 +252,9 @@ export class DSA5CharacterCreator {
         try {
           const packIndex = await this.foundryClient.query('foundry-mcp-bridge.getPackIndex', {
             packId: pack.id,
+            // Include the fields the species/profession filters read so the index
+            // carries them without loading every full document.
+            fields: ['type', 'system.details.species.value', 'system.details.career.value'],
           });
 
           // Filter archetypes


### PR DESCRIPTION
Addresses #77.

## Bug
`list-dsa5-archetypes` calls `foundry-mcp-bridge.getPackIndex`, which was **never registered** on the module. The per-pack call is wrapped in try/catch, so the tool reported success and silently returned an **empty list** every time.

## Fix
- Register `getPackIndex` with a GM-gated handler (mirrors `getAvailablePacks`).
- Add `dataAccess.getPackIndex(packId, fields?)` returning a pack's index entries, using the existing `getIndex({ fields })` pattern with a fallback for older Foundry APIs.
- The DSA5 tool now requests the `type` / `system.details.species.value` / `system.details.career.value` fields its filters read.

## Confidence / verification
- The **core empty-list bug** (missing query) is fixed with high confidence — builds clean, 146 tests pass.
- The **species/profession filters** depend on Foundry actually populating those dsa5 system fields in the index. I don't have a live DSA5 world to confirm that end-to-end — worth a check by someone who does (@apoapostolov / @frankyh75). The base archetype listing works regardless of the filters.

Leaving #77 open for you to close after verification.