### PR TITLE
feat: add 'place' action to manage-actors for existing world actors (#75)

### DIFF
--- a/packages/mcp-server/src/tools/actor-management.test.ts
+++ b/packages/mcp-server/src/tools/actor-management.test.ts
@@ -1,0 +1,59 @@
+/**
+ * manage-actors "place" action tests.
+ *
+ * The token placement itself runs browser-side (data-access.addActorsToScene),
+ * so these cover the MCP tool layer: the action is advertised, and a valid call
+ * forwards to the existing GM-gated addActorsToScene bridge query with defaults
+ * applied.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ActorManagementTools } from './actor-management.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ success: true, created: [] })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  const tools = new ActorManagementTools({ foundryClient, logger });
+  return { tools, query };
+}
+
+describe('manage-actors place action', () => {
+  it('advertises "place" in the action enum', () => {
+    const { tools } = makeTools();
+    const def = tools.getToolDefinitions()[0];
+    const actionEnum = def.inputSchema.properties.action.enum;
+    expect(actionEnum).toContain('place');
+  });
+
+  it('forwards to addActorsToScene with the given ids and options', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleManageActors({
+      action: 'place',
+      actorIds: ['abc', 'def'],
+      placement: 'grid',
+      hidden: true,
+    });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.addActorsToScene', {
+      actorIds: ['abc', 'def'],
+      placement: 'grid',
+      hidden: true,
+    });
+  });
+
+  it('defaults placement to random and hidden to false', async () => {
+    const { tools, query } = makeTools();
+    await tools.handleManageActors({ action: 'place', actorIds: ['abc'] });
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.addActorsToScene', {
+      actorIds: ['abc'],
+      placement: 'random',
+      hidden: false,
+    });
+  });
+
+  it('rejects a place call with no actorIds', async () => {
+    const { tools, query } = makeTools();
+    await expect(tools.handleManageActors({ action: 'place', actorIds: [] })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/tools/actor-management.ts
+++ b/packages/mcp-server/src/tools/actor-management.ts
@@ -59,9 +59,18 @@ export class ActorManagementTools {
           properties: {
             action: {
               type: 'string',
-              enum: ['create', 'update', 'delete', 'update-items', 'delete-items', 'describe'],
+              enum: [
+                'create',
+                'update',
+                'delete',
+                'place',
+                'update-items',
+                'delete-items',
+                'describe',
+              ],
               description:
                 'Operation to perform: "create" / "update" / "delete" actors, ' +
+                '"place" existing world actors as tokens on the current scene, ' +
                 '"update-items" / "delete-items" for embedded items, ' +
                 'or "describe" to get system-specific schema notes.',
             },
@@ -146,6 +155,24 @@ export class ActorManagementTools {
               minItems: 1,
               description: 'Required for "delete". IDs of the actors to delete.',
             },
+            // ── place ───────────────────────────────────────────────────────
+            actorIds: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 1,
+              description:
+                'Required for "place". IDs of existing world actors to drop as tokens on the ' +
+                'current scene.',
+            },
+            placement: {
+              type: 'string',
+              enum: ['random', 'grid', 'center'],
+              description: 'For "place": token layout strategy. Defaults to "random".',
+            },
+            hidden: {
+              type: 'boolean',
+              description: 'For "place": create the tokens hidden from players. Defaults to false.',
+            },
             // ── update-items ─────────────────────────────────────────────────
             actorIdentifier: {
               type: 'string',
@@ -190,7 +217,15 @@ export class ActorManagementTools {
   async handleManageActors(args: any): Promise<any> {
     const { action } = z
       .object({
-        action: z.enum(['create', 'update', 'delete', 'update-items', 'delete-items', 'describe']),
+        action: z.enum([
+          'create',
+          'update',
+          'delete',
+          'place',
+          'update-items',
+          'delete-items',
+          'describe',
+        ]),
       })
       .parse(args);
 
@@ -201,6 +236,8 @@ export class ActorManagementTools {
         return this.handleUpdate(args);
       case 'delete':
         return this.handleDelete(args);
+      case 'place':
+        return this.handlePlace(args);
       case 'update-items':
         return this.handleUpdateItems(args);
       case 'delete-items':
@@ -208,6 +245,32 @@ export class ActorManagementTools {
       case 'describe':
         return this.handleDescribe();
     }
+  }
+
+  // ── place ─────────────────────────────────────────────────────────────────
+
+  private async handlePlace(args: any): Promise<any> {
+    const schema = z.object({
+      actorIds: z.array(z.string().min(1)).min(1),
+      placement: z.enum(['random', 'grid', 'center']).default('random'),
+      hidden: z.boolean().default(false),
+    });
+
+    const { actorIds, placement, hidden } = schema.parse(args);
+
+    this.logger.info('Placing existing actors on scene', {
+      count: actorIds.length,
+      placement,
+      hidden,
+    });
+
+    // The module already exposes a GM-gated addActorsToScene query taking existing
+    // world actor IDs; expose it here rather than only via create-from-compendium.
+    return await this.foundryClient.query('foundry-mcp-bridge.addActorsToScene', {
+      actorIds,
+      placement,
+      hidden,
+    });
   }
 
   private async handleDescribe(): Promise<any> {


### PR DESCRIPTION
Addresses #75.

## Gap
`create-actor-from-compendium` can drop a **newly created** actor on the scene, but there was no MCP path to place an actor **already in the world** (session NPCs, reused monsters). The workaround was recreating from the pack (duplicating the actor).

## Fix
The module already exposes a GM-gated `addActorsToScene` query taking `{ actorIds, placement, hidden }` — it was just only reachable via create-from-compendium. This adds a **`place` action to `manage-actors`** that forwards existing `actorIds` to that query.

- No new top-level tool (matches the consolidation approach), no module changes — reuses the existing handler.
- `placement`: `random` (default) / `grid` / `center`; `hidden` defaults to false.

## Tests
Tool-layer tests: action advertised, forwards correctly, defaults applied, empty-ids rejected. 153 tests pass; schema smoke passes.

Leaving #75 open for you to close.