### PR TITLE
Raw document tools, persistent reconnect, headless GM runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Added
+- Raw document tools: `import-actor`, `export-actor`, `manage-compendium`, `manage-actor-items`, `update-actor-raw`, `run-script`, `bridge-info`. Full actor source (items with activities, effects, prototype token) goes in and out unchanged, world compendiums can be created and filled, embedded items and actors accept verbatim updates (dotted keys and `-=` deletions), and a script can run in the GM client. See `docs/raw-actor-tools.md`.
+- File-backed arguments (`filePath`, `scriptFile`, `outFile`) handled by the stdio wrapper on the machine that runs the MCP client, so the backend may live on another host.
+- `FOUNDRY_BIND_HOST` for the backend: bind the module-facing WebSocket and WebRTC signaling listeners to a specific interface (for example `127.0.0.1` when the backend runs next to Foundry on a public server).
+- Client-scoped module setting "Act as MCP bridge client" so extra GM sessions can stay passive.
+- `scripts/headless-gm/headless-gm.mjs`: a puppeteer runner that keeps a dedicated GM user logged in next to the Foundry server so the bridge does not depend on anyone's browser.
+- `scripts/mcp-call.mjs` (call any tool from the shell through the wrapper) and `scripts/deploy-module.sh` (rsync the built module to a remote Foundry data directory).
+
+### Changed
+- The module reconnects indefinitely with capped backoff instead of giving up after five attempts, and the heartbeat keeps retrying while the MCP server is down.
+- Connection type `auto` picks WebSocket for loopback hosts even on HTTPS pages; the WebRTC signaling path is only used for remote hosts.
+
 ## v0.8.3 (2026-06-11)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Foundry MCP Bridge enables natural AI conversations with your Foundry VTT ga
 - **Dice Coordination**: Interactive roll requests with player targeting
 - **Campaign Management**: Multi-part quest and campaign tracking
 - **Map Generation**: Create maps from prompts and automatically upload them into scenes in Foundry VTT using the optional ComfyUI component
+- **Raw Document Access**: Import and export complete actors (items with activities included), manage world compendiums, apply verbatim item and actor updates, and run scripts in the GM client - see [docs/raw-actor-tools.md](docs/raw-actor-tools.md)
 
 ## Installation
 

--- a/docs/raw-actor-tools.md
+++ b/docs/raw-actor-tools.md
@@ -1,0 +1,38 @@
+# Raw document tools
+
+Seven tools that give an MCP client the same level of access a GM has in the Foundry console, without going through system-specific helpers. They were written for D&D 5e 4.x/5.x actors whose buttons live in `system.activities`, but nothing in them is system-specific: documents go in and out as Foundry source data.
+
+All of them run through the Foundry module as `foundry-mcp-bridge.raw.*` queries (`packages/foundry-module/src/raw-handlers.ts`) and are exposed by `packages/mcp-server/src/tools/raw-actor.ts`. Every handler requires a GM user and the module setting **Allow write operations** for anything that writes.
+
+| Tool | What it does |
+|---|---|
+| `import-actor` | Create complete actors from source data (`system`, `items` with activities, `effects`, `prototypeToken`, `flags`) in the world or in a compendium pack. `replace: "byName"` (default) deletes same-named documents in the destination first; `keepId` keeps the `_id` values from the source. Failures are per actor and reported in `errors`. |
+| `export-actor` | Return `actor.toObject()` for a world actor or a compendium entry. With `outFile` the payload is written to disk by the wrapper and the response shrinks to a summary. |
+| `manage-compendium` | `list`, `create`, `contents`, `delete-entries`, `lock`, `unlock`, `delete-pack` for world packs (creation and deletion are world packs only). Locked packs are unlocked for the duration of a write and re-locked afterwards. |
+| `manage-actor-items` | `list`, `create` (full item source), `update-raw` (passed to `updateEmbeddedDocuments` verbatim, so dotted keys and `-=` deletions work), `delete`. |
+| `update-actor-raw` | `actor.update(update)` verbatim. Unlike `manage-actors`, nested objects are not replaced wholesale. |
+| `run-script` | Run the body of an async function inside the GM client with `game` available and `args` passed in. Errors and stack traces come back in the result instead of failing the call. |
+| `bridge-info` | Which user, world, system and connection type the bridge is running as. |
+
+## Actor identifiers
+
+`actorIdentifier` resolves in this order: UUID (world actors and compendium entries), world actor id, exact world actor name, then a case-insensitive partial name match. An ambiguous partial match is an error that lists the candidates.
+
+`pack` resolves as collection id (`world.my-bestiary`), then pack label, then pack name.
+
+## Files stay on the client machine
+
+`filePath`, `scriptFile` and `outFile` are handled by the stdio wrapper (`packages/mcp-server/src/tool-files.ts`) before the call reaches the backend, so the backend can run on a different host than the MCP client. A `filePath` for `import-actor` may hold one actor object or an array; for `manage-actor-items` it feeds `items` or `updates` depending on `action`; for `update-actor-raw` it holds the update object; `scriptFile` holds the script text. Inline responses are capped at 200,000 characters; `export-actor` beyond that requires `outFile`.
+
+## Typical flow: building a monster with buttons
+
+1. Build the actor source however you like (an exporter, a converter from a stat block, or a copy of an SRD actor from `export-actor`). For dnd5e 5.x each button is an activity inside an item: `attack`, `save`, `damage`, `heal`, `utility`, `cast`, with `activation.type` (`action`, `bonus`, `reaction`, `legendary`) and `consumption.targets` for charges, item uses or `resources.legact.value`.
+2. `manage-compendium` with `action: "create"` once, to get a world pack.
+3. `import-actor` with `filePath` and `destination: { type: "pack", pack: "world.my-bestiary" }`.
+4. Verify without opening a sheet through `run-script`, for example by reading `activity.labels` (`toHit`, `damage`, `save`, `range`, `target`) on the imported document.
+
+## Running the bridge without a browser
+
+`scripts/headless-gm/headless-gm.mjs` keeps a dedicated GM user logged in through a headless Chrome next to the Foundry server. Together with `FOUNDRY_BIND_HOST=127.0.0.1` on the backend and an SSH tunnel to the control port (31414) from the MCP client machine, the bridge stays up as long as the server does. See the comments at the top of the script for the environment variables; `HEADLESS_NO_CANVAS=1` disables canvas rendering for that user to keep CPU usage near zero.
+
+Other GM sessions on the same world should untick the client-scoped module setting **Act as MCP bridge client**, otherwise every GM browser tries to reach the MCP server on its own localhost.

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -30,7 +30,7 @@
     }
   ],
   "socket": true,
-  "manifest": "https://github.com/adambdooley/foundry-vtt-mcp/releases/latest/download/module.json",
+  "manifest": "https://raw.githubusercontent.com/adambdooley/foundry-vtt-mcp/master/packages/foundry-module/module.json",
   "download": "https://github.com/adambdooley/foundry-vtt-mcp/releases/latest/download/foundry-vtt-mcp.zip",
   "protected": false,
   "coreTranslation": false,

--- a/packages/foundry-module/src/main.ts
+++ b/packages/foundry-module/src/main.ts
@@ -6,6 +6,9 @@ import { CampaignHooks } from './campaign-hooks.js';
 import { ComfyUIManager } from './comfyui-manager.js';
 // Connection control now handled through settings menu
 
+/** How often, at most, the "MCP Server not found" notification may be shown. */
+const MCP_SERVER_NOTIFICATION_INTERVAL_MS = 10 * 60 * 1000;
+
 /**
  * Main Foundry MCP Bridge Module Class
  */
@@ -19,6 +22,7 @@ class FoundryMCPBridge {
   private heartbeatInterval: number | null = null;
   private lastActivity: Date = new Date();
   private isConnecting = false;
+  private heartbeatFailures = 0;
 
   constructor() {
     this.settings = new ModuleSettings();
@@ -165,6 +169,16 @@ class FoundryMCPBridge {
       return;
     }
 
+    // Client-scope opt-out: a GM browser with "Act as MCP bridge client" unticked
+    // stays passive - no socket, no heartbeat, no error.
+    if (!this.settings.getSetting('actAsBridge')) {
+      console.log(
+        `[${MODULE_ID}] Act as MCP bridge client is off for this browser - staying passive`
+      );
+      this.settings.updateConnectionStatusDisplay(false, 0);
+      return;
+    }
+
     if (this.socketBridge?.isConnected() || this.isConnecting) {
       console.log(`[${MODULE_ID}] Bridge already running or connecting`);
       return;
@@ -223,12 +237,13 @@ class FoundryMCPBridge {
           errorMessage.includes('ECONNREFUSED') ||
           errorMessage.includes('connect ECONNREFUSED')
         ) {
-          // Only show this notification if it's been more than 30 seconds since last shown
+          // Reconnect now runs forever, so this notification is throttled hard:
+          // once per 10 minutes, not once per retry.
           const lastShown = this.settings.getSetting('lastMCPServerNotification') as string;
           const now = new Date().getTime();
-          const thirtySecondsAgo = now - 30 * 1000;
+          const throttleCutoff = now - MCP_SERVER_NOTIFICATION_INTERVAL_MS;
 
-          if (!lastShown || new Date(lastShown).getTime() < thirtySecondsAgo) {
+          if (!lastShown || new Date(lastShown).getTime() < throttleCutoff) {
             ui.notifications?.warn(
               'MCP Server not found. Install it from https://github.com/adambdooley/foundry-vtt-mcp'
             );
@@ -259,6 +274,11 @@ class FoundryMCPBridge {
       return;
     }
 
+    // Remembered before the disconnect: only a live connection is worth announcing.
+    // The heartbeat restarts the bridge on every tick while the server is down, and
+    // a toast per tick would be unreadable.
+    const wasConnected = this.socketBridge.isConnected();
+
     try {
       console.log(`[${MODULE_ID}] Stopping MCP bridge...`);
 
@@ -276,7 +296,7 @@ class FoundryMCPBridge {
       console.log(`[${MODULE_ID}] Bridge stopped`);
 
       // Show disconnection notification based on user preference
-      if (this.settings.getSetting('enableNotifications')) {
+      if (wasConnected && this.settings.getSetting('enableNotifications')) {
         ui.notifications.info('MCP Bridge disconnected');
       }
     } catch (error) {
@@ -307,6 +327,7 @@ class FoundryMCPBridge {
     return {
       initialized: this.isInitialized,
       enabled: this.settings.getSetting('enabled'),
+      actAsBridge: this.settings.getSetting('actAsBridge'),
       connected: this.socketBridge?.isConnected() ?? false,
       connectionState: this.socketBridge?.getConnectionState() ?? 'disconnected',
       connectionInfo: this.socketBridge?.getConnectionInfo(),
@@ -349,38 +370,42 @@ class FoundryMCPBridge {
    */
   private async performHeartbeat(): Promise<void> {
     try {
+      // A passive browser has nothing to keep alive
+      if (!this.settings.getSetting('actAsBridge')) {
+        return;
+      }
+
       // Lightweight connection check - just verify socket state
       if (!this.socketBridge || !this.socketBridge.isConnected()) {
-        // Only log once per disconnection to avoid spam
-        if (this.lastActivity && new Date().getTime() - this.lastActivity.getTime() > 60000) {
-          console.warn(`[${MODULE_ID}] Heartbeat: Connection lost`);
-
-          // Attempt auto-reconnection if enabled (with backoff)
-          if (this.settings.getSetting('autoReconnectEnabled')) {
-            console.log(`[${MODULE_ID}] Attempting auto-reconnection...`);
-            await this.restart();
-          }
+        // Retry on every heartbeat for as long as the socket stays down. The
+        // reconnect ceiling is gone on purpose: a GM tab left open over a server
+        // restart has to come back on its own.
+        if (this.settings.getSetting('autoReconnectEnabled')) {
+          await this.restart();
         }
         return;
       }
 
       // Just update activity timestamp - no actual network ping needed
       // The socket bridge already handles connection state monitoring
+      this.heartbeatFailures = 0;
       this.updateLastActivity();
     } catch (error) {
-      // Only attempt reconnect once per failure cycle
-      if (this.settings.getSetting('autoReconnectEnabled')) {
-        console.log(`[${MODULE_ID}] Heartbeat failure - attempting single reconnection...`);
-        try {
-          await this.restart();
-        } catch (reconnectError) {
-          console.error(`[${MODULE_ID}] Auto-reconnection failed:`, reconnectError);
-          // Disable further attempts until manual intervention
-          await this.settings.setSetting('autoReconnectEnabled', false);
-          if (this.settings.getSetting('enableNotifications')) {
-            ui.notifications.warn('⚠️ Lost connection to AI model - Auto-reconnect disabled');
-          }
-        }
+      // Never latch auto-reconnect off - the next heartbeat tries again.
+      // Logged on the first failure and every tenth after it, so an MCP server
+      // left down overnight does not fill the console.
+      this.heartbeatFailures++;
+      if (this.heartbeatFailures === 1 || this.heartbeatFailures % 10 === 0) {
+        console.warn(
+          `[${MODULE_ID}] Heartbeat reconnect failed (attempt ${this.heartbeatFailures}), retrying on next tick:`,
+          error
+        );
+      }
+
+      // restart() stops the heartbeat through stop(); when the following start()
+      // throws, nothing re-arms it and the retry loop dies with the first failure.
+      if (this.heartbeatInterval === null) {
+        this.startHeartbeat();
       }
     }
   }
@@ -591,16 +616,21 @@ Hooks.once('ready', async () => {
 // Handle settings menu close to check for changes
 Hooks.on('closeSettingsConfig', () => {
   try {
-    const enabled = foundryMCPBridge.getStatus().enabled;
-    const connected = foundryMCPBridge.getStatus().connected;
+    const status = foundryMCPBridge.getStatus();
+    // The bridge should run only when the world enables it AND this browser
+    // volunteers to be the bridge client.
+    const shouldRun = status.enabled && status.actAsBridge !== false;
+    // connectionInfo is present whenever a socket bridge object exists, which
+    // also covers a connection still in progress.
+    const hasBridge = status.connected || status.connectionInfo !== undefined;
 
-    if (enabled && !connected) {
-      // Setting was enabled but not connected, try to start
+    if (shouldRun && !status.connected) {
+      // Newly enabled here, connect
       foundryMCPBridge.start().catch(error => {
         console.error(`[${MODULE_ID}] Failed to start after settings change:`, error);
       });
-    } else if (!enabled && connected) {
-      // Setting was disabled but still connected, stop
+    } else if (!shouldRun && hasBridge) {
+      // Turned off world-wide or on this browser, drop the socket
       foundryMCPBridge.stop().catch(error => {
         console.error(`[${MODULE_ID}] Failed to stop after settings change:`, error);
       });

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -1,14 +1,17 @@
 import { MODULE_ID } from './constants.js';
 import { FoundryDataAccess } from './data-access.js';
 import { ComfyUIManager } from './comfyui-manager.js';
+import { RawHandlers } from './raw-handlers.js';
 
 export class QueryHandlers {
   public dataAccess: FoundryDataAccess;
   private comfyuiManager: ComfyUIManager;
+  private rawHandlers: RawHandlers;
 
   constructor() {
     this.dataAccess = new FoundryDataAccess();
     this.comfyuiManager = new ComfyUIManager();
+    this.rawHandlers = new RawHandlers(this.dataAccess);
   }
 
   /**
@@ -158,6 +161,9 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.addSpellsToActor`] = this.handleAddSpellsToActor.bind(this);
     CONFIG.queries[`${modulePrefix}.addFeaturesFromCompendium`] =
       this.handleAddFeaturesFromCompendium.bind(this);
+
+    // Raw document queries (raw.*), kept in their own file
+    this.rawHandlers.registerHandlers();
   }
 
   /**

--- a/packages/foundry-module/src/raw-handlers.ts
+++ b/packages/foundry-module/src/raw-handlers.ts
@@ -1,0 +1,997 @@
+import { MODULE_ID } from './constants.js';
+import type { FoundryDataAccess } from './data-access.js';
+
+/**
+ * Raw document handlers.
+ *
+ * Everything registered here lives under `CONFIG.queries['foundry-mcp-bridge.raw.*']`
+ * and is deliberately kept out of `queries.ts` so upstream merges stay conflict-free.
+ * The theme is round-trip fidelity: full Foundry actor source documents (items with
+ * dnd5e activities included) in and out, world compendium management, verbatim
+ * document updates and a scripting escape hatch for the GM client.
+ */
+
+/** Default Actor folder used by importActors when the caller gives none. */
+const DEFAULT_IMPORT_FOLDER = 'Imported Actors';
+
+/** Upper bound on a single importActors batch. */
+const MAX_IMPORT_ACTORS = 50;
+
+/** Default runScript timeout. */
+const DEFAULT_SCRIPT_TIMEOUT_MS = 60000;
+
+/** Document types a world compendium may be created for. */
+const COMPENDIUM_DOCUMENT_TYPES = [
+  'Actor',
+  'Item',
+  'JournalEntry',
+  'Scene',
+  'RollTable',
+  'Macro',
+] as const;
+
+type AccessDenial = { success: false; error: string };
+
+interface ActorRef {
+  id: string;
+  name: string;
+  uuid: string;
+}
+
+export class RawHandlers {
+  constructor(private dataAccess: FoundryDataAccess) {}
+
+  /**
+   * Register every raw.* query handler in CONFIG.queries.
+   * Unregistration is handled by QueryHandlers.unregisterHandlers(), which drops
+   * every key with the module prefix.
+   */
+  registerHandlers(): void {
+    const prefix = `${MODULE_ID}.raw`;
+
+    CONFIG.queries[`${prefix}.importActors`] = this.handleImportActors.bind(this);
+    CONFIG.queries[`${prefix}.exportActor`] = this.handleExportActor.bind(this);
+    CONFIG.queries[`${prefix}.manageCompendium`] = this.handleManageCompendium.bind(this);
+    CONFIG.queries[`${prefix}.manageActorItems`] = this.handleManageActorItems.bind(this);
+    CONFIG.queries[`${prefix}.updateActor`] = this.handleUpdateActor.bind(this);
+    CONFIG.queries[`${prefix}.runScript`] = this.handleRunScript.bind(this);
+    CONFIG.queries[`${prefix}.bridgeInfo`] = this.handleBridgeInfo.bind(this);
+  }
+
+  // ─── Gates and shared helpers ───────────────────────────────────────────────
+
+  /**
+   * SECURITY: GM-only, plus the world-level write toggle for mutating handlers.
+   * Returns a denial payload to send back verbatim, or null when the call may proceed.
+   */
+  private checkAccess(requiresWrite: boolean): AccessDenial | null {
+    if (!game.user?.isGM) {
+      // Silent failure - no detail for non-GM users
+      return { success: false, error: 'Access denied' };
+    }
+
+    if (requiresWrite) {
+      let allowed = true;
+      try {
+        allowed = game.settings.get(MODULE_ID, 'allowWriteOperations') !== false;
+      } catch {
+        allowed = true;
+      }
+      if (!allowed) {
+        return { success: false, error: 'Write operations disabled' };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Audit a write the same way data-access does. `auditLog` is private to
+   * FoundryDataAccess in TypeScript terms only, so it is reachable at runtime;
+   * fall back to the console when it is not.
+   */
+  private audit(operation: string, data: any, result: 'success' | 'failure', error?: string): void {
+    const target = this.dataAccess as any;
+    if (typeof target?.auditLog === 'function') {
+      try {
+        target.auditLog(`raw.${operation}`, data, result, error);
+        return;
+      } catch {
+        // fall through to console logging
+      }
+    }
+    console.log(`[${MODULE_ID}] raw.${operation} ${result}`, data, error ?? '');
+  }
+
+  private static describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  /**
+   * Resolve an actor identifier: UUID, then world id, then exact world name,
+   * then a case-insensitive partial name match. An ambiguous partial match is an
+   * error listing the candidates. With `packId` the lookup is confined to that pack.
+   */
+  private async resolveActor(identifier: string, packId?: string): Promise<any> {
+    if (typeof identifier !== 'string' || identifier.trim().length === 0) {
+      throw new Error('actorIdentifier is required');
+    }
+
+    if (packId) {
+      const pack = this.resolvePack(packId);
+      const found = await this.findPackActor(pack, identifier);
+      if (!found) {
+        throw new Error(`Actor "${identifier}" not found in compendium ${pack.collection}`);
+      }
+      return found;
+    }
+
+    // 1. UUID (also covers Compendium.world.xxx.Actor.id)
+    if (identifier.includes('.')) {
+      try {
+        const doc = await (globalThis as any).fromUuid(identifier);
+        if (doc?.documentName === 'Actor') return doc;
+      } catch {
+        // not a UUID - fall through to the name/id lookups
+      }
+    }
+
+    const actors = (game as any).actors;
+
+    // 2. World id
+    const byId = actors?.get(identifier);
+    if (byId) return byId;
+
+    // 3. Exact world name
+    const byName = actors?.getName?.(identifier);
+    if (byName) return byName;
+
+    // 4. Case-insensitive partial name
+    const needle = identifier.toLowerCase();
+    const partial: any[] =
+      actors?.filter(
+        (a: any) => typeof a.name === 'string' && a.name.toLowerCase().includes(needle)
+      ) ?? [];
+
+    if (partial.length === 1) return partial[0];
+    if (partial.length > 1) {
+      const candidates = partial.map((a: any) => `${a.name} (${a.id})`).join(', ');
+      throw new Error(`Ambiguous actorIdentifier "${identifier}" - candidates: ${candidates}`);
+    }
+
+    throw new Error(`Actor not found: ${identifier}`);
+  }
+
+  /** Find an actor inside a compendium by id or exact name. */
+  private async findPackActor(pack: any, identifier: string): Promise<any> {
+    const byId = await pack.getDocument(identifier).catch(() => null);
+    if (byId) return byId;
+
+    const byName = await pack.getDocuments({ name: identifier }).catch(() => []);
+    if (Array.isArray(byName) && byName.length > 0) return byName[0];
+
+    const index: any[] = Array.from(await pack.getIndex());
+    const entry = index.find((e: any) => e.name?.toLowerCase() === identifier.toLowerCase());
+    if (entry) return await pack.getDocument(entry._id);
+
+    return null;
+  }
+
+  /** Resolve a compendium by collection id, then exact label, then machine name. */
+  private resolvePack(identifier: string): any {
+    if (typeof identifier !== 'string' || identifier.trim().length === 0) {
+      throw new Error('pack is required');
+    }
+
+    const packs = (game as any).packs;
+    const direct = packs?.get(identifier);
+    if (direct) return direct;
+
+    const all: any[] = Array.from(packs ?? []);
+    const byLabel = all.find(p => p.metadata?.label === identifier);
+    if (byLabel) return byLabel;
+
+    const byName = all.find(p => p.metadata?.name === identifier);
+    if (byName) return byName;
+
+    throw new Error(`Compendium not found: ${identifier}`);
+  }
+
+  /** Run a mutating operation against a pack, temporarily unlocking it if needed. */
+  private async withUnlockedPack<T>(pack: any, operation: () => Promise<T>): Promise<T> {
+    const wasLocked = pack.locked === true;
+
+    if (wasLocked) {
+      await pack.configure({ locked: false });
+    }
+
+    try {
+      return await operation();
+    } finally {
+      if (wasLocked) {
+        try {
+          await pack.configure({ locked: true });
+        } catch (error) {
+          console.warn(
+            `[${MODULE_ID}] Failed to re-lock compendium ${pack.collection}: ${RawHandlers.describeError(error)}`
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Find, or create, an Actor folder by name. Mirrors the private helper in
+   * data-access (folder lookup by name + type, creation with module flags) without
+   * touching upstream code.
+   */
+  private async getOrCreateActorFolder(folderName: string): Promise<string | null> {
+    try {
+      const existing = (game as any).folders?.find(
+        (f: any) => f.name === folderName && f.type === 'Actor'
+      );
+      if (existing) return existing.id;
+
+      const folder = await (globalThis as any).Folder.create({
+        name: folderName,
+        type: 'Actor',
+        description: `Actors imported via MCP bridge: ${folderName}`,
+        color: '#4a90e2',
+        sort: 0,
+        parent: null,
+        flags: {
+          [MODULE_ID]: {
+            mcpGenerated: true,
+            createdAt: new Date().toISOString(),
+          },
+        },
+      });
+      return folder?.id ?? null;
+    } catch (error) {
+      console.warn(
+        `[${MODULE_ID}] Failed to create folder "${folderName}": ${RawHandlers.describeError(error)}`
+      );
+      // Fall back to a folderless import rather than failing the whole batch
+      return null;
+    }
+  }
+
+  private static actorRef(doc: any): ActorRef {
+    return { id: doc?.id, name: doc?.name, uuid: doc?.uuid };
+  }
+
+  /** Both a Collection and a plain object are valid shapes for system.activities. */
+  private static activityList(raw: any): any[] {
+    if (!raw) return [];
+    const source = raw.contents ?? raw;
+    if (Array.isArray(source)) return source;
+    if (typeof source === 'object') return Object.values(source as Record<string, any>);
+    return [];
+  }
+
+  // ─── 2.1 importActors ───────────────────────────────────────────────────────
+
+  private async handleImportActors(data: {
+    actors: any[];
+    destination: { type: 'world'; folder?: string } | { type: 'pack'; pack: string };
+    replace?: 'byName' | 'none';
+    keepId?: boolean;
+  }): Promise<any> {
+    const denied = this.checkAccess(true);
+    if (denied) return denied;
+
+    this.dataAccess.validateFoundryState();
+
+    const actors = data?.actors;
+    if (!Array.isArray(actors) || actors.length === 0) {
+      throw new Error('actors array is required and must contain at least one entry');
+    }
+    if (actors.length > MAX_IMPORT_ACTORS) {
+      throw new Error(`actors array cannot contain more than ${MAX_IMPORT_ACTORS} entries`);
+    }
+
+    const destination = data?.destination;
+    if (!destination || (destination.type !== 'world' && destination.type !== 'pack')) {
+      throw new Error("destination is required and must be { type: 'world' } or { type: 'pack' }");
+    }
+
+    const replace = data?.replace ?? 'byName';
+    const keepId = data?.keepId === true;
+
+    const toPack = destination.type === 'pack';
+    const pack = toPack ? this.resolvePack(destination.pack) : null;
+    if (pack && pack.metadata?.type !== 'Actor') {
+      throw new Error(
+        `Compendium ${pack.collection} holds ${pack.metadata?.type} documents, not Actor`
+      );
+    }
+
+    const folderName = toPack
+      ? null
+      : ((destination as { type: 'world'; folder?: string }).folder ?? DEFAULT_IMPORT_FOLDER);
+    const folderId = folderName ? await this.getOrCreateActorFolder(folderName) : null;
+
+    // Pack index is consulted once per batch for replace lookups
+    if (pack && replace === 'byName') {
+      await pack.getIndex();
+    }
+
+    const created: ActorRef[] = [];
+    const replaced: ActorRef[] = [];
+    const errors: Array<{ name: string; error: string }> = [];
+
+    // One actor at a time: a rejected document must not take the batch with it
+    const importBatch = async (): Promise<void> => {
+      for (const raw of actors) {
+        const name = typeof raw?.name === 'string' ? raw.name : '(unnamed)';
+
+        try {
+          if (typeof raw?.name !== 'string' || raw.name.trim().length === 0) {
+            throw new Error('"name" is required and must be a non-empty string');
+          }
+          if (typeof raw?.type !== 'string' || raw.type.trim().length === 0) {
+            throw new Error('"type" is required and must be a non-empty string');
+          }
+
+          if (replace === 'byName') {
+            const gone = pack
+              ? await this.replaceInPack(pack, raw.name)
+              : await this.replaceInWorld(raw.name, folderId);
+            replaced.push(...gone);
+          }
+
+          const doc = RawHandlers.prepareActorDoc(raw, keepId, toPack ? null : folderId);
+          const ActorClass = (globalThis as any).Actor;
+          const impl = ActorClass?.implementation ?? ActorClass;
+
+          const options: Record<string, any> = { keepId };
+          if (pack) options.pack = pack.collection;
+
+          const result = await impl.createDocuments([doc], options);
+          const madeDoc = Array.isArray(result) ? result[0] : result;
+          if (!madeDoc) {
+            throw new Error('Foundry returned no document');
+          }
+
+          created.push(RawHandlers.actorRef(madeDoc));
+        } catch (error) {
+          errors.push({ name, error: RawHandlers.describeError(error) });
+        }
+      }
+    };
+
+    // A locked target pack is unlocked for the batch and locked again afterwards
+    if (pack) {
+      await this.withUnlockedPack(pack, importBatch);
+    } else {
+      await importBatch();
+    }
+
+    const destinationInfo = pack
+      ? { type: 'pack' as const, pack: pack.collection }
+      : { type: 'world' as const, folder: folderName };
+
+    this.audit(
+      'importActors',
+      {
+        destination: destinationInfo,
+        requested: actors.length,
+        created: created.length,
+        replaced: replaced.length,
+        errors: errors.length,
+      },
+      errors.length === actors.length ? 'failure' : 'success'
+    );
+
+    return { created, replaced, errors, destination: destinationInfo };
+  }
+
+  /**
+   * Turn an ActorData source object into a document ready for createDocuments.
+   * `folder` from the payload is dropped (the destination decides), `_stats` is
+   * always dropped (Foundry writes its own) and ids are dropped unless kept.
+   */
+  private static prepareActorDoc(
+    raw: any,
+    keepId: boolean,
+    folderId: string | null
+  ): Record<string, any> {
+    const doc: Record<string, any> = { ...raw };
+
+    delete doc._stats;
+    delete doc.folder;
+    if (!keepId) delete doc._id;
+
+    if (Array.isArray(doc.items)) {
+      doc.items = doc.items.map((item: any) => {
+        const copy: Record<string, any> = { ...item };
+        if (!keepId) delete copy._id;
+        return copy;
+      });
+    }
+
+    if (Array.isArray(doc.effects) && !keepId) {
+      doc.effects = doc.effects.map((effect: any) => {
+        const copy: Record<string, any> = { ...effect };
+        delete copy._id;
+        return copy;
+      });
+    }
+
+    if (folderId) doc.folder = folderId;
+
+    return doc;
+  }
+
+  /** Delete world actors of the same name inside the target folder. */
+  private async replaceInWorld(name: string, folderId: string | null): Promise<ActorRef[]> {
+    const matches: any[] =
+      (game as any).actors?.filter(
+        (a: any) => a.name === name && (a.folder?.id ?? null) === folderId
+      ) ?? [];
+
+    const removed: ActorRef[] = [];
+    for (const actor of matches) {
+      const ref = RawHandlers.actorRef(actor);
+      await actor.delete();
+      removed.push(ref);
+    }
+    return removed;
+  }
+
+  /** Delete compendium entries of the same name, unlocking the pack if needed. */
+  private async replaceInPack(pack: any, name: string): Promise<ActorRef[]> {
+    const entries = Array.from(pack.index ?? []).filter((e: any) => e.name === name) as any[];
+    if (entries.length === 0) return [];
+
+    return await this.withUnlockedPack(pack, async () => {
+      const removed: ActorRef[] = [];
+      for (const entry of entries) {
+        const doc = await pack.getDocument(entry._id);
+        if (!doc) continue;
+        const ref = RawHandlers.actorRef(doc);
+        await doc.delete();
+        removed.push(ref);
+      }
+      return removed;
+    });
+  }
+
+  // ─── 2.2 exportActor ────────────────────────────────────────────────────────
+
+  private async handleExportActor(data: { actorIdentifier: string; pack?: string }): Promise<any> {
+    const denied = this.checkAccess(false);
+    if (denied) return denied;
+
+    this.dataAccess.validateFoundryState();
+
+    const actor = await this.resolveActor(data?.actorIdentifier, data?.pack);
+    const source = actor.toObject();
+    const itemCount = Array.isArray(source?.items) ? source.items.length : 0;
+
+    return {
+      uuid: actor.uuid,
+      name: actor.name,
+      type: actor.type,
+      itemCount,
+      data: source,
+    };
+  }
+
+  // ─── 2.3 manageCompendium ───────────────────────────────────────────────────
+
+  private async handleManageCompendium(data: {
+    action: 'list' | 'create' | 'contents' | 'delete-entries' | 'lock' | 'unlock' | 'delete-pack';
+    pack?: string;
+    label?: string;
+    name?: string;
+    documentType?: string;
+    entryIds?: string[];
+    entryNames?: string[];
+  }): Promise<any> {
+    const action = data?.action;
+    const isWrite = action !== 'list' && action !== 'contents';
+
+    const denied = this.checkAccess(isWrite);
+    if (denied) return denied;
+
+    this.dataAccess.validateFoundryState();
+
+    switch (action) {
+      case 'list':
+        return this.listCompendiums();
+      case 'create':
+        return await this.createCompendium(data);
+      case 'contents':
+        return await this.compendiumContents(data?.pack ?? '');
+      case 'delete-entries':
+        return await this.deleteCompendiumEntries(data);
+      case 'lock':
+      case 'unlock':
+        return await this.setCompendiumLock(data?.pack ?? '', action === 'lock');
+      case 'delete-pack':
+        return await this.deleteCompendiumPack(data?.pack ?? '');
+      default:
+        throw new Error(
+          `Unknown action "${String(action)}". Valid actions: list, create, contents, delete-entries, lock, unlock, delete-pack`
+        );
+    }
+  }
+
+  private listCompendiums(): any[] {
+    const packs: any[] = Array.from((game as any).packs ?? []);
+
+    return packs.map(pack => ({
+      collection: pack.collection,
+      label: pack.metadata?.label,
+      type: pack.metadata?.type,
+      locked: pack.locked === true,
+      size: pack.index?.size ?? 0,
+      package: pack.metadata?.packageType,
+      packageName: pack.metadata?.packageName,
+    }));
+  }
+
+  private async createCompendium(data: {
+    label?: string;
+    name?: string;
+    documentType?: string;
+  }): Promise<any> {
+    const label = data?.label;
+    if (typeof label !== 'string' || label.trim().length === 0) {
+      throw new Error('label is required to create a compendium');
+    }
+
+    const documentType = data?.documentType ?? 'Actor';
+    if (!(COMPENDIUM_DOCUMENT_TYPES as readonly string[]).includes(documentType)) {
+      throw new Error(
+        `Unknown documentType "${documentType}". Valid types: ${COMPENDIUM_DOCUMENT_TYPES.join(', ')}`
+      );
+    }
+
+    const name = data?.name?.trim() ? data.name.trim() : RawHandlers.slugify(label);
+    if (!name) {
+      throw new Error(
+        `Could not derive a machine name from label "${label}" - pass "name" explicitly`
+      );
+    }
+
+    const existing = (game as any).packs?.get(`world.${name}`);
+    if (existing) {
+      return {
+        existed: true,
+        collection: existing.collection,
+        label: existing.metadata?.label,
+        type: existing.metadata?.type,
+        locked: existing.locked === true,
+        size: existing.index?.size ?? 0,
+      };
+    }
+
+    const CompendiumCollectionClass =
+      (globalThis as any).foundry?.documents?.collections?.CompendiumCollection ??
+      (globalThis as any).CompendiumCollection;
+
+    if (!CompendiumCollectionClass?.createCompendium) {
+      throw new Error('CompendiumCollection.createCompendium is unavailable in this Foundry build');
+    }
+
+    const pack = await CompendiumCollectionClass.createCompendium({
+      type: documentType,
+      label,
+      name,
+    });
+
+    this.audit('manageCompendium.create', { name, label, documentType }, 'success');
+
+    return {
+      existed: false,
+      collection: pack?.collection ?? `world.${name}`,
+      label: pack?.metadata?.label ?? label,
+      type: pack?.metadata?.type ?? documentType,
+      locked: pack?.locked === true,
+      size: pack?.index?.size ?? 0,
+    };
+  }
+
+  /** Latin/dash machine name; Cyrillic labels are transliterated first. */
+  private static slugify(label: string): string {
+    const map: Record<string, string> = {
+      а: 'a',
+      б: 'b',
+      в: 'v',
+      г: 'g',
+      д: 'd',
+      е: 'e',
+      ё: 'e',
+      ж: 'zh',
+      з: 'z',
+      и: 'i',
+      й: 'y',
+      к: 'k',
+      л: 'l',
+      м: 'm',
+      н: 'n',
+      о: 'o',
+      п: 'p',
+      р: 'r',
+      с: 's',
+      т: 't',
+      у: 'u',
+      ф: 'f',
+      х: 'h',
+      ц: 'c',
+      ч: 'ch',
+      ш: 'sh',
+      щ: 'sch',
+      ъ: '',
+      ы: 'y',
+      ь: '',
+      э: 'e',
+      ю: 'yu',
+      я: 'ya',
+    };
+
+    const transliterated = Array.from(label.toLowerCase())
+      .map(ch => (ch in map ? map[ch] : ch))
+      .join('');
+
+    return transliterated
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64);
+  }
+
+  private async compendiumContents(packId: string): Promise<any[]> {
+    const pack = this.resolvePack(packId);
+    const index: any[] = Array.from(await pack.getIndex());
+    const documentType = pack.metadata?.type;
+
+    return index.map(entry => ({
+      _id: entry._id,
+      name: entry.name,
+      type: entry.type ?? documentType,
+      img: entry.img ?? null,
+      uuid: entry.uuid ?? `Compendium.${pack.collection}.${documentType}.${entry._id}`,
+    }));
+  }
+
+  private async deleteCompendiumEntries(data: {
+    pack?: string;
+    entryIds?: string[];
+    entryNames?: string[];
+  }): Promise<any> {
+    const pack = this.resolvePack(data?.pack ?? '');
+    const ids = Array.isArray(data?.entryIds) ? data.entryIds : [];
+    const names = Array.isArray(data?.entryNames) ? data.entryNames : [];
+
+    if (ids.length === 0 && names.length === 0) {
+      throw new Error('Provide entryIds and/or entryNames identifying the entries to delete');
+    }
+
+    const index: any[] = Array.from(await pack.getIndex());
+    const targets = new Map<string, string>();
+    const notFound: string[] = [];
+
+    for (const id of ids) {
+      const entry = index.find(e => e._id === id);
+      if (entry) targets.set(entry._id, entry.name);
+      else notFound.push(id);
+    }
+
+    for (const name of names) {
+      const matches = index.filter(e => e.name === name);
+      if (matches.length === 0) notFound.push(name);
+      for (const entry of matches) targets.set(entry._id, entry.name);
+    }
+
+    const deleted: Array<{ _id: string; name: string }> = [];
+
+    if (targets.size > 0) {
+      await this.withUnlockedPack(pack, async () => {
+        for (const [id, name] of targets) {
+          const doc = await pack.getDocument(id);
+          if (!doc) {
+            notFound.push(id);
+            continue;
+          }
+          await doc.delete();
+          deleted.push({ _id: id, name });
+        }
+      });
+    }
+
+    this.audit(
+      'manageCompendium.delete-entries',
+      { pack: pack.collection, deleted: deleted.length, notFound: notFound.length },
+      'success'
+    );
+
+    return { pack: pack.collection, deleted, notFound };
+  }
+
+  private async setCompendiumLock(packId: string, locked: boolean): Promise<any> {
+    const pack = this.resolvePack(packId);
+    await pack.configure({ locked });
+
+    this.audit('manageCompendium.lock', { pack: pack.collection, locked }, 'success');
+
+    return { pack: pack.collection, locked };
+  }
+
+  private async deleteCompendiumPack(packId: string): Promise<any> {
+    const pack = this.resolvePack(packId);
+
+    if (pack.metadata?.packageType !== 'world') {
+      throw new Error(
+        `Only world compendiums can be deleted - ${pack.collection} belongs to ${pack.metadata?.packageType} "${pack.metadata?.packageName}"`
+      );
+    }
+
+    const collection = pack.collection;
+    await pack.deleteCompendium();
+
+    this.audit('manageCompendium.delete-pack', { pack: collection }, 'success');
+
+    return { deleted: true, pack: collection };
+  }
+
+  // ─── 2.4 manageActorItems ───────────────────────────────────────────────────
+
+  private async handleManageActorItems(data: {
+    actorIdentifier: string;
+    action: 'list' | 'create' | 'update-raw' | 'delete';
+    items?: any[];
+    updates?: Array<Record<string, any>>;
+    itemIds?: string[];
+  }): Promise<any> {
+    const action = data?.action;
+    const denied = this.checkAccess(action !== 'list');
+    if (denied) return denied;
+
+    this.dataAccess.validateFoundryState();
+
+    const actor = await this.resolveActor(data?.actorIdentifier);
+    let result: any;
+
+    switch (action) {
+      case 'list':
+        result = RawHandlers.listActorItems(actor);
+        break;
+
+      case 'create': {
+        const items = data?.items;
+        if (!Array.isArray(items) || items.length === 0) {
+          throw new Error('items array is required and must contain at least one entry');
+        }
+        const payload = items.map((item: any) => {
+          const copy: Record<string, any> = { ...item };
+          delete copy._id;
+          return copy;
+        });
+        const createdDocs = (await actor.createEmbeddedDocuments('Item', payload)) as any[];
+        result = (createdDocs ?? []).map(doc => ({ _id: doc.id, name: doc.name, type: doc.type }));
+        break;
+      }
+
+      case 'update-raw': {
+        const updates = data?.updates;
+        if (!Array.isArray(updates) || updates.length === 0) {
+          throw new Error('updates array is required and must contain at least one entry');
+        }
+        for (const [idx, update] of updates.entries()) {
+          if (!update || typeof update._id !== 'string' || update._id.length === 0) {
+            throw new Error(`updates[${idx}]: "_id" is required`);
+          }
+        }
+        // Passed to Foundry verbatim: dotted keys and "-=" deletions must survive
+        const updatedDocs = (await actor.updateEmbeddedDocuments('Item', updates)) as any[];
+        result = (updatedDocs ?? []).map(doc => ({ _id: doc.id, name: doc.name }));
+        break;
+      }
+
+      case 'delete': {
+        const itemIds = data?.itemIds;
+        if (!Array.isArray(itemIds) || itemIds.length === 0) {
+          throw new Error('itemIds array is required and must contain at least one entry');
+        }
+        const deletedDocs = (await actor.deleteEmbeddedDocuments('Item', itemIds)) as any[];
+        result = (deletedDocs ?? []).map(doc => ({ _id: doc.id, name: doc.name }));
+        break;
+      }
+
+      default:
+        throw new Error(
+          `Unknown action "${String(action)}". Valid actions: list, create, update-raw, delete`
+        );
+    }
+
+    if (action !== 'list') {
+      this.audit(
+        `manageActorItems.${action}`,
+        { actorId: actor.id, count: Array.isArray(result) ? result.length : 0 },
+        'success'
+      );
+    }
+
+    return { actorId: actor.id, actorName: actor.name, result };
+  }
+
+  private static listActorItems(actor: any): any[] {
+    const items: any[] = actor.items?.contents ?? Array.from(actor.items ?? []);
+
+    return items.map(item => {
+      const uses = item.system?.uses ?? {};
+
+      return {
+        _id: item.id,
+        name: item.name,
+        type: item.type,
+        img: item.img ?? null,
+        uses: {
+          max: uses.max ?? null,
+          spent: uses.spent ?? null,
+          recovery: uses.recovery ?? null,
+        },
+        activities: RawHandlers.activityList(item.system?.activities).map((activity: any) => ({
+          _id: activity._id ?? activity.id ?? null,
+          type: activity.type ?? null,
+          name: activity.name ?? null,
+          activation: activity.activation ?? null,
+        })),
+        compendiumSource: item._stats?.compendiumSource ?? null,
+      };
+    });
+  }
+
+  // ─── 2.5 updateActor ────────────────────────────────────────────────────────
+
+  private async handleUpdateActor(data: {
+    actorIdentifier: string;
+    update: Record<string, any>;
+  }): Promise<any> {
+    const denied = this.checkAccess(true);
+    if (denied) return denied;
+
+    this.dataAccess.validateFoundryState();
+
+    const update = data?.update;
+    if (!update || typeof update !== 'object' || Array.isArray(update)) {
+      throw new Error('update object is required');
+    }
+
+    const actor = await this.resolveActor(data?.actorIdentifier);
+
+    try {
+      // Verbatim: dotted keys and "-=" deletions are handled by Foundry, not here
+      await actor.update(update);
+    } catch (error) {
+      this.audit(
+        'updateActor',
+        { actorId: actor.id, keys: Object.keys(update) },
+        'failure',
+        RawHandlers.describeError(error)
+      );
+      throw error;
+    }
+
+    this.audit('updateActor', { actorId: actor.id, keys: Object.keys(update) }, 'success');
+
+    return RawHandlers.actorRef(actor);
+  }
+
+  // ─── 2.6 runScript ──────────────────────────────────────────────────────────
+
+  private async handleRunScript(data: {
+    script: string;
+    args?: any;
+    timeoutMs?: number;
+  }): Promise<any> {
+    const denied = this.checkAccess(true);
+    if (denied) return denied;
+
+    const script = data?.script;
+    if (typeof script !== 'string' || script.trim().length === 0) {
+      throw new Error('script is required and must be a non-empty string');
+    }
+
+    const timeoutMs =
+      typeof data?.timeoutMs === 'number' && data.timeoutMs > 0
+        ? data.timeoutMs
+        : DEFAULT_SCRIPT_TIMEOUT_MS;
+
+    const started = Date.now();
+    let timer: any = null;
+
+    try {
+      const AsyncFunction: any = Object.getPrototypeOf(async function () {
+        /* async function prototype probe */
+      }).constructor;
+      const fn = new AsyncFunction('args', script);
+
+      const timeout = new Promise((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Script timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      });
+
+      const value = await Promise.race([fn(data?.args), timeout]);
+      const durationMs = Date.now() - started;
+
+      let serializable = true;
+      try {
+        JSON.stringify(value ?? null);
+      } catch {
+        serializable = false;
+      }
+
+      this.audit('runScript', { length: script.length, durationMs }, 'success');
+
+      if (!serializable) {
+        return { ok: true, result: String(value), serialized: false, durationMs };
+      }
+      return { ok: true, result: value ?? null, durationMs };
+    } catch (error) {
+      const durationMs = Date.now() - started;
+      const message = RawHandlers.describeError(error);
+
+      this.audit('runScript', { length: script.length, durationMs }, 'failure', message);
+
+      // Reported in the body, never thrown, so the caller keeps the stack
+      return {
+        ok: false,
+        error: message,
+        stack: error instanceof Error ? (error.stack ?? null) : null,
+        durationMs,
+      };
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  // ─── 2.7 bridgeInfo ─────────────────────────────────────────────────────────
+
+  private async handleBridgeInfo(): Promise<any> {
+    const denied = this.checkAccess(false);
+    if (denied) return denied;
+
+    const anyGame = game as any;
+
+    let connectionType: string | null = null;
+    try {
+      const bridge = (globalThis as any).foundryMCPBridge;
+      connectionType = bridge?.getStatus?.()?.connectionInfo?.type ?? null;
+    } catch {
+      connectionType = null;
+    }
+    if (!connectionType) {
+      try {
+        connectionType = game.settings.get(MODULE_ID, 'connectionType') as string;
+      } catch {
+        connectionType = null;
+      }
+    }
+
+    let actAsBridge = true;
+    try {
+      actAsBridge = game.settings.get(MODULE_ID, 'actAsBridge') !== false;
+    } catch {
+      actAsBridge = true;
+    }
+
+    return {
+      user: anyGame.user?.name ?? null,
+      userId: anyGame.user?.id ?? null,
+      isGM: anyGame.user?.isGM === true,
+      world: anyGame.world?.id ?? null,
+      system: anyGame.system?.id ?? null,
+      systemVersion: anyGame.system?.version ?? null,
+      coreVersion: anyGame.version ?? anyGame.release?.version ?? null,
+      moduleVersion: anyGame.modules?.get(MODULE_ID)?.version ?? null,
+      connectionType,
+      actAsBridge,
+      url: window.location.origin,
+    };
+  }
+}

--- a/packages/foundry-module/src/settings.ts
+++ b/packages/foundry-module/src/settings.ts
@@ -201,6 +201,18 @@ export class ModuleSettings {
       onChange: this.onEnabledChange.bind(this),
     });
 
+    // Client-scope: which browser actually holds the bridge connection.
+    // Every GM client loads the module, but only the ticked one talks to the MCP
+    // server, so a second GM tab cannot steal the socket.
+    game.settings.register(this.moduleId, 'actAsBridge', {
+      name: 'Act as MCP bridge client',
+      hint: 'Only this browser connects to the MCP server. Untick on GM clients that should stay passive.',
+      scope: 'client',
+      config: true,
+      type: Boolean,
+      default: true,
+    });
+
     game.settings.register(this.moduleId, 'connectionType', {
       name: 'Connection Type',
       hint: 'Auto: Smart selection (HTTPS→WebRTC, HTTP→WebSocket). WebRTC: Encrypted P2P (works over internet). WebSocket: Traditional (localhost only).',
@@ -455,6 +467,7 @@ export class ModuleSettings {
       'serverHost',
       'serverPort',
       'connectionType',
+      'actAsBridge',
       // Permissions
       'allowWriteOperations',
       // Safety Controls

--- a/packages/foundry-module/src/socket-bridge.ts
+++ b/packages/foundry-module/src/socket-bridge.ts
@@ -1,6 +1,9 @@
 import { MODULE_ID, CONNECTION_STATES } from './constants.js';
 import { WebRTCConnection, type WebRTCConfig } from './webrtc-connection.js';
 
+/** Reconnect backoff ceiling - after this the bridge retries at a steady interval. */
+const RECONNECT_MAX_DELAY_MS = 30000;
+
 export interface BridgeConfig {
   enabled: boolean;
   serverHost: string;
@@ -55,10 +58,14 @@ export class SocketBridge {
     const configType = this.config.connectionType || 'auto';
 
     if (configType === 'auto') {
-      // Use WebRTC for HTTPS (secure), WebSocket for HTTP (localhost)
-      // WebRTC provides P2P encrypted channel without needing SSL certificates
+      // A loopback MCP host always takes plain WebSocket: browsers treat loopback as a
+      // potentially trustworthy origin, so ws://localhost is allowed even from an HTTPS
+      // page, and the WebRTC signaling path is fragile there (silent handshake failures).
+      // Remote hosts keep the old rule: WebRTC for HTTPS pages, WebSocket for HTTP.
+      const host = this.config.serverHost;
+      const isLoopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(host);
       const isHttps = window.location.protocol === 'https:';
-      const type = isHttps ? 'webrtc' : 'websocket';
+      const type = isLoopback ? 'websocket' : isHttps ? 'webrtc' : 'websocket';
       this.log(`Auto-detected connection type: ${type} (page is ${window.location.protocol})`);
       return type;
     }
@@ -377,10 +384,7 @@ export class SocketBridge {
             `[foundry-mcp-bridge] Scene background did not persist on create (got "${scene.background?.src}"), repairing via update()...`
           );
           await scene.update({ background: { src: expectedBackgroundSrc } });
-          console.log(
-            `[foundry-mcp-bridge] Scene background after repair:`,
-            scene.background?.src
-          );
+          console.log(`[foundry-mcp-bridge] Scene background after repair:`, scene.background?.src);
         }
       }
 
@@ -503,19 +507,23 @@ export class SocketBridge {
   }
 
   private scheduleReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      this.log(`Max reconnection attempts reached (${this.maxReconnectAttempts})`);
-      return;
-    }
-
+    // No attempt ceiling: a GM client that outlives the MCP server must reconnect
+    // on its own once the server is back, however long that takes.
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
     }
 
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000); // Exponential backoff, max 30s
+    // Exponential backoff capped at 30s, then a steady 30s retry forever.
+    // The exponent is clamped so long outages cannot overflow the calculation.
+    const exponent = Math.min(this.reconnectAttempts, 20);
+    const delay = Math.min(1000 * Math.pow(2, exponent), RECONNECT_MAX_DELAY_MS);
     this.reconnectAttempts++;
 
-    this.log(`Scheduling reconnection attempt ${this.reconnectAttempts} in ${delay}ms`);
+    // Log the first attempt and then every tenth, so a server left down overnight
+    // does not fill the console.
+    if (this.reconnectAttempts === 1 || this.reconnectAttempts % 10 === 0) {
+      this.log(`Scheduling reconnection attempt ${this.reconnectAttempts} in ${delay}ms`);
+    }
     this.connectionState = CONNECTION_STATES.RECONNECTING;
 
     this.reconnectTimer = setTimeout(async () => {

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -24,6 +24,7 @@ import { SceneTools } from './tools/scene.js';
 
 import { ActorCreationTools } from './tools/actor-creation.js';
 import { ActorManagementTools } from './tools/actor-management.js';
+import { RawActorTools } from './tools/raw-actor.js';
 
 import { QuestCreationTools } from './tools/quest-creation.js';
 
@@ -1194,6 +1195,7 @@ async function startBackend(): Promise<void> {
 
   const actorCreationTools = new ActorCreationTools({ foundryClient, logger });
   const actorManagementTools = new ActorManagementTools({ foundryClient, logger, systemRegistry });
+  const rawActorTools = new RawActorTools({ foundryClient, logger });
 
   const dsa5CharacterCreator = new DSA5CharacterCreator({ foundryClient, logger });
 
@@ -1423,6 +1425,8 @@ async function startBackend(): Promise<void> {
     ...actorCreationTools.getToolDefinitions(),
     ...actorManagementTools.getToolDefinitions(),
 
+    ...rawActorTools.getToolDefinitions(),
+
     ...dsa5CharacterCreator.getToolDefinitions(),
 
     ...dnd5eAddFeatureTool.getToolDefinitions(),
@@ -1601,6 +1605,43 @@ async function startBackend(): Promise<void> {
 
                 case 'manage-actors':
                   result = await actorManagementTools.handleManageActors(args);
+
+                  break;
+
+                // Raw document tools (import/export, compendiums, scripting)
+
+                case 'import-actor':
+                  result = await rawActorTools.handleImportActor(args);
+
+                  break;
+
+                case 'export-actor':
+                  result = await rawActorTools.handleExportActor(args);
+
+                  break;
+
+                case 'manage-compendium':
+                  result = await rawActorTools.handleManageCompendium(args);
+
+                  break;
+
+                case 'manage-actor-items':
+                  result = await rawActorTools.handleManageActorItems(args);
+
+                  break;
+
+                case 'update-actor-raw':
+                  result = await rawActorTools.handleUpdateActorRaw(args);
+
+                  break;
+
+                case 'run-script':
+                  result = await rawActorTools.handleRunScript(args);
+
+                  break;
+
+                case 'bridge-info':
+                  result = await rawActorTools.handleBridgeInfo(args);
 
                   break;
 

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -12,6 +12,7 @@ const ConfigSchema = z.object({
   foundry: z.object({
     host: z.string().default('localhost'),
     port: z.number().min(1024).max(65535).default(31415),
+    bindHost: z.string().default('0.0.0.0'),
     namespace: z.string().default('/foundry-mcp'),
     reconnectAttempts: z.number().min(1).max(20).default(5),
     reconnectDelay: z.number().min(100).max(30000).default(1000),
@@ -62,6 +63,10 @@ const rawConfig = {
   foundry: {
     host: process.env.FOUNDRY_HOST || 'localhost',
     port: parseInt(process.env.FOUNDRY_PORT || '31415', 10),
+    // Interface the module-facing WebSocket and WebRTC signaling servers bind to.
+    // Set FOUNDRY_BIND_HOST=127.0.0.1 when the backend runs on a host reachable
+    // from the internet and the Foundry client connects from the same machine.
+    bindHost: process.env.FOUNDRY_BIND_HOST || '0.0.0.0',
     namespace: process.env.FOUNDRY_NAMESPACE || '/foundry-mcp',
     reconnectAttempts: parseInt(process.env.FOUNDRY_RECONNECT_ATTEMPTS || '5', 10),
     reconnectDelay: parseInt(process.env.FOUNDRY_RECONNECT_DELAY || '1000', 10),

--- a/packages/mcp-server/src/foundry-connector.ts
+++ b/packages/mcp-server/src/foundry-connector.ts
@@ -83,9 +83,10 @@ export class FoundryConnector {
 
     // Start WebRTC signaling server
     await new Promise<void>((resolve, reject) => {
-      this.webrtcSignalingServer.listen(WEBRTC_PORT, '0.0.0.0', () => {
+      const bindHost = this.config.bindHost || '0.0.0.0';
+      this.webrtcSignalingServer.listen(WEBRTC_PORT, bindHost, () => {
         this.logger.info(`WebRTC signaling server listening on port ${WEBRTC_PORT}`);
-        console.error(`[WebRTC] Server started on 0.0.0.0:${WEBRTC_PORT}`);
+        console.error(`[WebRTC] Server started on ${bindHost}:${WEBRTC_PORT}`);
         resolve();
       });
       this.webrtcSignalingServer.on('error', (error: Error) => {
@@ -162,9 +163,12 @@ export class FoundryConnector {
 
     // Start the HTTP server
     await new Promise<void>((resolve, reject) => {
-      this.httpServer.listen(this.config.port, () => {
+      this.httpServer.listen(this.config.port, this.config.bindHost || '0.0.0.0', () => {
         this.isStarted = true;
-        this.logger.info('Foundry connector listening', { port: this.config.port });
+        this.logger.info('Foundry connector listening', {
+          port: this.config.port,
+          bindHost: this.config.bindHost || '0.0.0.0',
+        });
         resolve();
       });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -20,6 +20,8 @@ import * as fs from 'fs';
 
 import * as path from 'path';
 
+import { hydrateToolArgs, dehydrateToolResult, toolErrorResult } from './tool-files.js';
+
 const CONTROL_HOST = '127.0.0.1';
 
 const CONTROL_PORT = 31414;
@@ -358,10 +360,28 @@ async function startWrapper() {
   mcp.setRequestHandler(CallToolRequestSchema, async request => {
     const { name, arguments: args } = request.params as any;
 
-    try {
-      const res = await backend.send('call_tool', { name, args: args ?? {} });
+    // Files live on this machine, not necessarily on the backend host, so file-backed
+    // arguments are read here and the payload is inlined before the call is forwarded.
 
-      return res;
+    const hydrated = hydrateToolArgs(name, args ?? {});
+
+    if (!hydrated.ok) {
+      try {
+        (backend as any).log?.('CallTool: argument hydration failed', {
+          name,
+          error: hydrated.error,
+        });
+      } catch {
+        // Logging is best effort; the error still reaches the client below.
+      }
+
+      return toolErrorResult(hydrated.error) as any;
+    }
+
+    try {
+      const res = await backend.send('call_tool', { name, args: hydrated.args });
+
+      return dehydrateToolResult(name, hydrated.args, res);
     } catch (e: any) {
       return {
         content: [{ type: 'text', text: `Error: ${e?.message || 'Backend unavailable'}` }],

--- a/packages/mcp-server/src/tool-files.test.ts
+++ b/packages/mcp-server/src/tool-files.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the wrapper-side file hydration (src/tool-files.ts).
+ *
+ * These run against real temporary files: the whole point of the module is that
+ * the stdio wrapper - not the backend - touches the filesystem, so mocking fs
+ * would test nothing worth testing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { hydrateToolArgs, dehydrateToolResult, toolErrorResult } from './tool-files.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tool-files-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFixture(fileName: string, content: unknown): string {
+  const filePath = path.join(tmpDir, fileName);
+  fs.writeFileSync(
+    filePath,
+    typeof content === 'string' ? content : JSON.stringify(content),
+    'utf8'
+  );
+  return filePath;
+}
+
+function expectOk(outcome: ReturnType<typeof hydrateToolArgs>): Record<string, any> {
+  if (!outcome.ok) throw new Error(`expected hydration to succeed, got: ${outcome.error}`);
+  return outcome.args;
+}
+
+function expectError(outcome: ReturnType<typeof hydrateToolArgs>): string {
+  if (outcome.ok) throw new Error('expected hydration to fail, but it succeeded');
+  return outcome.error;
+}
+
+// ── import-actor ──────────────────────────────────────────────────────────────
+
+describe('hydrateToolArgs: import-actor', () => {
+  const destination = { type: 'world', folder: 'Imported Actors' };
+
+  it('reads a single actor object into a one-element actors array', () => {
+    const filePath = writeFixture('one.json', { name: 'Goblin Boss', type: 'npc' });
+
+    const args = expectOk(hydrateToolArgs('import-actor', { filePath, destination }));
+
+    expect(args.actors).toEqual([{ name: 'Goblin Boss', type: 'npc' }]);
+    expect(args.filePath).toBeUndefined();
+    expect(args.destination).toEqual(destination);
+  });
+
+  it('reads an array of actors as is', () => {
+    const filePath = writeFixture('many.json', [
+      { name: 'Hookwolf', type: 'npc' },
+      { name: 'Mannequin', type: 'npc' },
+    ]);
+
+    const args = expectOk(hydrateToolArgs('import-actor', { filePath, destination }));
+
+    expect(args.actors).toHaveLength(2);
+    expect(args.actors[1].name).toBe('Mannequin');
+  });
+
+  it('leaves inline actors untouched', () => {
+    const actors = [{ name: 'Siberian', type: 'npc' }];
+
+    const args = expectOk(hydrateToolArgs('import-actor', { actors, destination }));
+
+    expect(args.actors).toBe(actors);
+  });
+
+  it('rejects both actors and filePath', () => {
+    const filePath = writeFixture('one.json', { name: 'Goblin Boss', type: 'npc' });
+
+    const error = expectError(
+      hydrateToolArgs('import-actor', {
+        actors: [{ name: 'Goblin Boss', type: 'npc' }],
+        filePath,
+        destination,
+      })
+    );
+
+    expect(error).toMatch(/exactly one of "actors" or "filePath"/);
+  });
+
+  it('rejects neither actors nor filePath', () => {
+    const error = expectError(hydrateToolArgs('import-actor', { destination }));
+
+    expect(error).toMatch(/requires either "actors" or "filePath"/);
+  });
+
+  it('reports a missing file instead of throwing', () => {
+    const missing = path.join(tmpDir, 'nope.json');
+
+    const error = expectError(hydrateToolArgs('import-actor', { filePath: missing, destination }));
+
+    expect(error).toContain('Cannot read "filePath" file');
+    expect(error).toContain(missing);
+  });
+
+  it('reports malformed JSON', () => {
+    const filePath = writeFixture('broken.json', '{ "name": ');
+
+    const error = expectError(hydrateToolArgs('import-actor', { filePath, destination }));
+
+    expect(error).toContain('Cannot parse JSON');
+  });
+
+  it('rejects a JSON scalar', () => {
+    const filePath = writeFixture('scalar.json', '42');
+
+    const error = expectError(hydrateToolArgs('import-actor', { filePath, destination }));
+
+    expect(error).toMatch(/must hold a JSON object or an array of JSON objects/);
+  });
+
+  it('rejects an array with a non-object entry', () => {
+    const filePath = writeFixture('mixed.json', [{ name: 'Goblin Boss', type: 'npc' }, 'nope']);
+
+    const error = expectError(hydrateToolArgs('import-actor', { filePath, destination }));
+
+    expect(error).toContain('non-object entry at index 1');
+  });
+});
+
+// ── manage-actor-items ────────────────────────────────────────────────────────
+
+describe('hydrateToolArgs: manage-actor-items', () => {
+  it('loads a file into "items" for action create', () => {
+    const filePath = writeFixture('items.json', [{ name: 'Blade', type: 'weapon' }]);
+
+    const args = expectOk(
+      hydrateToolArgs('manage-actor-items', { actorIdentifier: 'Goblin Boss', action: 'create', filePath })
+    );
+
+    expect(args.items).toEqual([{ name: 'Blade', type: 'weapon' }]);
+    expect(args.updates).toBeUndefined();
+    expect(args.filePath).toBeUndefined();
+  });
+
+  it('loads a file into "updates" for action update-raw', () => {
+    const filePath = writeFixture('updates.json', { _id: 'abc', 'system.uses.max': '3' });
+
+    const args = expectOk(
+      hydrateToolArgs('manage-actor-items', {
+        actorIdentifier: 'Goblin Boss',
+        action: 'update-raw',
+        filePath,
+      })
+    );
+
+    expect(args.updates).toEqual([{ _id: 'abc', 'system.uses.max': '3' }]);
+    expect(args.filePath).toBeUndefined();
+  });
+
+  it('rejects filePath for actions that take no payload', () => {
+    const filePath = writeFixture('items.json', [{ name: 'Blade' }]);
+
+    const error = expectError(
+      hydrateToolArgs('manage-actor-items', { actorIdentifier: 'Goblin Boss', action: 'list', filePath })
+    );
+
+    expect(error).toMatch(/applies to action "create" or "update-raw" only/);
+  });
+
+  it('rejects filePath alongside an inline payload', () => {
+    const filePath = writeFixture('items.json', [{ name: 'Blade' }]);
+
+    const error = expectError(
+      hydrateToolArgs('manage-actor-items', {
+        actorIdentifier: 'Goblin Boss',
+        action: 'create',
+        items: [{ name: 'Other' }],
+        filePath,
+      })
+    );
+
+    expect(error).toMatch(/exactly one of "items" or "filePath"/);
+  });
+});
+
+// ── update-actor-raw ──────────────────────────────────────────────────────────
+
+describe('hydrateToolArgs: update-actor-raw', () => {
+  it('loads a JSON object into "update"', () => {
+    const filePath = writeFixture('update.json', { 'system.attributes.hp.max': 120 });
+
+    const args = expectOk(
+      hydrateToolArgs('update-actor-raw', { actorIdentifier: 'Goblin Boss', filePath })
+    );
+
+    expect(args.update).toEqual({ 'system.attributes.hp.max': 120 });
+    expect(args.filePath).toBeUndefined();
+  });
+
+  it('rejects an array payload', () => {
+    const filePath = writeFixture('update.json', [{ 'system.attributes.hp.max': 120 }]);
+
+    const error = expectError(
+      hydrateToolArgs('update-actor-raw', { actorIdentifier: 'Goblin Boss', filePath })
+    );
+
+    expect(error).toMatch(/must hold a single JSON object/);
+  });
+
+  it('rejects both update and filePath', () => {
+    const filePath = writeFixture('update.json', { name: 'Goblin Boss' });
+
+    const error = expectError(
+      hydrateToolArgs('update-actor-raw', {
+        actorIdentifier: 'Goblin Boss',
+        update: { name: 'Other' },
+        filePath,
+      })
+    );
+
+    expect(error).toMatch(/exactly one of "update" or "filePath"/);
+  });
+});
+
+// ── run-script ────────────────────────────────────────────────────────────────
+
+describe('hydrateToolArgs: run-script', () => {
+  it('reads scriptFile into script verbatim', () => {
+    const filePath = writeFixture('script.js', 'return game.actors.size;\n');
+
+    const args = expectOk(hydrateToolArgs('run-script', { scriptFile: filePath }));
+
+    expect(args.script).toBe('return game.actors.size;\n');
+    expect(args.scriptFile).toBeUndefined();
+  });
+
+  it('rejects both script and scriptFile', () => {
+    const filePath = writeFixture('script.js', 'return 1;');
+
+    const error = expectError(
+      hydrateToolArgs('run-script', { script: 'return 2;', scriptFile: filePath })
+    );
+
+    expect(error).toMatch(/exactly one of "script" or "scriptFile"/);
+  });
+
+  it('reports a missing script file', () => {
+    const missing = path.join(tmpDir, 'gone.js');
+
+    const error = expectError(hydrateToolArgs('run-script', { scriptFile: missing }));
+
+    expect(error).toContain('Cannot read "scriptFile" file');
+  });
+});
+
+// ── untouched tools ───────────────────────────────────────────────────────────
+
+describe('hydrateToolArgs: tools without file arguments', () => {
+  it('copies the args through unchanged', () => {
+    const original = { actorIdentifier: 'Goblin Boss', pack: 'world.my-bestiary' };
+
+    const args = expectOk(hydrateToolArgs('export-actor', original));
+
+    expect(args).toEqual(original);
+    expect(args).not.toBe(original);
+  });
+
+  it('tolerates undefined args', () => {
+    expect(expectOk(hydrateToolArgs('bridge-info', undefined))).toEqual({});
+  });
+});
+
+// ── dehydrateToolResult ───────────────────────────────────────────────────────
+
+describe('dehydrateToolResult: export-actor', () => {
+  const actorSource = { name: 'Goblin Boss', type: 'npc', items: [{ name: 'Blade' }] };
+
+  function backendResult(payload: unknown) {
+    return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+  }
+
+  it('writes the actor source and returns a summary without data', () => {
+    const outFile = path.join(tmpDir, 'nested', 'ozhog.json');
+    const result = backendResult({
+      uuid: 'Actor.abc',
+      name: 'Goblin Boss',
+      type: 'npc',
+      itemCount: 1,
+      data: actorSource,
+    });
+
+    const out = dehydrateToolResult('export-actor', { actorIdentifier: 'Goblin Boss', outFile }, result);
+    const summary = JSON.parse(out.content[0].text);
+
+    expect(summary).toEqual({
+      uuid: 'Actor.abc',
+      name: 'Goblin Boss',
+      type: 'npc',
+      itemCount: 1,
+      bytes: summary.bytes,
+      outFile,
+    });
+    expect(summary.data).toBeUndefined();
+
+    const onDisk = fs.readFileSync(outFile, 'utf8');
+    expect(JSON.parse(onDisk)).toEqual(actorSource);
+    expect(onDisk).toContain('\n  "name"'); // pretty-printed with 2 spaces
+    expect(summary.bytes).toBe(Buffer.byteLength(onDisk, 'utf8'));
+  });
+
+  it('passes the response through when no outFile is given', () => {
+    const result = backendResult({ uuid: 'Actor.abc', data: actorSource });
+
+    expect(dehydrateToolResult('export-actor', { actorIdentifier: 'Goblin Boss' }, result)).toBe(result);
+  });
+
+  it('passes error responses through untouched', () => {
+    const outFile = path.join(tmpDir, 'never.json');
+    const result = { content: [{ type: 'text', text: 'Error: no such actor' }], isError: true };
+
+    expect(dehydrateToolResult('export-actor', { outFile }, result)).toBe(result);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  it('passes non-JSON text through untouched', () => {
+    const outFile = path.join(tmpDir, 'never.json');
+    const result = { content: [{ type: 'text', text: 'plain text' }] };
+
+    expect(dehydrateToolResult('export-actor', { outFile }, result)).toBe(result);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  it('reports a write failure as a tool error', () => {
+    // A path under an existing regular file cannot be created.
+    const blocker = writeFixture('blocker', 'not a directory');
+    const outFile = path.join(blocker, 'actor.json');
+    const result = backendResult({ uuid: 'Actor.abc', data: actorSource });
+
+    const out = dehydrateToolResult('export-actor', { outFile }, result);
+
+    expect(out.isError).toBe(true);
+    expect(out.content[0].text).toContain('Cannot write "outFile"');
+  });
+
+  it('leaves other tools alone', () => {
+    const result = backendResult({ anything: true });
+
+    expect(dehydrateToolResult('manage-actor-items', { outFile: 'x.json' }, result)).toBe(result);
+  });
+});
+
+describe('toolErrorResult', () => {
+  it('builds an MCP error payload', () => {
+    expect(toolErrorResult('boom')).toEqual({
+      content: [{ type: 'text', text: 'Error: boom' }],
+      isError: true,
+    });
+  });
+});

--- a/packages/mcp-server/src/tool-files.ts
+++ b/packages/mcp-server/src/tool-files.ts
@@ -1,0 +1,229 @@
+/**
+ * File hydration for the raw actor tools.
+ *
+ * Files live on the machine that runs the stdio wrapper (src/index.ts), while the
+ * backend may later move to a different host. So every filesystem access happens
+ * here: `hydrateToolArgs` runs before a call_tool request is forwarded and
+ * `dehydrateToolResult` runs on the response that comes back.
+ *
+ * The backend never sees `filePath` / `scriptFile`; it does see `outFile`, but only
+ * to decide whether an oversized payload may be returned inline.
+ *
+ * Only Node built-ins are imported here - this module is bundled into
+ * dist/index.bundle.cjs by esbuild.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type ToolArgs = Record<string, any>;
+
+/** Result of hydrating tool arguments: either rewritten args or a user-facing error. */
+export type HydrateOutcome = { ok: true; args: ToolArgs } | { ok: false; error: string };
+
+/** Minimal shape of an MCP tool response as produced by the backend. */
+export interface McpToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+/** Build an MCP error response without ever reaching the backend. */
+export function toolErrorResult(message: string): McpToolResult {
+  return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unknown error';
+}
+
+function readTextFile(filePath: string, field: string): string {
+  const resolved = path.resolve(filePath);
+  try {
+    return fs.readFileSync(resolved, 'utf8');
+  } catch (error) {
+    throw new Error(`Cannot read "${field}" file ${resolved}: ${errorMessage(error)}`);
+  }
+}
+
+function readJsonFile(filePath: string, field: string): unknown {
+  const text = readTextFile(filePath, field);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Cannot parse JSON from "${field}" file ${path.resolve(filePath)}: ${errorMessage(error)}`
+    );
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Accept either a single JSON object or an array of them, always return an array. */
+function asObjectArray(parsed: unknown, filePath: string, field: string): unknown[] {
+  if (Array.isArray(parsed)) {
+    const bad = parsed.findIndex(entry => !isPlainObject(entry));
+    if (bad >= 0) {
+      throw new Error(
+        `"${field}" file ${path.resolve(filePath)} has a non-object entry at index ${bad}`
+      );
+    }
+    return parsed;
+  }
+  if (isPlainObject(parsed)) return [parsed];
+  throw new Error(
+    `"${field}" file ${path.resolve(filePath)} must hold a JSON object or an array of JSON objects`
+  );
+}
+
+// ── hydration ─────────────────────────────────────────────────────────────────
+
+/**
+ * Read any file-backed argument into the inline field the backend expects.
+ * Tools without file arguments are returned untouched.
+ */
+export function hydrateToolArgs(name: string, args: ToolArgs | undefined): HydrateOutcome {
+  const next: ToolArgs = { ...(args ?? {}) };
+
+  try {
+    switch (name) {
+      case 'import-actor':
+        hydrateImportActor(next);
+        break;
+      case 'manage-actor-items':
+        hydrateManageActorItems(next);
+        break;
+      case 'update-actor-raw':
+        hydrateUpdateActorRaw(next);
+        break;
+      case 'run-script':
+        hydrateRunScript(next);
+        break;
+      default:
+        break;
+    }
+  } catch (error) {
+    return { ok: false, error: errorMessage(error) };
+  }
+
+  return { ok: true, args: next };
+}
+
+function hydrateImportActor(args: ToolArgs): void {
+  const filePath = nonEmptyString(args.filePath);
+  const hasInline = args.actors !== undefined;
+
+  if (hasInline && filePath) {
+    throw new Error('import-actor takes exactly one of "actors" or "filePath", not both');
+  }
+  if (!hasInline && !filePath) {
+    throw new Error('import-actor requires either "actors" or "filePath"');
+  }
+  if (!filePath) return;
+
+  args.actors = asObjectArray(readJsonFile(filePath, 'filePath'), filePath, 'filePath');
+  delete args.filePath;
+}
+
+function hydrateManageActorItems(args: ToolArgs): void {
+  const filePath = nonEmptyString(args.filePath);
+  if (!filePath) return;
+
+  const action = nonEmptyString(args.action) ?? '';
+  const field = action === 'create' ? 'items' : action === 'update-raw' ? 'updates' : null;
+  if (!field) {
+    throw new Error(
+      `manage-actor-items "filePath" applies to action "create" or "update-raw" only, got "${action || 'none'}"`
+    );
+  }
+  if (args[field] !== undefined) {
+    throw new Error(`manage-actor-items takes exactly one of "${field}" or "filePath", not both`);
+  }
+
+  args[field] = asObjectArray(readJsonFile(filePath, 'filePath'), filePath, 'filePath');
+  delete args.filePath;
+}
+
+function hydrateUpdateActorRaw(args: ToolArgs): void {
+  const filePath = nonEmptyString(args.filePath);
+  if (!filePath) return;
+
+  if (args.update !== undefined) {
+    throw new Error('update-actor-raw takes exactly one of "update" or "filePath", not both');
+  }
+
+  const parsed = readJsonFile(filePath, 'filePath');
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `"filePath" file ${path.resolve(filePath)} must hold a single JSON object of update keys`
+    );
+  }
+
+  args.update = parsed;
+  delete args.filePath;
+}
+
+function hydrateRunScript(args: ToolArgs): void {
+  const scriptFile = nonEmptyString(args.scriptFile);
+  const hasInline = nonEmptyString(args.script) !== undefined;
+
+  if (hasInline && scriptFile) {
+    throw new Error('run-script takes exactly one of "script" or "scriptFile", not both');
+  }
+  if (!scriptFile) return;
+
+  args.script = readTextFile(scriptFile, 'scriptFile');
+  delete args.scriptFile;
+}
+
+// ── dehydration ───────────────────────────────────────────────────────────────
+
+/**
+ * Post-process a backend response. Only export-actor with "outFile" is affected:
+ * the actor source is written to disk and the response shrinks to a summary.
+ * Anything unexpected (error response, non-JSON text, missing "data") passes through.
+ */
+export function dehydrateToolResult(name: string, args: ToolArgs | undefined, result: any): any {
+  if (name !== 'export-actor') return result;
+
+  const outFile = nonEmptyString(args?.outFile);
+  if (!outFile) return result;
+  if (!result || result.isError) return result;
+
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== 'string') return result;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return result;
+  }
+  if (!isPlainObject(parsed) || parsed.data === undefined) return result;
+
+  const resolved = path.resolve(outFile);
+  try {
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    const json = JSON.stringify(parsed.data, null, 2);
+    fs.writeFileSync(resolved, json, 'utf8');
+
+    const summary = {
+      uuid: parsed.uuid,
+      name: parsed.name,
+      type: parsed.type,
+      itemCount: parsed.itemCount,
+      bytes: Buffer.byteLength(json, 'utf8'),
+      outFile: resolved,
+    };
+    return { content: [{ type: 'text', text: JSON.stringify(summary) }] };
+  } catch (error) {
+    return toolErrorResult(`Cannot write "outFile" ${resolved}: ${errorMessage(error)}`);
+  }
+}

--- a/packages/mcp-server/src/tools/raw-actor.test.ts
+++ b/packages/mcp-server/src/tools/raw-actor.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Raw actor tool tests.
+ *
+ * The Foundry side runs browser-side, so these cover the MCP tool layer: schemas
+ * are advertised, validated arguments reach the right raw.* bridge query, and the
+ * inline response limit fires when a payload is too large to hand back directly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RawActorTools, MAX_INLINE_RESPONSE_CHARS } from './raw-actor.js';
+
+function makeTools(queryImpl?: (method: string, data: any) => unknown) {
+  const query = vi.fn(queryImpl ?? (async () => ({ ok: true })));
+  const logger: any = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), child: () => logger };
+  const foundryClient: any = { query };
+  return { tools: new RawActorTools({ foundryClient, logger }), query };
+}
+
+describe('RawActorTools definitions', () => {
+  it('advertises all seven tools with object input schemas', () => {
+    const { tools } = makeTools();
+    const defs = tools.getToolDefinitions();
+
+    expect(defs.map(d => d.name)).toEqual([
+      'import-actor',
+      'export-actor',
+      'manage-compendium',
+      'manage-actor-items',
+      'update-actor-raw',
+      'run-script',
+      'bridge-info',
+    ]);
+    for (const def of defs) {
+      expect(def.inputSchema.type).toBe('object');
+    }
+  });
+
+  it('tells clients import-actor takes full actor source with activities', () => {
+    const { tools } = makeTools();
+    const def = tools.getToolDefinitions().find(d => d.name === 'import-actor');
+
+    expect(def!.description).toContain(
+      'full Foundry actor source including items with activities; the recommended way to create ' +
+        'monsters with legendary actions, recharge, templates and spell links'
+    );
+  });
+
+  it('advertises the file-backed arguments so clients can pass them', () => {
+    const { tools } = makeTools();
+    const byName = Object.fromEntries(tools.getToolDefinitions().map(d => [d.name, d]));
+
+    expect(byName['import-actor'].inputSchema.properties.filePath).toBeDefined();
+    expect(byName['export-actor'].inputSchema.properties.outFile).toBeDefined();
+    expect(byName['manage-actor-items'].inputSchema.properties.filePath).toBeDefined();
+    expect(byName['update-actor-raw'].inputSchema.properties.filePath).toBeDefined();
+    expect(byName['run-script'].inputSchema.properties.scriptFile).toBeDefined();
+  });
+});
+
+describe('import-actor', () => {
+  it('forwards actors with replace and keepId defaults applied', async () => {
+    const { tools, query } = makeTools();
+
+    await tools.handleImportActor({
+      actors: [{ name: 'Goblin Boss', type: 'npc', items: [{ name: 'Клинок' }] }],
+      destination: { type: 'pack', pack: 'world.my-bestiary' },
+    });
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.importActors', {
+      actors: [{ name: 'Goblin Boss', type: 'npc', items: [{ name: 'Клинок' }] }],
+      destination: { type: 'pack', pack: 'world.my-bestiary' },
+      replace: 'byName',
+      keepId: false,
+    });
+  });
+
+  it('keeps unknown actor fields such as system and prototypeToken', async () => {
+    const { tools, query } = makeTools();
+    const actor = {
+      name: 'Goblin Boss',
+      type: 'npc',
+      system: { attributes: { hp: { max: 120 } } },
+      prototypeToken: { name: 'Goblin Boss' },
+    };
+
+    await tools.handleImportActor({ actors: [actor], destination: { type: 'world' } });
+
+    expect(query.mock.calls[0][1].actors[0]).toEqual(actor);
+  });
+
+  it('rejects a pack destination with no pack', async () => {
+    const { tools, query } = makeTools();
+
+    await expect(
+      tools.handleImportActor({
+        actors: [{ name: 'A', type: 'npc' }],
+        destination: { type: 'pack' },
+      })
+    ).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 50 actors', async () => {
+    const { tools, query } = makeTools();
+    const actors = Array.from({ length: 51 }, (_, i) => ({ name: `A${i}`, type: 'npc' }));
+
+    await expect(
+      tools.handleImportActor({ actors, destination: { type: 'world' } })
+    ).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('export-actor', () => {
+  it('forwards the identifier and optional pack', async () => {
+    const { tools, query } = makeTools();
+
+    await tools.handleExportActor({ actorIdentifier: 'Goblin Boss', pack: 'world.my-bestiary' });
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.exportActor', {
+      actorIdentifier: 'Goblin Boss',
+      pack: 'world.my-bestiary',
+    });
+  });
+
+  it('refuses an oversized payload when no outFile is given', async () => {
+    const big = { data: 'x'.repeat(MAX_INLINE_RESPONSE_CHARS + 10) };
+    const { tools } = makeTools(async () => big);
+
+    await expect(tools.handleExportActor({ actorIdentifier: 'Goblin Boss' })).rejects.toThrow(
+      /over the 200000 character response limit/
+    );
+  });
+
+  it('allows an oversized payload when outFile is given', async () => {
+    const big = { data: 'x'.repeat(MAX_INLINE_RESPONSE_CHARS + 10) };
+    const { tools } = makeTools(async () => big);
+
+    await expect(
+      tools.handleExportActor({ actorIdentifier: 'Goblin Boss', outFile: '/tmp/ozhog.json' })
+    ).resolves.toBe(big);
+  });
+});
+
+describe('manage-compendium', () => {
+  it('requires a pack for pack-scoped actions', async () => {
+    const { tools, query } = makeTools();
+
+    await expect(tools.handleManageCompendium({ action: 'contents' })).rejects.toThrow(
+      /requires "pack"/
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('requires a label for create', async () => {
+    const { tools } = makeTools();
+
+    await expect(tools.handleManageCompendium({ action: 'create' })).rejects.toThrow(
+      /requires "label"/
+    );
+  });
+
+  it('requires ids or names for delete-entries', async () => {
+    const { tools } = makeTools();
+
+    await expect(
+      tools.handleManageCompendium({ action: 'delete-entries', pack: 'world.my-bestiary' })
+    ).rejects.toThrow(/requires "entryIds" or "entryNames"/);
+  });
+
+  it('forwards a valid create call', async () => {
+    const { tools, query } = makeTools();
+
+    await tools.handleManageCompendium({
+      action: 'create',
+      label: 'My Bestiary',
+      documentType: 'Actor',
+    });
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.manageCompendium', {
+      action: 'create',
+      label: 'My Bestiary',
+      documentType: 'Actor',
+    });
+  });
+});
+
+describe('manage-actor-items', () => {
+  it('passes dotted keys and deletions through verbatim', async () => {
+    const { tools, query } = makeTools();
+    const updates = [{ _id: 'abc123', 'system.uses.max': '3', 'system.activities.-=def456': null }];
+
+    await tools.handleManageActorItems({
+      actorIdentifier: 'Goblin Boss',
+      action: 'update-raw',
+      updates,
+    });
+
+    expect(query.mock.calls[0][1].updates).toEqual(updates);
+  });
+
+  it('rejects update-raw without updates', async () => {
+    const { tools, query } = makeTools();
+
+    await expect(
+      tools.handleManageActorItems({ actorIdentifier: 'Goblin Boss', action: 'update-raw' })
+    ).rejects.toThrow(/requires "updates" or "filePath"/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('applies the inline response limit to list', async () => {
+    const { tools } = makeTools(async () => ({ items: 'x'.repeat(MAX_INLINE_RESPONSE_CHARS) }));
+
+    await expect(
+      tools.handleManageActorItems({ actorIdentifier: 'Goblin Boss', action: 'list' })
+    ).rejects.toThrow(/response limit/);
+  });
+});
+
+describe('update-actor-raw', () => {
+  it('forwards the update object unchanged', async () => {
+    const { tools, query } = makeTools();
+    const update = { 'system.attributes.hp.max': 120, 'system.details.-=cr': null };
+
+    await tools.handleUpdateActorRaw({ actorIdentifier: 'Goblin Boss', update });
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.updateActor', {
+      actorIdentifier: 'Goblin Boss',
+      update,
+    });
+  });
+
+  it('rejects an empty update', async () => {
+    const { tools } = makeTools();
+
+    await expect(
+      tools.handleUpdateActorRaw({ actorIdentifier: 'Goblin Boss', update: {} })
+    ).rejects.toThrow(/at least one key/);
+  });
+});
+
+describe('run-script and bridge-info', () => {
+  it('forwards script, args and timeout', async () => {
+    const { tools, query } = makeTools();
+
+    await tools.handleRunScript({
+      script: 'return game.actors.size;',
+      args: { a: 1 },
+      timeoutMs: 5000,
+    });
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.runScript', {
+      script: 'return game.actors.size;',
+      args: { a: 1 },
+      timeoutMs: 5000,
+    });
+  });
+
+  it('rejects an empty script', async () => {
+    const { tools } = makeTools();
+
+    await expect(tools.handleRunScript({ script: '' })).rejects.toThrow();
+  });
+
+  it('queries bridge info with an empty payload', async () => {
+    const { tools, query } = makeTools();
+
+    await tools.handleBridgeInfo({});
+
+    expect(query).toHaveBeenCalledWith('foundry-mcp-bridge.raw.bridgeInfo', {});
+  });
+});

--- a/packages/mcp-server/src/tools/raw-actor.ts
+++ b/packages/mcp-server/src/tools/raw-actor.ts
@@ -1,0 +1,578 @@
+/**
+ * Raw Actor Tools
+ *
+ * Raw, high-fidelity access to Foundry documents:
+ * full actor import/export (items with activities included), world compendium
+ * management, verbatim embedded-item and actor updates, an arbitrary script
+ * escape hatch, and a bridge diagnostics probe.
+ *
+ * Every handler forwards to a `foundry-mcp-bridge.raw.*` query in the module.
+ *
+ * The `filePath` / `scriptFile` / `outFile` arguments are advertised in the schemas
+ * so MCP clients can use them, but they are handled entirely by the stdio wrapper
+ * (src/tool-files.ts) before the call reaches this class. The only one this class
+ * looks at is `outFile`, and only to decide whether a large payload may be inlined.
+ */
+
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Largest tool response returned inline, in characters of serialized JSON. */
+export const MAX_INLINE_RESPONSE_CHARS = 200_000;
+
+export interface RawActorToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+const actorDataSchema = z
+  .object({
+    name: z.string().min(1),
+    type: z.string().min(1),
+  })
+  .passthrough();
+
+const destinationSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('world'), folder: z.string().min(1).optional() }),
+  z.object({ type: z.literal('pack'), pack: z.string().min(1) }),
+]);
+
+export class RawActorTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor({ foundryClient, logger }: RawActorToolsOptions) {
+    this.foundryClient = foundryClient;
+    this.logger = logger.child({ component: 'RawActorTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'import-actor',
+        description:
+          'Import complete actor documents into the world or a compendium pack. Accepts full ' +
+          'Foundry actor source including items with activities; the recommended way to create ' +
+          'monsters with legendary actions, recharge, templates and spell links.\n' +
+          '- Provide exactly one of "actors" (inline) or "filePath" (a JSON file on the machine ' +
+          'running this MCP server, holding one actor object or an array of them).\n' +
+          '- "destination" targets the world (optionally a named folder) or a compendium pack.\n' +
+          '- "replace": "byName" (default) removes same-named documents in the destination first, ' +
+          '"none" keeps them.\n' +
+          '- A failing actor does not abort the rest; failures come back in "errors".',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actors: {
+              type: 'array',
+              minItems: 1,
+              maxItems: 50,
+              description:
+                'Full actor source objects as returned by export-actor, each with "name" and ' +
+                '"type" plus optional "system", "items", "effects", "prototypeToken", "flags". ' +
+                'Mutually exclusive with "filePath".',
+              items: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', description: 'Display name of the actor.' },
+                  type: {
+                    type: 'string',
+                    description: 'Actor type valid for the active game system, e.g. "npc".',
+                  },
+                  img: { type: 'string', description: 'Portrait path.' },
+                  system: {
+                    type: 'object',
+                    additionalProperties: true,
+                    description: 'System data, passed to Foundry unchanged.',
+                  },
+                  items: {
+                    type: 'array',
+                    description:
+                      'Full embedded item source objects, including "system.activities".',
+                    items: { type: 'object', additionalProperties: true },
+                  },
+                },
+                required: ['name', 'type'],
+                additionalProperties: true,
+              },
+            },
+            filePath: {
+              type: 'string',
+              description:
+                'Path to a JSON file holding one actor object or an array of actor objects. ' +
+                'Read by the MCP wrapper before the call is forwarded. ' +
+                'Mutually exclusive with "actors".',
+            },
+            destination: {
+              type: 'object',
+              description: 'Where the actors go: the world or a compendium pack.',
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['world', 'pack'],
+                  description: '"world" for game.actors, "pack" for a compendium.',
+                },
+                folder: {
+                  type: 'string',
+                  description:
+                    'For type "world": Actor folder name, created if absent. Defaults to "Imported Actors".',
+                },
+                pack: {
+                  type: 'string',
+                  description:
+                    'For type "pack": pack collection id (e.g. "world.my-bestiary"), label, or name.',
+                },
+              },
+              required: ['type'],
+            },
+            replace: {
+              type: 'string',
+              enum: ['byName', 'none'],
+              description:
+                'Delete same-named documents in the destination before creating. Defaults to "byName".',
+            },
+            keepId: {
+              type: 'boolean',
+              description:
+                'Keep the "_id" values from the source data instead of letting Foundry assign new ones. Defaults to false.',
+            },
+          },
+          required: ['destination'],
+        },
+      },
+      {
+        name: 'export-actor',
+        description:
+          'Export one actor as its full Foundry source object, items and activities included. ' +
+          'Use it to snapshot a monster before editing, or to copy an actor between worlds and ' +
+          'compendiums together with import-actor.\n' +
+          '- The actor is resolved by UUID, id, exact name, then case-insensitive partial name.\n' +
+          '- Pass "outFile" for large actors: the source is written to that path and the response ' +
+          'shrinks to a summary. Without it, responses above ' +
+          `${MAX_INLINE_RESPONSE_CHARS} characters are refused.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actorIdentifier: {
+              type: 'string',
+              description: 'Actor UUID, id, or name. Partial names must be unambiguous.',
+            },
+            pack: {
+              type: 'string',
+              description:
+                'Optional compendium pack to look in (collection id, label, or name) instead of the world.',
+            },
+            outFile: {
+              type: 'string',
+              description:
+                'Path to write the actor source JSON to (pretty-printed, UTF-8; directories are ' +
+                'created). Written by the MCP wrapper on the machine running this server.',
+            },
+          },
+          required: ['actorIdentifier'],
+        },
+      },
+      {
+        name: 'manage-compendium',
+        description:
+          'Inspect and manage compendium packs of the current world.\n' +
+          '- "list": all packs with collection id, label, document type, locked flag and size.\n' +
+          '- "create": make a world pack (returns the existing one if the name is taken).\n' +
+          '- "contents": index entries of one pack.\n' +
+          '- "delete-entries": remove entries by id or by exact name.\n' +
+          '- "lock" / "unlock": toggle the pack lock.\n' +
+          '- "delete-pack": drop a world pack entirely (world packs only).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              type: 'string',
+              enum: [
+                'list',
+                'create',
+                'contents',
+                'delete-entries',
+                'lock',
+                'unlock',
+                'delete-pack',
+              ],
+              description: 'Operation to perform.',
+            },
+            pack: {
+              type: 'string',
+              description:
+                'Required for every action except "list" and "create". Pack collection id ' +
+                '(e.g. "world.my-bestiary"), label, or name.',
+            },
+            label: {
+              type: 'string',
+              description: 'Required for "create". Display name, e.g. "My Bestiary".',
+            },
+            name: {
+              type: 'string',
+              description:
+                'For "create". Machine name; defaults to a latin/hyphen slug of the label.',
+            },
+            documentType: {
+              type: 'string',
+              enum: ['Actor', 'Item', 'JournalEntry', 'Scene', 'RollTable', 'Macro'],
+              description: 'For "create". Document type of the pack. Defaults to "Actor".',
+            },
+            entryIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'For "delete-entries". Entry ids to remove.',
+            },
+            entryNames: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'For "delete-entries". Exact entry names to remove.',
+            },
+          },
+          required: ['action'],
+        },
+      },
+      {
+        name: 'manage-actor-items',
+        description:
+          'Work with the embedded items of one actor at source level.\n' +
+          '- "list": items with uses, activities and compendium source.\n' +
+          '- "create": add full item source objects, activities included.\n' +
+          '- "update-raw": pass updates to Foundry verbatim, so dotted keys ' +
+          '("system.uses.max") and key deletions ("system.activities.-=abc123": null) survive. ' +
+          'Use this instead of manage-actors "update-items" whenever a nested field must be kept.\n' +
+          '- "delete": remove items by id.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actorIdentifier: {
+              type: 'string',
+              description: 'Actor UUID, id, or name. Partial names must be unambiguous.',
+            },
+            action: {
+              type: 'string',
+              enum: ['list', 'create', 'update-raw', 'delete'],
+              description: 'Operation to perform.',
+            },
+            items: {
+              type: 'array',
+              minItems: 1,
+              description:
+                'Required for "create". Full item source objects, passed to Foundry as they are.',
+              items: { type: 'object', additionalProperties: true },
+            },
+            updates: {
+              type: 'array',
+              minItems: 1,
+              description:
+                'Required for "update-raw". Each entry needs "_id" plus the keys to change; ' +
+                'dotted paths and "-=" deletions are forwarded unchanged.',
+              items: {
+                type: 'object',
+                properties: { _id: { type: 'string', description: 'Embedded item id.' } },
+                required: ['_id'],
+                additionalProperties: true,
+              },
+            },
+            itemIds: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 1,
+              description: 'Required for "delete". Ids of the embedded items to remove.',
+            },
+            filePath: {
+              type: 'string',
+              description:
+                'Path to a JSON file holding the "items" ("create") or "updates" ("update-raw") ' +
+                'array. Read by the MCP wrapper before the call is forwarded.',
+            },
+          },
+          required: ['actorIdentifier', 'action'],
+        },
+      },
+      {
+        name: 'update-actor-raw',
+        description:
+          'Update one actor with a verbatim Foundry update object. Dotted keys ' +
+          '("system.attributes.hp.max") reach Foundry untouched, so sibling fields survive - ' +
+          'unlike manage-actors "update", which replaces nested system objects wholesale. ' +
+          'Key deletion via "-=" is supported.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            actorIdentifier: {
+              type: 'string',
+              description: 'Actor UUID, id, or name. Partial names must be unambiguous.',
+            },
+            update: {
+              type: 'object',
+              additionalProperties: true,
+              description:
+                'Update keys passed straight to actor.update(), e.g. ' +
+                '{"system.attributes.hp.max": 120, "name": "Goblin Boss"}.',
+            },
+            filePath: {
+              type: 'string',
+              description:
+                'Path to a JSON file holding the update object. Read by the MCP wrapper before ' +
+                'the call is forwarded. Mutually exclusive with "update".',
+            },
+          },
+          required: ['actorIdentifier'],
+        },
+      },
+      {
+        name: 'run-script',
+        description:
+          'Run a JavaScript snippet inside the GM browser client that acts as the bridge. ' +
+          'The snippet is the body of an async function receiving "args"; "return" hands the ' +
+          'value back. Use it for one-off maintenance no other tool covers. Requires GM and ' +
+          'enabled write operations; errors come back with their stack instead of throwing.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            script: {
+              type: 'string',
+              description:
+                'Async function body, e.g. "return game.actors.size;". Mutually exclusive with "scriptFile".',
+            },
+            scriptFile: {
+              type: 'string',
+              description:
+                'Path to a .js file holding the script body. Read by the MCP wrapper before the ' +
+                'call is forwarded. Mutually exclusive with "script".',
+            },
+            args: {
+              description: 'Optional JSON value handed to the script as "args".',
+            },
+            timeoutMs: {
+              type: 'number',
+              description: 'Abort the script after this many milliseconds. Defaults to 60000.',
+            },
+          },
+        },
+      },
+      {
+        name: 'bridge-info',
+        description:
+          'Report which Foundry client currently acts as the MCP bridge: user, GM flag, world, ' +
+          'game system and version, core version, module version, connection type and origin URL. ' +
+          'Call it first when bridge behaviour looks wrong.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    ];
+  }
+
+  // ── import-actor ──────────────────────────────────────────────────────────
+
+  async handleImportActor(args: any): Promise<any> {
+    const schema = z.object({
+      actors: z.array(actorDataSchema).min(1).max(50),
+      destination: destinationSchema,
+      replace: z.enum(['byName', 'none']).default('byName'),
+      keepId: z.boolean().default(false),
+    });
+
+    const { actors, destination, replace, keepId } = schema.parse(args);
+
+    this.logger.info('Importing actors', {
+      count: actors.length,
+      destination: destination.type,
+      replace,
+      keepId,
+    });
+
+    return await this.foundryClient.query('foundry-mcp-bridge.raw.importActors', {
+      actors,
+      destination,
+      replace,
+      keepId,
+    });
+  }
+
+  // ── export-actor ──────────────────────────────────────────────────────────
+
+  async handleExportActor(args: any): Promise<any> {
+    const schema = z.object({
+      actorIdentifier: z.string().min(1),
+      pack: z.string().min(1).optional(),
+      outFile: z.string().min(1).optional(),
+    });
+
+    const { actorIdentifier, pack, outFile } = schema.parse(args);
+
+    this.logger.info('Exporting actor', { actorIdentifier, pack, toFile: !!outFile });
+
+    const result = await this.foundryClient.query('foundry-mcp-bridge.raw.exportActor', {
+      actorIdentifier,
+      pack,
+    });
+
+    this.assertWithinInlineLimit(result, outFile, 'export-actor');
+
+    return result;
+  }
+
+  // ── manage-compendium ─────────────────────────────────────────────────────
+
+  async handleManageCompendium(args: any): Promise<any> {
+    const schema = z.object({
+      action: z.enum([
+        'list',
+        'create',
+        'contents',
+        'delete-entries',
+        'lock',
+        'unlock',
+        'delete-pack',
+      ]),
+      pack: z.string().min(1).optional(),
+      label: z.string().min(1).optional(),
+      name: z.string().min(1).optional(),
+      documentType: z
+        .enum(['Actor', 'Item', 'JournalEntry', 'Scene', 'RollTable', 'Macro'])
+        .optional(),
+      entryIds: z.array(z.string().min(1)).optional(),
+      entryNames: z.array(z.string().min(1)).optional(),
+    });
+
+    const parsed = schema.parse(args);
+    const { action, pack, label, entryIds, entryNames } = parsed;
+
+    if (action !== 'list' && action !== 'create' && !pack) {
+      throw new Error(`manage-compendium action "${action}" requires "pack"`);
+    }
+    if (action === 'create' && !label) {
+      throw new Error('manage-compendium action "create" requires "label"');
+    }
+    if (action === 'delete-entries' && !entryIds?.length && !entryNames?.length) {
+      throw new Error(
+        'manage-compendium action "delete-entries" requires "entryIds" or "entryNames"'
+      );
+    }
+
+    this.logger.info('Managing compendium', { action, pack });
+
+    return await this.foundryClient.query('foundry-mcp-bridge.raw.manageCompendium', parsed);
+  }
+
+  // ── manage-actor-items ────────────────────────────────────────────────────
+
+  async handleManageActorItems(args: any): Promise<any> {
+    const schema = z.object({
+      actorIdentifier: z.string().min(1),
+      action: z.enum(['list', 'create', 'update-raw', 'delete']),
+      items: z.array(z.record(z.any())).min(1).optional(),
+      updates: z
+        .array(z.object({ _id: z.string().min(1) }).passthrough())
+        .min(1)
+        .optional(),
+      itemIds: z.array(z.string().min(1)).min(1).optional(),
+    });
+
+    const { actorIdentifier, action, items, updates, itemIds } = schema.parse(args);
+
+    if (action === 'create' && !items) {
+      throw new Error('manage-actor-items action "create" requires "items" or "filePath"');
+    }
+    if (action === 'update-raw' && !updates) {
+      throw new Error('manage-actor-items action "update-raw" requires "updates" or "filePath"');
+    }
+    if (action === 'delete' && !itemIds) {
+      throw new Error('manage-actor-items action "delete" requires "itemIds"');
+    }
+
+    this.logger.info('Managing actor items', { actorIdentifier, action });
+
+    const result = await this.foundryClient.query('foundry-mcp-bridge.raw.manageActorItems', {
+      actorIdentifier,
+      action,
+      items,
+      updates,
+      itemIds,
+    });
+
+    if (action === 'list') {
+      this.assertWithinInlineLimit(result, undefined, 'manage-actor-items list');
+    }
+
+    return result;
+  }
+
+  // ── update-actor-raw ──────────────────────────────────────────────────────
+
+  async handleUpdateActorRaw(args: any): Promise<any> {
+    const schema = z.object({
+      actorIdentifier: z.string().min(1),
+      update: z.record(z.any()),
+    });
+
+    const { actorIdentifier, update } = schema.parse(args);
+
+    if (Object.keys(update).length === 0) {
+      throw new Error('update-actor-raw requires at least one key in "update"');
+    }
+
+    this.logger.info('Updating actor verbatim', {
+      actorIdentifier,
+      keys: Object.keys(update).length,
+    });
+
+    return await this.foundryClient.query('foundry-mcp-bridge.raw.updateActor', {
+      actorIdentifier,
+      update,
+    });
+  }
+
+  // ── run-script ────────────────────────────────────────────────────────────
+
+  async handleRunScript(args: any): Promise<any> {
+    const schema = z.object({
+      script: z.string().min(1),
+      args: z.any().optional(),
+      timeoutMs: z.number().int().positive().optional(),
+    });
+
+    const { script, args: scriptArgs, timeoutMs } = schema.parse(args);
+
+    this.logger.info('Running bridge script', { length: script.length, timeoutMs });
+
+    return await this.foundryClient.query('foundry-mcp-bridge.raw.runScript', {
+      script,
+      args: scriptArgs,
+      timeoutMs,
+    });
+  }
+
+  // ── bridge-info ───────────────────────────────────────────────────────────
+
+  async handleBridgeInfo(_args?: any): Promise<any> {
+    this.logger.info('Querying bridge info');
+
+    return await this.foundryClient.query('foundry-mcp-bridge.raw.bridgeInfo', {});
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  /**
+   * Refuse payloads too large to hand back inline. export-actor can spill to disk
+   * via "outFile"; other callers are told to use it.
+   */
+  private assertWithinInlineLimit(result: unknown, outFile: string | undefined, label: string) {
+    if (outFile) return;
+
+    const size = JSON.stringify(result)?.length ?? 0;
+    if (size <= MAX_INLINE_RESPONSE_CHARS) return;
+
+    throw new Error(
+      `${label} produced ${size} characters, over the ${MAX_INLINE_RESPONSE_CHARS} character response limit. ` +
+        'Re-run export-actor with "outFile" to write the payload to a file instead.'
+    );
+  }
+}

--- a/scripts/headless-gm/headless-gm.mjs
+++ b/scripts/headless-gm/headless-gm.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+// Headless Foundry GM client that keeps the MCP bridge module connected 24/7.
+//
+// Runs a headless Chrome next to the Foundry server, logs in as a dedicated GM
+// user and stays on the /game page. The bridge module inside that page connects
+// to the MCP backend on localhost, so the bridge no longer depends on anyone's
+// browser being open. Handles world restarts (/join, /setup) and page crashes by
+// re-logging in with backoff.
+//
+// Env: FOUNDRY_URL (http://127.0.0.1:30000), FOUNDRY_USER, FOUNDRY_PASSWORD,
+//      HEADLESS_NO_CANVAS=1 to disable canvas rendering for the bot client.
+
+import puppeteer from 'puppeteer';
+
+const FOUNDRY_URL = (process.env.FOUNDRY_URL || 'http://127.0.0.1:30000').replace(/\/$/, '');
+const FOUNDRY_USER = process.env.FOUNDRY_USER || '';
+const FOUNDRY_PASSWORD = process.env.FOUNDRY_PASSWORD || '';
+const NO_CANVAS = process.env.HEADLESS_NO_CANVAS === '1';
+const PROFILE_DIR = process.env.HEADLESS_PROFILE_DIR || new URL('./profile', import.meta.url).pathname;
+const POLL_MS = 15000;
+
+if (!FOUNDRY_USER || !FOUNDRY_PASSWORD) {
+  console.error('FOUNDRY_USER and FOUNDRY_PASSWORD are required');
+  process.exit(2);
+}
+
+const log = (...a) => console.log(new Date().toISOString(), ...a);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function launch() {
+  const browser = await puppeteer.launch({
+    headless: true,
+    // Persistent profile: Foundry client settings (noCanvas, maxFPS) live in localStorage.
+    userDataDir: PROFILE_DIR,
+    args: [
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      // Foundry needs WebGL even on the join page (PIXI probes it); software GL via SwiftShader.
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+      '--ignore-gpu-blocklist',
+      '--mute-audio',
+      '--autoplay-policy=no-user-gesture-required',
+      '--window-size=1280,800',
+    ],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  page.on('console', msg => {
+    const text = msg.text();
+    if (text.includes('foundry-mcp-bridge') || msg.type() === 'error') log('[page]', msg.type(), text.slice(0, 300));
+  });
+  page.on('pageerror', err => log('[pageerror]', String(err).slice(0, 300)));
+  // A blank tab that takes the foreground once the game is ready: Chrome throttles painting
+  // and rAF in background tabs, which stops SwiftShader from compositing the Foundry UI at
+  // full frame rate. The join page needs rAF to render its form, so it stays in front until
+  // login completes. Sockets and query handling keep working in the background tab.
+  const idle = await browser.newPage();
+  await idle.goto('about:blank').catch(() => {});
+  await page.bringToFront().catch(() => {});
+  return { browser, page, idle };
+}
+
+async function readState(page) {
+  try {
+    return await page.evaluate(() => ({
+      path: location.pathname,
+      ready: Boolean(globalThis.game && globalThis.game.ready),
+      user: globalThis.game?.user?.name ?? null,
+      bridge: globalThis.foundryMCPBridge?.getStatus?.() ?? null,
+    }));
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+async function seedClientSettings(page) {
+  // Foundry reads client-scoped settings from localStorage at init, so seeding them on the
+  // join page means the game never renders the canvas at 60 fps before the loop catches up.
+  await page.evaluate(noCanvas => {
+    try {
+      localStorage.setItem('core.maxFPS', '5');
+      if (noCanvas) localStorage.setItem('core.noCanvas', 'true');
+    } catch {}
+  }, NO_CANVAS);
+}
+
+async function login(page) {
+  await page.waitForSelector('select[name="userid"]', { timeout: 30000 });
+  await seedClientSettings(page);
+  const picked = await page.evaluate(name => {
+    const select = document.querySelector('select[name="userid"]');
+    const option = Array.from(select.options).find(o => o.textContent.trim() === name);
+    if (!option) return false;
+    select.value = option.value;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  }, FOUNDRY_USER);
+  if (!picked) {
+    log(`user "${FOUNDRY_USER}" is missing from the join list (logged in elsewhere or not created)`);
+    return false;
+  }
+  await page.click('input[name="password"]', { clickCount: 3 });
+  await page.type('input[name="password"]', FOUNDRY_PASSWORD);
+  const submitted = await page.evaluate(() => {
+    const button =
+      document.querySelector('button[name="join"]') ||
+      document.querySelector('form#join-game button[type="submit"]') ||
+      document.querySelector('form button[type="submit"]');
+    if (!button) return false;
+    button.click();
+    return true;
+  });
+  if (!submitted) {
+    log('join button not found');
+    return false;
+  }
+  await page.waitForFunction(() => location.pathname.startsWith('/game'), { timeout: 60000 }).catch(() => {});
+  return true;
+}
+
+async function applyClientSettings(page) {
+  // Keep the software renderer cheap: low frame cap, or no canvas at all.
+  const changed = await page.evaluate(async noCanvas => {
+    let reload = false;
+    // maxFPS onChange touches canvas.app.renderer, so only set it while a canvas exists
+    if (!noCanvas && game.settings.get('core', 'maxFPS') !== 5) await game.settings.set('core', 'maxFPS', 5);
+    if (noCanvas && !game.settings.get('core', 'noCanvas')) {
+      await game.settings.set('core', 'noCanvas', true);
+      reload = true;
+    }
+    return reload;
+  }, NO_CANVAS);
+  if (changed) {
+    log('noCanvas enabled for this client, reloading');
+    await page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {});
+  }
+}
+
+async function main() {
+  let { browser, page, idle } = await launch();
+  let lastLogged = '';
+  let failures = 0;
+  let backgrounded = false;
+
+  for (;;) {
+    try {
+      if (!browser.connected) throw new Error('browser disconnected');
+      const state = await readState(page);
+      const key = JSON.stringify({ p: state.path, r: state.ready, c: state.bridge?.connected ?? null, e: state.error ? 1 : 0 });
+      if (key !== lastLogged) {
+        log('state', JSON.stringify(state).slice(0, 400));
+        lastLogged = key;
+      }
+
+      if (state.error || !state.path || state.path === 'blank') {
+        await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      } else if (state.path.startsWith('/join')) {
+        if (backgrounded) {
+          await page.bringToFront().catch(() => {});
+          backgrounded = false;
+        }
+        await login(page);
+      } else if (state.path.startsWith('/game')) {
+        if (state.ready) {
+          failures = 0;
+          await applyClientSettings(page);
+          if (!backgrounded && state.bridge?.connected) {
+            await idle.bringToFront().catch(() => {});
+            backgrounded = true;
+            log('foundry tab moved to background');
+          }
+          const bridge = state.bridge;
+          if (bridge && bridge.enabled && !bridge.connected && !bridge.actAsBridge) {
+            log('actAsBridge is off for this client - enabling');
+            await page.evaluate(() => game.settings.set('foundry-mcp-bridge', 'actAsBridge', true));
+          }
+        }
+      } else {
+        // /setup, /license, /auth or anything else: world is down, wait and retry
+        await sleep(POLL_MS);
+        await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => {});
+      }
+    } catch (error) {
+      failures += 1;
+      log('loop error', String(error).slice(0, 300), 'failures', failures);
+      if (failures >= 3) {
+        log('relaunching browser');
+        try {
+          await browser.close();
+        } catch {}
+        ({ browser, page, idle } = await launch());
+        backgrounded = false;
+        failures = 0;
+      }
+      await sleep(Math.min(POLL_MS * failures, 60000));
+    }
+    await sleep(POLL_MS);
+  }
+}
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));
+
+main().catch(error => {
+  console.error('fatal', error);
+  process.exit(1);
+});

--- a/scripts/mcp-call.mjs
+++ b/scripts/mcp-call.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Call one MCP tool through the stdio wrapper (dist/index.js) from the shell.
+// Exercises the full path: wrapper (file hydration) -> backend control socket -> Foundry module.
+//
+//   node scripts/mcp-call.mjs list
+//   node scripts/mcp-call.mjs bridge-info '{}'
+//   node scripts/mcp-call.mjs import-actor '{"filePath":"/abs/actor.json","destination":{"type":"pack","pack":"world.my-bestiary"}}'
+//   node scripts/mcp-call.mjs run-script '{"script":"return game.world.id"}'
+//
+// Env: FOUNDRY_HOST/FOUNDRY_PORT are passed through to the wrapper like Claude Code does.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const [, , toolName, argsJson] = process.argv;
+if (!toolName) {
+  console.error('usage: mcp-call.mjs <tool|list> [json-args]');
+  process.exit(2);
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const wrapper = path.join(here, '..', 'packages', 'mcp-server', 'dist', 'index.js');
+
+const child = spawn(process.execPath, [wrapper], {
+  stdio: ['pipe', 'pipe', 'inherit'],
+  env: {
+    ...process.env,
+    FOUNDRY_HOST: process.env.FOUNDRY_HOST || 'localhost',
+    FOUNDRY_PORT: process.env.FOUNDRY_PORT || '31415',
+    FOUNDRY_CONNECTION_TYPE: process.env.FOUNDRY_CONNECTION_TYPE || 'websocket',
+    LOG_LEVEL: process.env.LOG_LEVEL || 'warn',
+  },
+});
+
+let buffer = '';
+const pending = new Map();
+let nextId = 1;
+
+child.stdout.on('data', chunk => {
+  buffer += chunk.toString();
+  let idx;
+  while ((idx = buffer.indexOf('\n')) >= 0) {
+    const line = buffer.slice(0, idx).trim();
+    buffer = buffer.slice(idx + 1);
+    if (!line) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (msg.id !== undefined && pending.has(msg.id)) {
+      pending.get(msg.id)(msg);
+      pending.delete(msg.id);
+    }
+  }
+});
+
+function rpc(method, params) {
+  const id = nextId++;
+  return new Promise(resolve => {
+    pending.set(id, resolve);
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+  });
+}
+
+function notify(method, params) {
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+}
+
+const timer = setTimeout(() => {
+  console.error('timeout');
+  child.kill();
+  process.exit(1);
+}, Number(process.env.MCP_CALL_TIMEOUT || 120000));
+
+try {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'mcp-call', version: '0.1' },
+  });
+  notify('notifications/initialized', {});
+
+  if (toolName === 'list') {
+    const res = await rpc('tools/list', {});
+    for (const t of res.result?.tools || []) console.log(t.name);
+  } else {
+    const args = argsJson ? JSON.parse(argsJson) : {};
+    const res = await rpc('tools/call', { name: toolName, arguments: args });
+    if (res.error) {
+      console.error('rpc error:', JSON.stringify(res.error));
+      process.exitCode = 1;
+    } else {
+      const content = res.result?.content || [];
+      for (const c of content) console.log(c.type === 'text' ? c.text : JSON.stringify(c));
+      if (res.result?.isError) process.exitCode = 1;
+    }
+  }
+} finally {
+  clearTimeout(timer);
+  child.stdin.end();
+  child.kill();
+}

--- a/scripts/mcp-schema-smoke-test.mjs
+++ b/scripts/mcp-schema-smoke-test.mjs
@@ -22,7 +22,8 @@ const importDist = async (relativePath) =>
 
 const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { CompendiumTools }, { SceneTools },
   { ActorCreationTools }, { QuestCreationTools }, { DiceRollTools }, { CampaignManagementTools },
-  { OwnershipTools }, { TokenManipulationTools }, { MapGenerationTools }, { getSystemRegistry },
+  { OwnershipTools }, { TokenManipulationTools }, { MapGenerationTools }, { RawActorTools },
+  { getSystemRegistry },
   { DnD5eAdapter }, { PF2eAdapter }, { DSA5Adapter }, { CosmereRpgAdapter }] = await Promise.all([
   importDist('config.js'),
   importDist('logger.js'),
@@ -37,6 +38,7 @@ const [{ config }, { Logger }, { FoundryClient }, { CharacterTools }, { Compendi
   importDist('tools/ownership.js'),
   importDist('tools/token-manipulation.js'),
   importDist('tools/map-generation.js'),
+  importDist('tools/raw-actor.js'),
   importDist('systems/index.js'),
   importDist('systems/dnd5e/adapter.js'),
   importDist('systems/pf2e/adapter.js'),
@@ -64,6 +66,7 @@ const tools = [
   ...new OwnershipTools({ foundryClient, logger }).getToolDefinitions(),
   ...new TokenManipulationTools({ foundryClient, logger }).getToolDefinitions(),
   ...new MapGenerationTools({ foundryClient, logger, backendComfyUIHandlers: {} }).getToolDefinitions(),
+  ...new RawActorTools({ foundryClient, logger }).getToolDefinitions(),
 ];
 
 if (!tools.length) {
@@ -86,6 +89,26 @@ if (additionalPropertiesFalseCount === objectSchemas.length) {
   fail(
     'Every tool schema has additionalProperties=false. This indicates schema normalization is forcing strictness globally.',
   );
+}
+
+const rawActorToolNames = [
+  'import-actor',
+  'export-actor',
+  'manage-compendium',
+  'manage-actor-items',
+  'update-actor-raw',
+  'run-script',
+  'bridge-info',
+];
+for (const name of rawActorToolNames) {
+  if (!tools.some((tool) => tool.name === name)) {
+    fail(`Expected raw actor tool "${name}" to be present but it was not found.`);
+  }
+}
+
+const importActorDescription = tools.find((tool) => tool.name === 'import-actor').description;
+if (!importActorDescription.includes('full Foundry actor source including items with activities')) {
+  fail('Tool "import-actor" no longer advertises that it takes full actor source with activities.');
 }
 
 const switchSceneSchema = tools.find((tool) => tool.name === 'switch-scene')?.inputSchema;


### PR DESCRIPTION
## What

Seven new tools that give the MCP client raw, system-agnostic access to Foundry documents, plus reliability work on the module and a way to run the bridge without a browser.

**Tools** (`packages/mcp-server/src/tools/raw-actor.ts`, module side `packages/foundry-module/src/raw-handlers.ts`, queries `foundry-mcp-bridge.raw.*`):
- `import-actor` - full actor source (items with `system.activities`, effects, prototype token, flags) into the world or a compendium pack; `replace: byName`, `keepId`, per-actor error reporting.
- `export-actor` - `actor.toObject()` for world actors and compendium entries, optionally straight to a file.
- `manage-compendium` - list / create / contents / delete-entries / lock / unlock / delete-pack for world packs; locked packs are unlocked for the write and re-locked.
- `manage-actor-items` - list / create / `update-raw` (verbatim `updateEmbeddedDocuments`, dotted keys and `-=` work) / delete.
- `update-actor-raw` - verbatim `actor.update`.
- `run-script` - async function body in the GM client with `game` and `args`; errors returned in the result with stack.
- `bridge-info` - which user / world / connection the bridge runs as.

The motivation was dnd5e 4.x/5.x monsters with legendary actions, recharge and templates: the existing helpers cannot express those, while full source import does it in one call. Nothing in the tools is system-specific.

**File-backed arguments** (`filePath`, `scriptFile`, `outFile`) are hydrated in the stdio wrapper (`src/tool-files.ts`), so the backend can run on a different host than the MCP client.

**Module**
- Reconnect with capped backoff, no attempt limit; the heartbeat keeps retrying while the MCP server is down instead of disabling itself.
- Client-scoped setting "Act as MCP bridge client" so extra GM sessions stay passive.
- Connection type `auto` uses WebSocket for loopback hosts even on HTTPS pages (the WebRTC signaling path failed silently there in my setup); remote hosts keep the previous behaviour.

**Backend**: `FOUNDRY_BIND_HOST` to bind the WebSocket and WebRTC signaling listeners to a specific interface (127.0.0.1 when the backend runs next to Foundry on a public server).

**Scripts**: `scripts/headless-gm/headless-gm.mjs` (puppeteer runner keeping a dedicated GM user logged in next to the Foundry server; with `HEADLESS_NO_CANVAS=1` it idles at ~1% CPU), `scripts/mcp-call.mjs` (call any tool from the shell through the wrapper), `scripts/deploy-module.sh` (rsync the built module to a remote data directory).

Docs: `docs/raw-actor-tools.md`, README bullet, CHANGELOG entry under Unreleased. Versions untouched.

## Tests

- `npm run typecheck`, `npm run build`, `npm run bundle:server` - clean.
- `npm run test --workspace=packages/mcp-server` - 12 files, 203 tests (50 new: `tool-files.test.ts`, `tools/raw-actor.test.ts`).
- `node scripts/mcp-schema-smoke-test.mjs` - passes, checks the seven tools are advertised.
- Live: Foundry 14.360 + dnd5e 5.3.0, 22 monsters imported into a world pack with legendary actions, recharge and area templates; six player sheets repaired through `run-script` / `manage-actor-items`; headless GM runner under systemd on Ubuntu 24.04.

Note: `npm run lint` inside the workspaces fails on the current master too (`.eslintrc.json` resolves `tsconfig.eslint.json` from the workspace directory); linting from the repository root works and the new files add no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)