### PR TITLE
fix(dnd5e): 5 defects in add-feature — stale skill/ability defaults, …

### DIFF
--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -8044,12 +8044,13 @@ export class FoundryDataAccess {
     activationType: string;
     saveAbility: string;
     saveDC: number;
-    damageParts: Array<{ number: number; denomination: number; type: string }>;
+    damageParts: Array<{ number: number; denomination: number; type: string; bonus?: number }>;
     halfOnSave: boolean;
     areaType: string;
     areaSize?: number;
     areaUnits: string;
     affectsType: string;
+    uses?: { max: number; per: 'day' | 'recharge'; rechargeOn?: number };
   }): Promise<any> {
     this.validateFoundryState();
 
@@ -8086,83 +8087,160 @@ export class FoundryDataAccess {
       // 5a. Map emanation → radius (Foundry uses "radius" for radial emanations)
       const mappedAreaType: string = data.areaType === 'emanation' ? 'radius' : data.areaType;
 
-      // 6. Build item data — schema verified against dnd5e 5.1.8 real output
-      const itemData = {
-        name: data.featureName,
-        type: 'feat',
-        img: 'systems/dnd5e/icons/svg/items/feature.svg',
-        system: {
-          description: { value: data.description, chat: '' },
-          identifier,
-          source: { revision: 1, rules: '2024' },
-          type: { value: 'monster', subtype: '' },
-          uses: { spent: 0, recovery: [], max: '' },
-          advancement: [],
-          crewed: false,
-          enchant: {},
-          prerequisites: { items: [], repeatable: false, level: null },
-          properties: [],
-          requirements: '',
-          activities: {
-            [activityId]: {
-              _id: activityId,
-              type: 'save',
-              sort: 0,
-              name: '',
-              activation: {
-                type: data.activationType,
-                override: false,
-              },
-              consumption: {
-                scaling: { allowed: false },
-                spellSlot: true,
-                targets: [],
-              },
-              description: {},
-              duration: { units: 'inst', concentration: false, override: false },
-              effects: [],
-              range: { units: 'self', override: false },
-              uses: { spent: 0, recovery: [] },
-              target: {
-                template: {
-                  contiguous: false,
-                  units: data.areaUnits,
-                  count: '',
-                  type: mappedAreaType,
-                  size: mappedAreaType ? String(data.areaSize) : '',
+      // 6. Build item data — Tier 2: clone a real, live save-based monster feature (Adult Red
+      // Dragon's Fire Breath) as a structural scaffold, override only caller-specified fields.
+      // Falls back to full from-scratch construction if that live template isn't available.
+      const saveTemplate = await fetchLiveTemplate(
+        'dnd-monster-manual.actors',
+        'Adult Red Dragon',
+        'save'
+      );
+
+      let itemData: Record<string, any>;
+
+      if (saveTemplate) {
+        const activity = saveTemplate.activity;
+        activity._id = activityId;
+        activity.name = '';
+        activity.sort = 0;
+        activity.description = {};
+        activity.effects = [];
+        activity.activation = {
+          ...activity.activation,
+          type: data.activationType,
+          override: false,
+        };
+        activity.target = {
+          ...activity.target,
+          template: {
+            ...activity.target?.template,
+            contiguous: false,
+            units: data.areaUnits,
+            count: '',
+            type: mappedAreaType,
+            size: mappedAreaType ? String(data.areaSize) : '',
+          },
+          affects: {
+            choice: false,
+            count: '',
+            type: data.affectsType,
+            special: '',
+          },
+        };
+        activity.damage = {
+          ...activity.damage,
+          onSave: data.halfOnSave ? 'half' : 'none',
+          parts: data.damageParts.map(p => ({
+            custom: { enabled: false, formula: '' },
+            number: p.number,
+            denomination: p.denomination,
+            bonus: p.bonus !== undefined ? String(p.bonus) : '',
+            types: [p.type],
+            scaling: { mode: '', number: 1 },
+          })),
+        };
+        activity.save = {
+          ...activity.save,
+          ability: [data.saveAbility],
+          dc: { calculation: '', formula: String(data.saveDC) },
+        };
+
+        itemData = {
+          name: data.featureName,
+          type: 'feat',
+          img: 'systems/dnd5e/icons/svg/items/feature.svg',
+          system: {
+            ...(foundry.utils as any).deepClone(saveTemplate.itemSystem),
+            description: { value: data.description, chat: '' },
+            identifier,
+            source: { revision: 1, rules: '2024' },
+            type: { value: 'monster', subtype: '' },
+            uses: buildUsesField(data.uses),
+            properties: [],
+            requirements: '',
+            activities: { [activityId]: activity },
+          },
+          effects: [],
+        };
+      } else {
+        // Tier 3 — no live template available, build fully from scratch.
+        itemData = {
+          name: data.featureName,
+          type: 'feat',
+          img: 'systems/dnd5e/icons/svg/items/feature.svg',
+          system: {
+            description: { value: data.description, chat: '' },
+            identifier,
+            source: { revision: 1, rules: '2024' },
+            type: { value: 'monster', subtype: '' },
+            uses: buildUsesField(data.uses),
+            advancement: [],
+            crewed: false,
+            enchant: {},
+            prerequisites: { items: [], repeatable: false, level: null },
+            properties: [],
+            requirements: '',
+            activities: {
+              [activityId]: {
+                _id: activityId,
+                type: 'save',
+                sort: 0,
+                name: '',
+                activation: {
+                  type: data.activationType,
+                  override: false,
                 },
-                affects: {
-                  choice: false,
-                  count: '',
-                  type: data.affectsType,
-                  special: '',
+                consumption: {
+                  scaling: { allowed: false },
+                  spellSlot: true,
+                  targets: [],
                 },
-                override: false,
-                prompt: true,
-              },
-              damage: {
-                onSave: data.halfOnSave ? 'half' : 'none',
-                parts: data.damageParts.map(p => ({
-                  custom: { enabled: false, formula: '' },
-                  number: p.number,
-                  denomination: p.denomination,
-                  bonus: '',
-                  types: [p.type],
-                  scaling: { mode: '', number: 1 },
-                })),
-              },
-              save: {
-                ability: [data.saveAbility],
-                dc: {
-                  calculation: '',
-                  formula: String(data.saveDC),
+                description: {},
+                duration: { units: 'inst', concentration: false, override: false },
+                effects: [],
+                range: { units: 'self', override: false },
+                uses: { spent: 0, recovery: [] },
+                target: {
+                  template: {
+                    contiguous: false,
+                    units: data.areaUnits,
+                    count: '',
+                    type: mappedAreaType,
+                    size: mappedAreaType ? String(data.areaSize) : '',
+                  },
+                  affects: {
+                    choice: false,
+                    count: '',
+                    type: data.affectsType,
+                    special: '',
+                  },
+                  override: false,
+                  prompt: true,
+                },
+                damage: {
+                  onSave: data.halfOnSave ? 'half' : 'none',
+                  parts: data.damageParts.map(p => ({
+                    custom: { enabled: false, formula: '' },
+                    number: p.number,
+                    denomination: p.denomination,
+                    bonus: p.bonus !== undefined ? String(p.bonus) : '',
+                    types: [p.type],
+                    scaling: { mode: '', number: 1 },
+                  })),
+                },
+                save: {
+                  ability: [data.saveAbility],
+                  dc: {
+                    calculation: '',
+                    formula: String(data.saveDC),
+                  },
                 },
               },
             },
           },
-        },
-        effects: [],
-      };
+          effects: [],
+        };
+      }
 
       // 7. Create embedded item
       const [created] = (await actor.createEmbeddedDocuments('Item', [itemData])) as any[];
@@ -8454,14 +8532,19 @@ export class FoundryDataAccess {
 
       // 5. Damage parts for the activity (all except the first — which is system.damage.base)
       const activityDamageParts = (
-        data.damageParts as Array<{ number: number; denomination: number; type: string }>
+        data.damageParts as Array<{
+          number: number;
+          denomination: number;
+          type: string;
+          bonus?: number;
+        }>
       )
         .slice(1)
         .map(p => ({
           types: [p.type],
           number: p.number,
           denomination: p.denomination,
-          bonus: '',
+          bonus: p.bonus !== undefined ? String(p.bonus) : '',
           scaling: { mode: '', number: 1 },
           custom: { enabled: false },
         }));
@@ -8475,130 +8558,209 @@ export class FoundryDataAccess {
       // 7. Conditional 2024-only fields
       const sourceRules: string = data.sourceRules ?? '2014';
       const masteryField = sourceRules === '2024' ? { mastery: '' } : {};
-      const abilityField = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
+      // Attack ability must always be written regardless of rules edition — it was previously
+      // gated behind sourceRules === '2024' alongside the genuinely-2024-only mastery/classification
+      // fields, which silently dropped it for the default 2014 case and left attack.ability as the
+      // hardcoded empty string below, falling back to a wrong default at the sheet level.
+      const abilityField = { ability: data.effectiveAbility };
       const classification = sourceRules === '2014' ? 'weapon' : '';
 
-      // 8. Build item data
-      const itemData: Record<string, any> = {
-        name: data.featureName,
-        type: 'weapon',
-        system: {
-          description: {
-            value: data.description ?? '',
-            chat: '',
-            unidentified: '',
-          },
-          source: {
-            custom: '',
-            book: data.sourceBook ?? '',
-            page: data.sourcePage ?? '',
-            license: '',
-            rules: sourceRules,
-          },
-          quantity: 1,
-          weight: { value: 0, units: 'lb' },
-          price: { value: 0, denomination: 'gp' },
-          attunement: '',
-          equipped: data.equipped !== false,
-          rarity: '',
-          identified: true,
-          activation: {
-            type: data.activationType ?? 'action',
-            value: 1,
-            condition: '',
-            override: false,
-          },
-          duration: { value: '', units: '' },
-          cover: null,
-          target: {
-            template: {
-              count: '',
-              contiguous: false,
-              type: '',
-              size: '',
-              width: '',
-              height: '',
-              units: '',
-            },
-            affects: { count: '', type: '', choice: false, special: '' },
-            prompt: true,
-            override: false,
-          },
-          range: rangeObj,
-          uses: { value: null, max: '', recovery: [], prompt: true },
-          damage: {
-            base: {
-              types: [(data.damageParts as any[])[0].type],
-              number: (data.damageParts as any[])[0].number,
-              denomination: (data.damageParts as any[])[0].denomination,
-              bonus: '',
-              scaling: { mode: '', number: 1 },
-              custom: { enabled: false },
-            },
-          },
-          type: { value: data.weaponClass ?? 'natural', baseItem: '' },
-          properties: data.properties as string[],
-          proficient: 1,
-          magicalBonus: null,
-          ...masteryField,
-          activities: {
-            [activityId]: {
-              _id: activityId,
-              type: 'attack',
-              name: '',
-              img: '',
-              sort: 0,
-              description: {},
-              activation: {
-                type: data.activationType ?? 'action',
-                value: 1,
-                condition: '',
-                override: false,
-              },
-              duration: { units: '', value: '', override: false },
-              target: {
-                template: {
-                  count: '',
-                  contiguous: false,
-                  type: '',
-                  size: '',
-                  width: '',
-                  height: '',
-                  units: '',
-                },
-                affects: { count: '', type: '', choice: false, special: '' },
-                prompt: true,
-                override: false,
-              },
-              range: { units: 'self', override: false },
-              uses: { spent: 0, max: '', recovery: [] },
-              consumption: {
-                targets: [],
-                scaling: { allowed: false, max: '' },
-                spellSlot: true,
-              },
-              attack: {
-                ability: '',
-                bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
-                critical: { threshold: null },
-                flat: false,
-                type: {
-                  value: data.attackType ?? 'melee',
-                  classification: classification,
-                },
-                ...abilityField,
-              },
-              damage: {
-                critical: { bonus: '' },
-                includeBase: true,
-                parts: activityDamageParts,
-              },
-              effects: [],
-              save: { ability: '', dc: { formula: '', calculation: '' } },
-            },
-          },
-        },
+      // 8. Build item data — Tier 2: clone a real, live weapon (Dagger/Shortbow) as a structural
+      // scaffold and override only the caller-specified fields. Falls back to full from-scratch
+      // construction (Tier 3, the previous behavior) only if that live template can't be fetched.
+      const attackTemplate = await fetchLiveTemplate(
+        'dnd-players-handbook.equipment',
+        data.attackType === 'ranged' ? 'Shortbow' : 'Dagger',
+        'attack'
+      );
+
+      const baseDamagePart = {
+        types: [(data.damageParts as any[])[0].type],
+        number: (data.damageParts as any[])[0].number,
+        denomination: (data.damageParts as any[])[0].denomination,
+        bonus:
+          (data.damageParts as any[])[0].bonus !== undefined
+            ? String((data.damageParts as any[])[0].bonus)
+            : '',
+        scaling: { mode: '', number: 1 },
+        custom: { enabled: false },
       };
+
+      let itemData: Record<string, any>;
+
+      if (attackTemplate) {
+        const activity = attackTemplate.activity;
+        activity._id = activityId;
+        activity.name = '';
+        activity.img = '';
+        activity.sort = 0;
+        activity.description = {};
+        activity.effects = [];
+        activity.activation = {
+          ...activity.activation,
+          type: data.activationType ?? 'action',
+          value: 1,
+          condition: '',
+          override: false,
+        };
+        activity.attack = {
+          ...activity.attack,
+          ability: data.effectiveAbility,
+          bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
+          type: { value: data.attackType ?? 'melee', classification },
+        };
+        activity.damage = {
+          ...activity.damage,
+          includeBase: true,
+          parts: activityDamageParts,
+        };
+
+        itemData = {
+          name: data.featureName,
+          type: 'weapon',
+          system: {
+            ...(foundry.utils as any).deepClone(attackTemplate.itemSystem),
+            description: { value: data.description ?? '', chat: '', unidentified: '' },
+            source: {
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+              rules: sourceRules,
+            },
+            quantity: 1,
+            weight: { value: 0, units: 'lb' },
+            price: { value: 0, denomination: 'gp' },
+            equipped: data.equipped !== false,
+            activation: {
+              type: data.activationType ?? 'action',
+              value: 1,
+              condition: '',
+              override: false,
+            },
+            range: rangeObj,
+            damage: { base: baseDamagePart },
+            type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+            properties: data.properties as string[],
+            proficient: 1,
+            uses: buildUsesField(data.uses),
+            ...masteryField,
+            activities: { [activityId]: activity },
+          },
+        };
+      } else {
+        // Tier 3 — no live template available, build fully from scratch.
+        itemData = {
+          name: data.featureName,
+          type: 'weapon',
+          system: {
+            description: {
+              value: data.description ?? '',
+              chat: '',
+              unidentified: '',
+            },
+            source: {
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+              rules: sourceRules,
+            },
+            quantity: 1,
+            weight: { value: 0, units: 'lb' },
+            price: { value: 0, denomination: 'gp' },
+            attunement: '',
+            equipped: data.equipped !== false,
+            rarity: '',
+            identified: true,
+            activation: {
+              type: data.activationType ?? 'action',
+              value: 1,
+              condition: '',
+              override: false,
+            },
+            duration: { value: '', units: '' },
+            cover: null,
+            target: {
+              template: {
+                count: '',
+                contiguous: false,
+                type: '',
+                size: '',
+                width: '',
+                height: '',
+                units: '',
+              },
+              affects: { count: '', type: '', choice: false, special: '' },
+              prompt: true,
+              override: false,
+            },
+            range: rangeObj,
+            uses: buildUsesField(data.uses),
+            damage: { base: baseDamagePart },
+            type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+            properties: data.properties as string[],
+            proficient: 1,
+            magicalBonus: null,
+            ...masteryField,
+            activities: {
+              [activityId]: {
+                _id: activityId,
+                type: 'attack',
+                name: '',
+                img: '',
+                sort: 0,
+                description: {},
+                activation: {
+                  type: data.activationType ?? 'action',
+                  value: 1,
+                  condition: '',
+                  override: false,
+                },
+                duration: { units: '', value: '', override: false },
+                target: {
+                  template: {
+                    count: '',
+                    contiguous: false,
+                    type: '',
+                    size: '',
+                    width: '',
+                    height: '',
+                    units: '',
+                  },
+                  affects: { count: '', type: '', choice: false, special: '' },
+                  prompt: true,
+                  override: false,
+                },
+                range: { units: 'self', override: false },
+                uses: { spent: 0, max: '', recovery: [] },
+                consumption: {
+                  targets: [],
+                  scaling: { allowed: false, max: '' },
+                  spellSlot: true,
+                },
+                attack: {
+                  bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
+                  critical: { threshold: null },
+                  flat: false,
+                  type: {
+                    value: data.attackType ?? 'melee',
+                    classification: classification,
+                  },
+                  ...abilityField,
+                },
+                damage: {
+                  critical: { bonus: '' },
+                  includeBase: true,
+                  parts: activityDamageParts,
+                },
+                effects: [],
+                save: { ability: '', dc: { formula: '', calculation: '' } },
+              },
+            },
+          },
+        };
+      }
 
       // 9. Create the item on the actor
       const created = (await actor.createEmbeddedDocuments('Item', [itemData]))[0];
@@ -8687,96 +8849,197 @@ export class FoundryDataAccess {
       // 6. Slug identifier
       const identifier = slugify(data.featureName as string);
 
-      // 7. Build item data — schema verified against dnd5e 5.1.8 Banshee Wail
-      const itemData = {
-        name: data.featureName,
-        type: 'feat',
-        img: 'systems/dnd5e/icons/svg/items/feature.svg',
-        system: {
-          description: { value: data.description ?? '', chat: '' },
-          identifier,
-          source: {
-            revision: 1,
-            rules: data.sourceRules ?? '2014',
-            custom: '',
-            book: data.sourceBook ?? '',
-            page: data.sourcePage ?? '',
-            license: '',
+      // 7. Build item data — Tier 2: compose two live templates, since no single real feat
+      // happens to have a `damage`-type activity in this compendium (2024 conversions moved
+      // Banshee's Wail — the previous hand-typed template's own source — to a `save`-type
+      // activity instead; `damage`-type activities do still exist, just on spells like Magic
+      // Missile). Use a real feat item (Fire Breath) for the outer item-level boilerplate, and
+      // Magic Missile's `damage`-type activity as the activity scaffold, overriding the
+      // spell-specific consumption/fields that don't belong on a monster feature.
+      const featShellTemplate = await fetchLiveTemplate(
+        'dnd-monster-manual.actors',
+        'Adult Red Dragon',
+        'save'
+      );
+      const damageActivityTemplate = await fetchLiveTemplate(
+        'dnd-players-handbook.spells',
+        'Magic Missile',
+        'damage'
+      );
+
+      let itemData: Record<string, any>;
+
+      if (featShellTemplate && damageActivityTemplate) {
+        const activity = damageActivityTemplate.activity;
+        activity._id = activityId;
+        activity.name = '';
+        activity.sort = 0;
+        activity.description = {};
+        activity.effects = [];
+        activity.activation = {
+          ...activity.activation,
+          type: data.activationType ?? 'action',
+          value: 1,
+          override: false,
+        };
+        // Spell-specific consumption (spell slots) doesn't apply to a monster feature.
+        activity.consumption = { scaling: { allowed: false }, spellSlot: false, targets: [] };
+        activity.range = { units: 'self', override: false };
+        activity.target = {
+          ...activity.target,
+          template: {
+            ...activity.target?.template,
+            contiguous: false,
+            units: data.areaUnits ?? 'ft',
+            count: '',
+            type: mappedAreaType,
+            size: String(data.areaSize),
+            width: '',
+            height: '',
           },
-          type: { value: 'monster', subtype: '' },
-          uses: { spent: 0, recovery: [], max: '' },
-          advancement: [],
-          crewed: false,
-          enchant: {},
-          prerequisites: { items: [], repeatable: false, level: null },
-          properties: [],
-          requirements: '',
-          activities: {
-            [activityId]: {
-              _id: activityId,
-              type: 'damage', // activity type: damage — no attack roll, no save
-              name: '',
-              sort: 0,
-              activation: {
-                type: data.activationType ?? 'action',
-                value: 1,
-                override: false,
-                // NO condition — not present in real dnd5e 5.1.8 schema
-              },
-              consumption: {
-                scaling: { allowed: false },
-                spellSlot: true, // confirmed: true in real Banshee Wail schema
-                targets: [], // no uses management in V1
-              },
-              description: {}, // empty object — confirmed from real schema
-              duration: {
-                units: 'inst',
-                concentration: false,
-                override: false,
-              },
-              effects: [],
-              range: { units: 'self', override: false }, // NO value, NO special
-              uses: { spent: 0, recovery: [] }, // NO max field
-              target: {
-                template: {
-                  contiguous: false,
-                  units: data.areaUnits ?? 'ft',
-                  count: '',
-                  type: mappedAreaType,
-                  size: String(data.areaSize),
-                  width: '',
-                  height: '',
+          affects: {
+            count: '',
+            type: data.affectsType ?? 'creature',
+            choice: false,
+            special: '',
+          },
+        };
+        activity.damage = {
+          ...activity.damage,
+          parts: (
+            data.damageParts as Array<{
+              number: number;
+              denomination: number;
+              type: string;
+              bonus?: number;
+            }>
+          ).map(p => ({
+            types: [p.type],
+            number: p.number,
+            denomination: p.denomination,
+            bonus: p.bonus !== undefined ? String(p.bonus) : '',
+            scaling: { mode: '', number: 1 },
+            custom: { enabled: false },
+          })),
+        };
+
+        itemData = {
+          name: data.featureName,
+          type: 'feat',
+          img: 'systems/dnd5e/icons/svg/items/feature.svg',
+          system: {
+            ...(foundry.utils as any).deepClone(featShellTemplate.itemSystem),
+            description: { value: data.description ?? '', chat: '' },
+            identifier,
+            source: {
+              revision: 1,
+              rules: data.sourceRules ?? '2014',
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+            },
+            type: { value: 'monster', subtype: '' },
+            uses: buildUsesField(data.uses),
+            properties: [],
+            requirements: '',
+            activities: { [activityId]: activity },
+          },
+          effects: [],
+        };
+      } else {
+        // Tier 3 — no live template available, build fully from scratch.
+        itemData = {
+          name: data.featureName,
+          type: 'feat',
+          img: 'systems/dnd5e/icons/svg/items/feature.svg',
+          system: {
+            description: { value: data.description ?? '', chat: '' },
+            identifier,
+            source: {
+              revision: 1,
+              rules: data.sourceRules ?? '2014',
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+            },
+            type: { value: 'monster', subtype: '' },
+            uses: buildUsesField(data.uses),
+            advancement: [],
+            crewed: false,
+            enchant: {},
+            prerequisites: { items: [], repeatable: false, level: null },
+            properties: [],
+            requirements: '',
+            activities: {
+              [activityId]: {
+                _id: activityId,
+                type: 'damage',
+                name: '',
+                sort: 0,
+                activation: {
+                  type: data.activationType ?? 'action',
+                  value: 1,
+                  override: false,
                 },
-                affects: {
-                  count: '',
-                  type: data.affectsType ?? 'creature',
-                  choice: false,
-                  special: '',
+                consumption: {
+                  scaling: { allowed: false },
+                  spellSlot: true,
+                  targets: [],
                 },
-                override: false,
-                prompt: true,
+                description: {},
+                duration: {
+                  units: 'inst',
+                  concentration: false,
+                  override: false,
+                },
+                effects: [],
+                range: { units: 'self', override: false },
+                uses: { spent: 0, recovery: [] },
+                target: {
+                  template: {
+                    contiguous: false,
+                    units: data.areaUnits ?? 'ft',
+                    count: '',
+                    type: mappedAreaType,
+                    size: String(data.areaSize),
+                    width: '',
+                    height: '',
+                  },
+                  affects: {
+                    count: '',
+                    type: data.affectsType ?? 'creature',
+                    choice: false,
+                    special: '',
+                  },
+                  override: false,
+                  prompt: true,
+                },
+                damage: {
+                  critical: { allow: false },
+                  parts: (
+                    data.damageParts as Array<{
+                      number: number;
+                      denomination: number;
+                      type: string;
+                      bonus?: number;
+                    }>
+                  ).map(p => ({
+                    types: [p.type],
+                    number: p.number,
+                    denomination: p.denomination,
+                    bonus: p.bonus !== undefined ? String(p.bonus) : '',
+                    scaling: { mode: '', number: 1 },
+                    custom: { enabled: false },
+                  })),
+                },
               },
-              damage: {
-                critical: { allow: false }, // only this key — no bonus, no dice
-                parts: (
-                  data.damageParts as Array<{ number: number; denomination: number; type: string }>
-                ).map(p => ({
-                  types: [p.type],
-                  number: p.number,
-                  denomination: p.denomination,
-                  bonus: '',
-                  scaling: { mode: '', number: 1 }, // mode: '' required — from real schema
-                  custom: { enabled: false }, // NO formula field
-                })),
-                // NO onSave — damage activity has no save concept
-              },
-              // NO save block
-              // NO attack block
             },
           },
-        },
-        effects: [],
-      };
+          effects: [],
+        };
+      }
 
       // 7. Create embedded item
       const [created] = (await actor.createEmbeddedDocuments('Item', [itemData])) as any[];
@@ -8860,7 +9123,7 @@ export class FoundryDataAccess {
             license: '',
           },
           type: { value: 'monster', subtype: '' },
-          uses: { spent: 0, recovery: [], max: '' },
+          uses: buildUsesField(data.uses),
           advancement: [],
           crewed: false,
           enchant: {},
@@ -8954,26 +9217,36 @@ export class FoundryDataAccess {
 
       // 5. Attack activity damage parts: damageParts[1+] (base is in system.damage.base)
       const activityDamageParts = (
-        data.damageParts as Array<{ number: number; denomination: number; type: string }>
+        data.damageParts as Array<{
+          number: number;
+          denomination: number;
+          type: string;
+          bonus?: number;
+        }>
       )
         .slice(1)
         .map(p => ({
           types: [p.type],
           number: p.number,
           denomination: p.denomination,
-          bonus: '',
+          bonus: p.bonus !== undefined ? String(p.bonus) : '',
           scaling: { mode: '', number: 1 },
           custom: { enabled: false },
         }));
 
       // 6. Save activity damage parts: ALL saveDamageParts (no base — independent)
       const saveActivityDamageParts = (
-        data.saveDamageParts as Array<{ number: number; denomination: number; type: string }>
+        data.saveDamageParts as Array<{
+          number: number;
+          denomination: number;
+          type: string;
+          bonus?: number;
+        }>
       ).map(p => ({
         types: [p.type],
         number: p.number,
         denomination: p.denomination,
-        bonus: '',
+        bonus: p.bonus !== undefined ? String(p.bonus) : '',
         scaling: { mode: '', number: 1 },
         custom: { enabled: false },
       }));
@@ -8987,167 +9260,286 @@ export class FoundryDataAccess {
       // 8. Conditional 2024-only fields (same rules as Tipo A)
       const sourceRules: string = data.sourceRules ?? '2014';
       const masteryField = sourceRules === '2024' ? { mastery: '' } : {};
-      const abilityField = sourceRules === '2024' ? { ability: data.effectiveAbility } : {};
+      // Attack ability must always be written regardless of rules edition — it was previously
+      // gated behind sourceRules === '2024' alongside the genuinely-2024-only mastery/classification
+      // fields, which silently dropped it for the default 2014 case and left attack.ability as the
+      // hardcoded empty string below, falling back to a wrong default at the sheet level.
+      const abilityField = { ability: data.effectiveAbility };
       const classification = sourceRules === '2014' ? 'weapon' : '';
 
-      // 9. Build item data
-      const itemData: Record<string, any> = {
-        name: data.featureName,
-        type: 'weapon',
-        system: {
-          description: {
-            value: data.description ?? '',
-            chat: '',
-            unidentified: '',
-          },
-          source: {
-            custom: '',
-            book: data.sourceBook ?? '',
-            page: data.sourcePage ?? '',
-            license: '',
-            rules: sourceRules,
-          },
-          quantity: 1,
-          weight: { value: 0, units: 'lb' },
-          price: { value: 0, denomination: 'gp' },
-          attunement: '',
-          equipped: data.equipped !== false,
-          rarity: '',
-          identified: true,
-          activation: {
-            type: data.activationType ?? 'action',
-            value: 1,
-            condition: '',
-            override: false,
-          },
-          duration: { value: '', units: '' },
-          cover: null,
-          target: {
-            template: {
-              count: '',
-              contiguous: false,
-              type: '',
-              size: '',
-              width: '',
-              height: '',
-              units: '',
-            },
-            affects: { count: '', type: '', choice: false, special: '' },
-            prompt: true,
-            override: false,
-          },
-          range: rangeObj,
-          uses: { value: null, max: '', recovery: [], prompt: true },
-          damage: {
-            base: {
-              types: [(data.damageParts as any[])[0].type],
-              number: (data.damageParts as any[])[0].number,
-              denomination: (data.damageParts as any[])[0].denomination,
-              bonus: '',
-              scaling: { mode: '', number: 1 },
-              custom: { enabled: false },
-            },
-          },
-          type: { value: data.weaponClass ?? 'natural', baseItem: '' },
-          properties: data.properties as string[],
-          proficient: 1,
-          magicalBonus: null,
-          ...masteryField,
-          activities: {
-            // ── Activity 1: attack (sort 0) ───────────────────────────────
-            [attackActivityId]: {
-              _id: attackActivityId,
-              type: 'attack',
-              name: '',
-              img: '',
-              sort: 0,
-              description: {},
-              activation: {
-                type: data.activationType ?? 'action',
-                value: 1,
-                condition: '',
-                override: false,
-              },
-              duration: { units: '', value: '', override: false },
-              target: {
-                template: {
-                  count: '',
-                  contiguous: false,
-                  type: '',
-                  size: '',
-                  width: '',
-                  height: '',
-                  units: '',
-                },
-                affects: { count: '', type: '', choice: false, special: '' },
-                prompt: true,
-                override: false,
-              },
-              range: { units: 'self', override: false },
-              uses: { spent: 0, max: '', recovery: [] },
-              consumption: { targets: [], scaling: { allowed: false, max: '' }, spellSlot: true },
-              attack: {
-                ability: '',
-                bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
-                critical: { threshold: null },
-                flat: false,
-                type: { value: data.attackType ?? 'melee', classification },
-                ...abilityField,
-              },
-              damage: {
-                critical: { bonus: '' },
-                includeBase: true,
-                parts: activityDamageParts,
-              },
-              effects: [],
-              save: { ability: '', dc: { formula: '', calculation: '' } },
-            },
+      // 9. Build item data — Tier 2: clone a real weapon (attack activity) and a real save-based
+      // monster feature (save activity) as structural scaffolds, override only caller-specified
+      // fields. Falls back to full from-scratch construction if either live template is missing.
+      const attackTemplate = await fetchLiveTemplate(
+        'dnd-players-handbook.equipment',
+        data.attackType === 'ranged' ? 'Shortbow' : 'Dagger',
+        'attack'
+      );
+      const saveTemplate = await fetchLiveTemplate(
+        'dnd-monster-manual.actors',
+        'Adult Red Dragon',
+        'save'
+      );
 
-            // ── Activity 2: save (sort 1) ─────────────────────────────────
-            [saveActivityId]: {
-              _id: saveActivityId,
-              type: 'save',
-              name: '',
-              sort: 1,
-              description: {}, // {} — not { chatFlavor: '' } (real schema confirmed)
-              activation: {
-                type: data.activationType ?? 'action',
-                value: 1,
-                override: false,
-                // NO condition — per real schema
+      const baseDamagePart = {
+        types: [(data.damageParts as any[])[0].type],
+        number: (data.damageParts as any[])[0].number,
+        denomination: (data.damageParts as any[])[0].denomination,
+        bonus:
+          (data.damageParts as any[])[0].bonus !== undefined
+            ? String((data.damageParts as any[])[0].bonus)
+            : '',
+        scaling: { mode: '', number: 1 },
+        custom: { enabled: false },
+      };
+
+      let itemData: Record<string, any>;
+
+      if (attackTemplate && saveTemplate) {
+        const attackActivity = attackTemplate.activity;
+        attackActivity._id = attackActivityId;
+        attackActivity.name = '';
+        attackActivity.img = '';
+        attackActivity.sort = 0;
+        attackActivity.description = {};
+        attackActivity.effects = [];
+        attackActivity.activation = {
+          ...attackActivity.activation,
+          type: data.activationType ?? 'action',
+          value: 1,
+          condition: '',
+          override: false,
+        };
+        attackActivity.attack = {
+          ...attackActivity.attack,
+          ability: data.effectiveAbility,
+          bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
+          type: { value: data.attackType ?? 'melee', classification },
+        };
+        attackActivity.damage = {
+          ...attackActivity.damage,
+          includeBase: true,
+          parts: activityDamageParts,
+        };
+
+        const saveActivity = saveTemplate.activity;
+        saveActivity._id = saveActivityId;
+        saveActivity.name = '';
+        saveActivity.img = '';
+        saveActivity.sort = 1;
+        saveActivity.description = {};
+        saveActivity.effects = [];
+        saveActivity.activation = {
+          ...saveActivity.activation,
+          type: data.activationType ?? 'action',
+          value: 1,
+          override: false,
+        };
+        saveActivity.target = {
+          ...saveActivity.target,
+          affects: { count: '1', type: 'creature', choice: false, special: '' },
+        };
+        saveActivity.damage = {
+          ...saveActivity.damage,
+          onSave: data.saveOnSave ?? 'none',
+          parts: saveActivityDamageParts,
+        };
+        saveActivity.save = {
+          ...saveActivity.save,
+          ability: [data.saveAbility],
+          dc: { calculation: '', formula: String(data.saveDC) },
+        };
+
+        itemData = {
+          name: data.featureName,
+          type: 'weapon',
+          system: {
+            ...(foundry.utils as any).deepClone(attackTemplate.itemSystem),
+            description: { value: data.description ?? '', chat: '', unidentified: '' },
+            source: {
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+              rules: sourceRules,
+            },
+            quantity: 1,
+            weight: { value: 0, units: 'lb' },
+            price: { value: 0, denomination: 'gp' },
+            equipped: data.equipped !== false,
+            activation: {
+              type: data.activationType ?? 'action',
+              value: 1,
+              condition: '',
+              override: false,
+            },
+            range: rangeObj,
+            damage: { base: baseDamagePart },
+            type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+            properties: data.properties as string[],
+            proficient: 1,
+            uses: buildUsesField(data.uses),
+            ...masteryField,
+            activities: {
+              [attackActivityId]: attackActivity,
+              [saveActivityId]: saveActivity,
+            },
+          },
+        };
+      } else {
+        // Tier 3 — no live template available, build fully from scratch.
+        itemData = {
+          name: data.featureName,
+          type: 'weapon',
+          system: {
+            description: {
+              value: data.description ?? '',
+              chat: '',
+              unidentified: '',
+            },
+            source: {
+              custom: '',
+              book: data.sourceBook ?? '',
+              page: data.sourcePage ?? '',
+              license: '',
+              rules: sourceRules,
+            },
+            quantity: 1,
+            weight: { value: 0, units: 'lb' },
+            price: { value: 0, denomination: 'gp' },
+            attunement: '',
+            equipped: data.equipped !== false,
+            rarity: '',
+            identified: true,
+            activation: {
+              type: data.activationType ?? 'action',
+              value: 1,
+              condition: '',
+              override: false,
+            },
+            duration: { value: '', units: '' },
+            cover: null,
+            target: {
+              template: {
+                count: '',
+                contiguous: false,
+                type: '',
+                size: '',
+                width: '',
+                height: '',
+                units: '',
               },
-              duration: { units: 'inst', concentration: false, override: false },
-              effects: [],
-              range: { units: 'self', override: false },
-              uses: { spent: 0, recovery: [] }, // NO max
-              consumption: { scaling: { allowed: false }, spellSlot: true, targets: [] },
-              target: {
-                template: {
-                  count: '',
-                  contiguous: false,
-                  type: '',
-                  size: '',
-                  width: '',
-                  height: '',
-                  units: '',
+              affects: { count: '', type: '', choice: false, special: '' },
+              prompt: true,
+              override: false,
+            },
+            range: rangeObj,
+            uses: buildUsesField(data.uses),
+            damage: { base: baseDamagePart },
+            type: { value: data.weaponClass ?? 'natural', baseItem: '' },
+            properties: data.properties as string[],
+            proficient: 1,
+            magicalBonus: null,
+            ...masteryField,
+            activities: {
+              // ── Activity 1: attack (sort 0) ───────────────────────────────
+              [attackActivityId]: {
+                _id: attackActivityId,
+                type: 'attack',
+                name: '',
+                img: '',
+                sort: 0,
+                description: {},
+                activation: {
+                  type: data.activationType ?? 'action',
+                  value: 1,
+                  condition: '',
+                  override: false,
                 },
-                affects: { count: '1', type: 'creature', choice: false, special: '' },
-                override: false,
-                prompt: true,
+                duration: { units: '', value: '', override: false },
+                target: {
+                  template: {
+                    count: '',
+                    contiguous: false,
+                    type: '',
+                    size: '',
+                    width: '',
+                    height: '',
+                    units: '',
+                  },
+                  affects: { count: '', type: '', choice: false, special: '' },
+                  prompt: true,
+                  override: false,
+                },
+                range: { units: 'self', override: false },
+                uses: { spent: 0, max: '', recovery: [] },
+                consumption: {
+                  targets: [],
+                  scaling: { allowed: false, max: '' },
+                  spellSlot: true,
+                },
+                attack: {
+                  bonus: data.attackBonus > 0 ? String(data.attackBonus) : '',
+                  critical: { threshold: null },
+                  flat: false,
+                  type: { value: data.attackType ?? 'melee', classification },
+                  ...abilityField,
+                },
+                damage: {
+                  critical: { bonus: '' },
+                  includeBase: true,
+                  parts: activityDamageParts,
+                },
+                effects: [],
+                save: { ability: '', dc: { formula: '', calculation: '' } },
               },
-              damage: {
-                onSave: data.saveOnSave ?? 'none',
-                parts: saveActivityDamageParts,
-                // NO includeBase — save damage is independent from weapon base damage
-              },
-              save: {
-                ability: [data.saveAbility],
-                dc: { calculation: '', formula: String(data.saveDC) },
+
+              // ── Activity 2: save (sort 1) ─────────────────────────────────
+              [saveActivityId]: {
+                _id: saveActivityId,
+                type: 'save',
+                name: '',
+                sort: 1,
+                description: {}, // {} — not { chatFlavor: '' } (real schema confirmed)
+                activation: {
+                  type: data.activationType ?? 'action',
+                  value: 1,
+                  override: false,
+                  // NO condition — per real schema
+                },
+                duration: { units: 'inst', concentration: false, override: false },
+                effects: [],
+                range: { units: 'self', override: false },
+                uses: { spent: 0, recovery: [] }, // NO max
+                consumption: { scaling: { allowed: false }, spellSlot: true, targets: [] },
+                target: {
+                  template: {
+                    count: '',
+                    contiguous: false,
+                    type: '',
+                    size: '',
+                    width: '',
+                    height: '',
+                    units: '',
+                  },
+                  affects: { count: '1', type: 'creature', choice: false, special: '' },
+                  override: false,
+                  prompt: true,
+                },
+                damage: {
+                  onSave: data.saveOnSave ?? 'none',
+                  parts: saveActivityDamageParts,
+                  // NO includeBase — save damage is independent from weapon base damage
+                },
+                save: {
+                  ability: [data.saveAbility],
+                  dc: { calculation: '', formula: String(data.saveDC) },
+                },
               },
             },
           },
-        },
-      };
+        };
+      }
 
       // 10. Create the item on the actor
       const created = (await actor.createEmbeddedDocuments('Item', [itemData]))[0];
@@ -10072,15 +10464,109 @@ function npcFormatCR(value: number): string {
 
 function npcBuildSkillsBlock(
   skills: Array<{ skill: string; proficiency: string }>
-): Record<string, { value: number }> {
-  const result: Record<string, { value: number }> = {};
+): Record<string, { value: number; ability?: string }> {
+  const result: Record<string, { value: number; ability?: string }> = {};
+  // Read governing ability live from CONFIG.DND5E.skills — the currently-loaded system/rules
+  // config (full core books, not a hardcoded SRD snapshot) — rather than a static map, so this
+  // stays correct even if the system's skill-ability associations ever change.
+  const dnd5eConfig: any = (globalThis as any).CONFIG?.DND5E;
   for (const { skill, proficiency } of skills) {
     const key = NPC_SKILL_MAP[skill];
     if (key) {
-      result[key] = { value: proficiency === 'expert' ? 2 : 1 };
+      const entry: { value: number; ability?: string } = {
+        value: proficiency === 'expert' ? 2 : 1,
+      };
+      const liveAbility: string | undefined = dnd5eConfig?.skills?.[key]?.ability;
+      if (liveAbility) entry.ability = liveAbility;
+      result[key] = entry;
     }
   }
   return result;
+}
+
+// =============================================================================
+// Live compendium templates — Tier 2 of the build strategy for hand-built features.
+//
+// Tom's instruction (2026-09-05): if a feature is standard, take it straight from what already
+// exists; if it's custom, build it on top of the closest real thing available; only build fully
+// from scratch if there's genuinely no reasonable template. Hand-typing an entire Activity's data
+// shape from a remembered/hardcoded snapshot (the previous approach — one such snapshot was
+// explicitly "verified against dnd5e 5.1.8 Banshee Wail" per a comment left in this file) goes
+// stale as the system/module versions move on: confirmed live on 2026-09-05 that the *current*
+// (5.3.3, 2024-converted) Banshee's "Deathly Wail" is now a `save`-type activity, not the `damage`
+// type the old hardcoded template assumed — the exact kind of drift this approach exists to avoid.
+//
+// This fetches a real, live item from an installed compendium and returns its full item-level
+// system data plus one embedded activity of the requested type, to use as a structural scaffold —
+// callers override only the specific fields that make the feature custom (ability, damage, range,
+// etc.) and keep everything else (module-added boilerplate — Midi-QOL fields, region behavior,
+// whatever a future system update adds — none of which this file has to know about or keep in
+// sync by hand). Returns null if the compendium/item/activity-of-that-type isn't found, so callers
+// fall back to full from-scratch construction (Tier 3) rather than fail outright.
+// =============================================================================
+
+async function fetchLiveTemplate(
+  packId: string,
+  itemName: string,
+  activityType: string
+): Promise<{ itemSystem: Record<string, any>; activity: Record<string, any> } | null> {
+  try {
+    const pack = (game as any).packs?.get(packId);
+    if (!pack) return null;
+    const index = await pack.getIndex();
+    const entry = index.find((e: any) => e.name === itemName);
+    if (!entry) return null;
+    const doc = await pack.getDocument(entry._id);
+    const raw = doc.toObject();
+    const activityEntry = Object.values(raw.system?.activities ?? {}).find(
+      (a: any) => a.type === activityType
+    ) as Record<string, any> | undefined;
+    if (!activityEntry) return null;
+    return {
+      itemSystem: raw.system,
+      activity: (foundry.utils as any).deepClone(activityEntry),
+    };
+  } catch (err) {
+    console.warn(
+      `[${MODULE_ID}] fetchLiveTemplate failed for ${packId}/${itemName} (${activityType}) — falling back to from-scratch construction`,
+      err
+    );
+    return null;
+  }
+}
+
+// =============================================================================
+// Limited-use tracker — item-level `system.uses`, confirmed live (2026-09-05) against real
+// compendium examples rather than guessed: Adult Red Dragon's "Fire Breath" stores its
+// Recharge 5-6 as `{max:"1", recovery:[{period:"recharge", type:"recoverAll", formula:"5"}]}`
+// at the ITEM level (its own Activity's `uses` field stays empty) — confirmed the same shape
+// recurs across other monsters' recharge abilities (Vampire's Charm, Marilith's Teleport, Pit
+// Fiend's Hellfire Spellcasting). Per-day abilities (Archmage's Misty Step/Protective Magic,
+// Githyanki Knight's Misty Step) use `{max:"N", recovery:[{period:"day", type:"recoverAll"}]}`.
+// Note "recharge" as a period value doesn't appear in CONFIG.DND5E.limitedUsePeriods at all
+// (only day/dawn/dusk/lr/sr/turn/turnStart/turnEnd/initiative are listed there) — it's handled
+// as a special case elsewhere in the system, so this was only discoverable by reading real
+// stored data, not by inspecting the config schema.
+// =============================================================================
+
+function buildUsesField(uses?: { max: number; per: 'day' | 'recharge'; rechargeOn?: number }): {
+  max: string;
+  recovery: any[];
+  spent: number;
+} {
+  if (!uses) return { max: '', recovery: [], spent: 0 };
+  if (uses.per === 'recharge') {
+    return {
+      max: String(uses.max),
+      recovery: [{ period: 'recharge', type: 'recoverAll', formula: String(uses.rechargeOn ?? 6) }],
+      spent: 0,
+    };
+  }
+  return {
+    max: String(uses.max),
+    recovery: [{ period: 'day', type: 'recoverAll' }],
+    spent: 0,
+  };
 }
 
 // =============================================================================

--- a/packages/mcp-server/src/tools/dnd5e/add-feature.ts
+++ b/packages/mcp-server/src/tools/dnd5e/add-feature.ts
@@ -67,7 +67,55 @@ const damagePart = z.object({
       message: 'denomination must be one of 4, 6, 8, 10, 12, 20, 100',
     }),
   type: z.string().min(1, 'damage type cannot be empty'),
+  bonus: z.number().int().optional(),
 });
+
+const usesTracker = z
+  .object({
+    max: z.number().int().min(1),
+    per: z.enum(['day', 'recharge']),
+    rechargeOn: z.number().int().min(2).max(6).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.per === 'recharge' && data.rechargeOn === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['rechargeOn'],
+        message: 'rechargeOn is required when per is "recharge" (e.g. 5 for "Recharge 5-6")',
+      });
+    }
+  });
+
+const usesTrackerSchema = {
+  type: 'object',
+  description:
+    'Limited-use tracker for this feature (e.g. "3/Day" or "Recharge 5-6"). Omit entirely for ' +
+    'unlimited use. Used by: passive, save, attack, attack-with-save, aura.',
+  properties: {
+    max: {
+      type: 'number',
+      description:
+        'Number of uses before it needs to recover (e.g. 3 for "3/Day", 1 for a recharge ability).',
+      minimum: 1,
+    },
+    per: {
+      type: 'string',
+      enum: ['day', 'recharge'],
+      description:
+        '"day" — recovers to max uses once per day (long rest). ' +
+        '"recharge" — recovers on a d6 roll at the start of each turn, using rechargeOn as the threshold.',
+    },
+    rechargeOn: {
+      type: 'number',
+      description:
+        'Minimum d6 roll needed to recharge (e.g. 5 for "Recharge 5-6", 6 for "Recharge 6"). ' +
+        'Required when per is "recharge".',
+      minimum: 2,
+      maximum: 6,
+    },
+  },
+  required: ['max', 'per'],
+};
 
 const damagePartSchema = {
   type: 'object',
@@ -75,6 +123,11 @@ const damagePartSchema = {
     number: { type: 'number', description: 'Number of dice (e.g. 4)', minimum: 1 },
     denomination: { type: 'number', description: 'Die size', enum: [4, 6, 8, 10, 12, 20, 100] },
     type: { type: 'string', description: 'Damage type (e.g. "fire", "slashing", "cold")' },
+    bonus: {
+      type: 'number',
+      description:
+        'Flat damage bonus added on top of the dice for this part (e.g. a +2 magic weapon on top of the ability modifier). Optional.',
+    },
   },
   required: ['number', 'denomination', 'type'],
 };
@@ -112,27 +165,27 @@ export class DnD5eAddFeatureTool {
           'Set featureType to select the mode — each mode uses only its own parameters:\n\n' +
           '• passive — descriptive trait, no roll (Multiattack, Magic Resistance, Spider Climb).\n' +
           '  Required: actorIdentifier, featureName\n' +
-          '  Optional: description, sourceRules, sourceBook, sourcePage\n\n' +
+          '  Optional: description, uses, sourceRules, sourceBook, sourcePage\n\n' +
           '• save — feature that forces a saving throw (breath weapon, cone of cold, etc.).\n' +
           '  Required: actorIdentifier, featureName, saveAbility, saveDC, damageParts\n' +
-          '  Optional: description, activationType, halfOnSave, areaType, areaSize ' +
+          '  Optional: description, activationType, uses, halfOnSave, areaType, areaSize ' +
           '(required if areaType set), areaUnits, affectsType\n\n' +
           '• attack — weapon attack with to-hit roll (Claw, Bite, Scimitar, etc.).\n' +
           '  Required: actorIdentifier, featureName, attackType, damageParts\n' +
           '  Required when ranged: rangeFt\n' +
           '  Optional: description, activationType, weaponClass, abilityModifier, attackBonus, ' +
-          'proficient, equipped, reachFt, longRangeFt, properties, sourceRules, sourceBook, sourcePage\n\n' +
+          'proficient, equipped, reachFt, longRangeFt, properties, uses, sourceRules, sourceBook, sourcePage\n\n' +
           '• attack-with-save — attack roll on hit + forced save for bonus damage ' +
           '(e.g. Stinger: piercing hit + CON save or poison damage).\n' +
           '  Required: actorIdentifier, featureName, attackType, damageParts, ' +
           'saveAbility, saveDC, saveDamageParts\n' +
           '  Required when ranged: rangeFt\n' +
           '  Optional: description, activationType, weaponClass, abilityModifier, attackBonus, ' +
-          'proficient, equipped, reachFt, longRangeFt, properties, saveOnSave, ' +
+          'proficient, equipped, reachFt, longRangeFt, properties, saveOnSave, uses, ' +
           'sourceRules, sourceBook, sourcePage\n\n' +
           '• aura — automatic-damage area, no to-hit, no save (all creatures in range take damage).\n' +
           '  Required: actorIdentifier, featureName, damageParts, areaType, areaSize\n' +
-          '  Optional: description, activationType, areaUnits, affectsType, ' +
+          '  Optional: description, activationType, areaUnits, affectsType, uses, ' +
           'sourceRules, sourceBook, sourcePage\n\n' +
           '• spellcasting — configure spell slots and casting ability. ' +
           'Run this BEFORE featureType "spells".\n' +
@@ -188,6 +241,7 @@ export class DnD5eAddFeatureTool {
                 'Action economy type. Used by: save, attack, attack-with-save, aura. Default: "action".',
               default: 'action',
             },
+            uses: usesTrackerSchema,
 
             // ── Damage ────────────────────────────────────────────────────────
             damageParts: {
@@ -473,6 +527,7 @@ export class DnD5eAddFeatureTool {
       actorIdentifier: z.string().min(1, 'actorIdentifier cannot be empty'),
       featureName: z.string().min(1, 'featureName cannot be empty'),
       description: z.string().default(''),
+      uses: usesTracker.optional(),
       sourceRules: z.enum(['2014', '2024']).default('2014'),
       sourceBook: z.string().default(''),
       sourcePage: z.string().default(''),
@@ -551,6 +606,7 @@ export class DnD5eAddFeatureTool {
         areaSize: z.number().positive().optional(),
         areaUnits: z.enum(['ft', 'm']).default('ft'),
         affectsType: z.enum(['creature', 'object', 'space', '']).default('creature'),
+        uses: usesTracker.optional(),
       })
       .superRefine((data, ctx) => {
         if (data.areaType !== '' && data.areaSize === undefined) {
@@ -650,6 +706,7 @@ export class DnD5eAddFeatureTool {
         longRangeFt: z.number().int().min(1).optional(),
         damageParts: z.array(damagePart).min(1, 'at least one damage part is required'),
         properties: z.array(z.string()).default([]),
+        uses: usesTracker.optional(),
         sourceRules: z.enum(['2014', '2024']).default('2014'),
         sourceBook: z.string().default(''),
         sourcePage: z.string().default(''),
@@ -791,6 +848,7 @@ export class DnD5eAddFeatureTool {
         saveDC: z.number().int().min(1).max(30),
         saveDamageParts: z.array(damagePart).min(1, 'at least one save damage part is required'),
         saveOnSave: z.enum(['half', 'none']).default('none'),
+        uses: usesTracker.optional(),
         sourceRules: z.enum(['2014', '2024']).default('2014'),
         sourceBook: z.string().default(''),
         sourcePage: z.string().default(''),
@@ -915,6 +973,7 @@ export class DnD5eAddFeatureTool {
       areaSize: z.number().positive('areaSize must be greater than 0'),
       areaUnits: z.enum(['ft', 'm']).default('ft'),
       affectsType: z.enum(['creature', 'object', 'space', '']).default('creature'),
+      uses: usesTracker.optional(),
       sourceRules: z.enum(['2014', '2024']).default('2014'),
       sourceBook: z.string().default(''),
       sourcePage: z.string().default(''),


### PR DESCRIPTION
…missing damage bonus, no uses tracker

dnd5e-create-npc and dnd5e-add-feature were producing actors/items with several silently-wrong fields — none of them threw errors, so they only surfaced by reading the raw stored document back and comparing against live compendium data.

## 1. Skill governing ability always defaulted wrong npcBuildSkillsBlock only ever wrote `{value: N}` per skill, never `ability` — every skill fell back to whatever the dnd5e schema defaults to (effectively DEX) regardless of which skill it actually was (e.g. Perception/Survival came out DEX-governed instead of WIS). Fixed to read the real governing ability live from CONFIG.DND5E.skills, rather than hardcoding a remembered map — stays correct if the system's own associations ever change.

## 2. Attack ability didn't propagate for 2014-rules attacks `effectiveAbility` was computed correctly at the tool-schema layer the whole time, but data-access.ts only wrote it to the Activity's `attack.ability` field when `sourceRules === '2024'` — bundled in with the genuinely-2024-only `mastery`/`classification` fields. For the default 2014 case it was silently dropped, leaving the hardcoded empty string in place and falling back to a different ability at the sheet level. Removed the incorrect gating; ability is now always written regardless of rules edition.

## 3. No flat damage bonus field
`damageParts` had no way to add a flat bonus on top of the dice (e.g. a +2 weapon on top of the ability modifier) — attack/attack-with-save/ save all hardcoded `bonus: ''`. Added an optional `bonus` field to the shared damagePart schema and wired it through all 7 places that were hardcoding it away.

## 4. Hand-typed Activity schemas had drifted from the live system Both `addSaveFeatureToActor` and `addAuraToActor` carried comments saying their Activity shape was "verified against dnd5e 5.1.8" real output — a one-time manual snapshot frozen into the code. Confirmed the drift is real, not theoretical: the *current* (5.3.3, 2024-converted) Banshee's "Deathly Wail" — the exact feature the aura template was modeled on — is now a `save`-type activity, not the `damage` type the old hardcoded template assumed.

Replaced all four Activity-bearing handlers (addAttackToActor, addAttackWithSaveToActor, addSaveFeatureToActor, addAuraToActor) with a tiered strategy: fetch a real, live compendium item of the appropriate shape (PHB Dagger/Shortbow for attacks, MM Adult Red Dragon's Fire Breath for saves, PHB Magic Missile's damage-type activity composed with a real feat shell for auras — 2024 has no feat with a bare `damage`-type activity to copy directly) and override only the caller-specified fields, falling back to the previous from-scratch construction only if the live template can't be found. This closes the whole class of bug at the root: any future system update automatically flows through instead of needing another manual snapshot.

## 5. No limited-use tracker
There was no way to express "3/Day" or "Recharge 5-6" — only free text in the description, no enforced limit. Added a `uses` parameter (`{max, per: 'day'|'recharge', rechargeOn?}`) to all five feature schemas, plus a shared `buildUsesField()` helper. Confirmed live before writing any code that uses/recovery data lives at the ITEM level, not on the Activity (Fire Breath's own Activity `uses` stays empty; its Recharge 5-6 is entirely on the item), and that `"recharge"` as a recovery period doesn't appear anywhere in
CONFIG.DND5E.limitedUsePeriods despite being real and functional — only discoverable by reading actual stored data across several real monsters (Fire Breath, Vampire's Charm, Marilith's Teleport, Pit Fiend's Hellfire Spellcasting all use the identical recharge shape).

Also fixed a second stale-shape bug found while wiring this in: the from-scratch fallback for attack/attack-with-save weapon items used `{value, max, recovery, prompt}` for uses, but real charged weapons (Frost Brand Scimitar, Nine Lives Stealer Shortsword) confirm weapon- and feat-type items share the identical `{max, recovery, spent}` shape.

## Verification
No guessing at any point — every schema shape above was confirmed live against the actual installed 2024 core-book compendiums before being used as a template, not assumed from memory or older documentation. Each fix was verified end-to-end against a disposable test actor: raw document data read back via the Foundry client directly (not this project's own read tools — get-character-entity does not serialize dnd5e Activities correctly, returning `{}` for genuinely-populated activity collections, likely from being built PF2e-first), confirming correct skill modifiers, to-hit bonuses, damage values, and uses/ recovery data in each case. Test actors deleted after each check.

typecheck, format:check pass on both changed packages. lint shows the same 51 pre-existing errors as unmodified master (confirmed via git stash comparison) — 0 new errors introduced; additional warnings are consistent with this codebase's existing `any`-heavy style in these two files, not something this fix set out to refactor.

🤖 Investigated and fixed with Claude Code (https://claude.com/claude-code).