### PR TITLE
fix: include scene_name in map job dedup hash (#80)

### DIFF
--- a/packages/mcp-server/src/job-queue.test.ts
+++ b/packages/mcp-server/src/job-queue.test.ts
@@ -1,0 +1,65 @@
+/**
+ * JobQueue dedup tests.
+ *
+ * createJob() collapses genuinely identical requests onto one job (retry
+ * protection), but must NOT collapse requests that differ in a param the caller
+ * cares about. Regression cover for #80: a second generate-map call with the
+ * same prompt but a different scene_name was handed back the earlier job and
+ * created the scene under the earlier call's name.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { JobQueue } from './job-queue.js';
+
+function makeQueue() {
+  const logger: any = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return new JobQueue({ logger });
+}
+
+const base = {
+  prompt: 'a quiet moonlit forest clearing',
+  size: 'medium' as const,
+  grid_size: 70,
+  quality: 'low',
+};
+
+let queues: JobQueue[] = [];
+function queue() {
+  const q = makeQueue();
+  queues.push(q);
+  return q;
+}
+afterEach(async () => {
+  await Promise.all(queues.map(q => q.shutdown()));
+  queues = [];
+});
+
+describe('JobQueue.createJob dedup', () => {
+  it('dedups a genuinely identical request', async () => {
+    const q = queue();
+    const a = await q.createJob({ params: { ...base, scene_name: 'A' } });
+    const b = await q.createJob({ params: { ...base, scene_name: 'A' } });
+    expect(b.id).toBe(a.id);
+  });
+
+  it('does not dedup when only scene_name differs (#80)', async () => {
+    const q = queue();
+    const a = await q.createJob({ params: { ...base, scene_name: 'A' } });
+    const b = await q.createJob({ params: { ...base, scene_name: 'B' } });
+    expect(b.id).not.toBe(a.id);
+    expect(b.params.scene_name).toBe('B');
+  });
+
+  it('does not dedup when only quality differs', async () => {
+    const q = queue();
+    const a = await q.createJob({ params: { ...base, scene_name: 'A', quality: 'low' } });
+    const b = await q.createJob({ params: { ...base, scene_name: 'A', quality: 'high' } });
+    expect(b.id).not.toBe(a.id);
+  });
+});

--- a/packages/mcp-server/src/job-queue.ts
+++ b/packages/mcp-server/src/job-queue.ts
@@ -5,8 +5,10 @@ export type JobStatus = 'queued' | 'generating' | 'processing' | 'complete' | 'f
 
 export interface GenerateMapInput {
   prompt: string;
+  scene_name?: string;
   size: 'small' | 'medium' | 'large';
   grid_size: number;
+  quality?: string;
 }
 
 export interface CreateJobParams {
@@ -332,10 +334,17 @@ export class JobQueue {
   }
 
   private generatePromptHash(params: GenerateMapInput): string {
+    // The hash must represent the full request. Omitting scene_name caused
+    // #80: a second call with the same prompt but a different scene_name matched
+    // a prior job and was handed that job back — creating the scene under the
+    // earlier call's name. Include every param that distinguishes one request
+    // from another so dedup only ever collapses genuinely identical requests.
     const hashInput = JSON.stringify({
       prompt: params.prompt.trim().toLowerCase(),
+      scene_name: params.scene_name?.trim().toLowerCase() ?? '',
       size: params.size,
       grid_size: params.grid_size,
+      quality: params.quality ?? '',
     });
 
     return createHash('sha256').update(hashInput).digest('hex').substring(0, 16);


### PR DESCRIPTION
Addresses #80.

## Bug
`generate-map` deduplicates jobs by a hash of `prompt + size + grid_size` only. A second call with the **same prompt but a different `scene_name`** produces the same hash, so `createJob()` returns the **earlier** job — the scene is created under the earlier call's `scene_name`, and `check-map-status` points at a job that isn't tracking the new request.

## Fix
Include `scene_name` (and `quality`) in the dedup hash so it represents the full request — dedup then only collapses genuinely identical re-fires (retry protection), not distinct requests that happen to share a prompt.

## Tests
Added `job-queue.test.ts`: identical request dedups; scene_name-differs and quality-differs each get a fresh job. 149 tests pass.

Leaving #80 open for you to close.