### PR TITLE
Scene music tools + playlist management/playback (Closes #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+### New Features
+
+- **Scene music tools** (Closes #93)
+  - `get-scene-music`: read a scene's `playlist` / `playlistSound` binding (ids + names)
+  - `update-scene-music`: set or clear the binding by id or unique name; writes through `scene.update()` with the core `playlist` / `playlistSound` fields so it syncs to connected clients without a reload. Validates both ids exist before writing; a sound cannot be bound without its parent playlist.
+  - `list-playlists`: playlists with all sounds (id, name, path) for name-to-id resolution
+
+- **Playlist management + playback tools**
+  - `manage-playlists` (`create` | `update` | `delete` | `describe`): playlist CRUD on any system; `create` accepts sounds inline (`path` required, plus `name`, `volume`, `repeat`, `fade`); `update` patches playlist fields and/or individual sounds matched by exact id or unique path/name within the playlist; `describe` with no identifier lists all playlists compactly, with an identifier returns the full document including every sound
+  - `control-playlist`: `play` (playAll), `stop` (stopAll), `cycle-mode` (sequential -> shuffle -> soundboard), plus per-sound `play-sound` / `stop-sound` - all through the client Playlist API so the server and every connected client stay in sync
+
+Both tools are GM-only (same silent GM validation as every other bridge tool) and system-agnostic.
+
 ## v0.8.3 (2026-06-11)
 
 ### New Features

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-mcp-bridge",
   "title": "Foundry MCP Bridge",
   "description": "Connect Foundry VTT to AI models through MCP protocol. Enable AI-powered actor creation, intelligent compendium search, campaign analysis, and interactive dice roll coordination. Supports Claude, local LLMs, and future AI models with comprehensive GM-only security.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "compatibility": {
     "minimum": "13",
     "verified": "14",

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -7300,6 +7300,405 @@ export class FoundryDataAccess {
     }
   }
 
+  // ===== SCENE MUSIC BINDINGS =====
+
+  /**
+   * Find a scene by id or exact name (case-insensitive). Shared by the
+   * scene music methods; mirrors the switchScene lookup.
+   */
+  private findSceneByIdentifier(identifier: string): any {
+    const scenes = game.scenes?.contents || [];
+    const target = scenes.find(
+      (scene: any) =>
+        scene.id === identifier || scene.name.toLowerCase() === identifier.toLowerCase()
+    );
+    if (!target) {
+      throw new Error(`Scene not found: "${identifier}"`);
+    }
+    return target;
+  }
+
+  /**
+   * Resolve a playlist/sound identifier to its document. Accepts an exact id,
+   * an exact name, or a unique case-insensitive name substring. Returns the
+   * document, or null for a null/empty identifier (intentional clear).
+   */
+  private findMusicDoc(
+    collection: any,
+    identifier: string | null | undefined,
+    kind: 'playlist' | 'playlistSound'
+  ): any | null {
+    if (identifier === null || identifier === undefined || identifier === '') {
+      return null;
+    }
+    if (typeof identifier !== 'string') {
+      throw new Error(`${kind} identifier must be a string or null`);
+    }
+    const docs = collection?.contents || collection || [];
+    const idMatch = docs.find((d: any) => d.id === identifier);
+    if (idMatch) return idMatch;
+    const exact = docs.find((d: any) => (d.name || '').toLowerCase() === identifier.toLowerCase());
+    if (exact) return exact;
+    const partial = docs.filter((d: any) =>
+      (d.name || '').toLowerCase().includes(identifier.toLowerCase())
+    );
+    if (partial.length === 1) return partial[0];
+    throw new Error(
+      partial.length > 1
+        ? `${kind} identifier is ambiguous: "${identifier}" matches ${partial.length} documents`
+        : `${kind} not found: "${identifier}"`
+    );
+  }
+
+  /**
+   * Read the music binding of a scene (playlist + playlistSound, with names).
+   */
+  async getSceneMusic(options: { scene_identifier: string }): Promise<any> {
+    this.validateFoundryState();
+
+    try {
+      const scene = this.findSceneByIdentifier(options.scene_identifier);
+      const playlistId = (scene as any).playlist || null;
+      const soundId = (scene as any).playlistSound || null;
+      const playlistDoc = playlistId ? (game as any).playlists?.get(playlistId) || null : null;
+      const soundDoc = playlistDoc && soundId ? playlistDoc.sounds?.get(soundId) || null : null;
+
+      return {
+        success: true,
+        sceneId: scene.id,
+        sceneName: scene.name,
+        playlist: playlistId ? { id: playlistId, name: playlistDoc?.name || '(unknown)' } : null,
+        playlistSound: soundId ? { id: soundId, name: soundDoc?.name || '(unknown)' } : null,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to get scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * List playlists with their sounds, for name -> id resolution.
+   */
+  async listPlaylists(_options: Record<string, any> = {}): Promise<any> {
+    this.validateFoundryState();
+
+    try {
+      const playlists = (game as any).playlists?.contents || [];
+      return {
+        success: true,
+        playlists: playlists.map((pl: any) => ({
+          id: pl.id,
+          name: pl.name,
+          mode: pl.mode,
+          playing: pl.playing,
+          soundCount: pl.sounds?.size || 0,
+          sounds: (pl.sounds?.contents || []).map((s: any) => ({
+            id: s.id,
+            name: s.name,
+            path: s.path,
+          })),
+        })),
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to list playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Set or clear the music binding of a scene. Writes through scene.update()
+   * with the core ForeignDocumentFields playlist/playlistSound (id-only),
+   * so the change syncs to connected clients without a reload. Both
+   * identifiers are validated to exist before writing; explicit null clears.
+   */
+  async updateSceneMusic(options: {
+    scene_identifier: string;
+    playlist?: string | null;
+    playlist_sound?: string | null;
+  }): Promise<any> {
+    this.validateFoundryState();
+
+    try {
+      const scene = this.findSceneByIdentifier(options.scene_identifier);
+
+      const update: Record<string, any> = {};
+      const result: Record<string, any> = {
+        success: true,
+        sceneId: scene.id,
+        sceneName: scene.name,
+      };
+
+      if ('playlist' in options) {
+        const pl = this.findMusicDoc((game as any).playlists, options.playlist, 'playlist');
+        update.playlist = pl ? pl.id : null;
+        result.playlist = pl ? { id: pl.id, name: pl.name } : null;
+      }
+      if ('playlist_sound' in options) {
+        // A sound id is only valid together with its parent playlist: the
+        // scene config UI enforces the same invariant.
+        if (options.playlist_sound && !('playlist' in options) && !(scene as any).playlist) {
+          throw new Error(
+            'playlist_sound requires the scene to have a playlist (pass playlist too)'
+          );
+        }
+        const parent = options.playlist
+          ? this.findMusicDoc((game as any).playlists, options.playlist, 'playlist')
+          : null;
+        const snd = this.findMusicDoc(
+          parent ? parent.sounds : null,
+          options.playlist_sound,
+          'playlistSound'
+        );
+        update.playlistSound = snd ? snd.id : null;
+        result.playlistSound = snd ? { id: snd.id, name: snd.name } : null;
+      }
+
+      if (Object.keys(update).length === 0) {
+        throw new Error('Nothing to update: pass playlist and/or playlist_sound (null to clear)');
+      }
+      if (
+        'playlist' in update &&
+        'playlistSound' in update &&
+        update.playlistSound &&
+        !update.playlist
+      ) {
+        throw new Error('playlist_sound cannot be set while clearing playlist');
+      }
+
+      await scene.update(update);
+
+      return result;
+    } catch (error) {
+      throw new Error(
+        `Failed to update scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  // ===== PLAYLIST MANAGEMENT (CRUD + PLAYBACK) =====
+
+  /**
+   * Create or update a playlist, optionally with sounds in one call.
+   * playlist: null -> create; identifier -> update by id or (unique) name.
+   */
+  async managePlaylists(options: {
+    action: 'create' | 'update' | 'delete' | 'describe';
+    playlist?: string | null;
+    name?: string;
+    mode?: number;
+    fade?: number;
+    description?: string;
+    sorting?: 'a' | 'm';
+    folder?: string | null;
+    color?: string | null;
+    sounds?: Array<{
+      name?: string;
+      path?: string;
+      id?: string;
+      volume?: number;
+      repeat?: boolean;
+      fade?: number;
+    }>;
+    updates?: Record<string, any>;
+  }): Promise<any> {
+    this.validateFoundryState();
+
+    try {
+      const playlists = () => (game as any).playlists?.contents || [];
+
+      if (options.action === 'describe') {
+        const doc = options.playlist
+          ? this.findMusicDoc((game as any).playlists, options.playlist, 'playlist')
+          : null;
+        if (!doc) {
+          return {
+            success: true,
+            playlists: playlists().map((pl: any) => ({
+              id: pl.id,
+              name: pl.name,
+              mode: pl.mode,
+              playing: pl.playing,
+              soundCount: pl.sounds?.size || 0,
+            })),
+          };
+        }
+        return {
+          success: true,
+          playlist: {
+            id: doc.id,
+            name: doc.name,
+            mode: doc.mode,
+            playing: doc.playing,
+            description: doc.description || '',
+            folder: doc.folder || null,
+            sort: doc.sort,
+            sounds: (doc.sounds?.contents || []).map((s: any) => ({
+              id: s.id,
+              name: s.name,
+              path: s.path,
+              volume: s.volume,
+              repeat: s.repeat,
+              fade: s.fade,
+              playing: s.playing,
+            })),
+          },
+        };
+      }
+
+      if (options.action === 'create') {
+        if (!options.name || typeof options.name !== 'string') {
+          throw new Error('name is required for create');
+        }
+        const data: Record<string, any> = { name: options.name };
+        if (options.mode !== undefined) data.mode = options.mode;
+        if (options.fade !== undefined) data.fade = options.fade;
+        if (options.description !== undefined) data.description = options.description;
+        if (options.sorting !== undefined) data.sorting = options.sorting;
+        if (options.folder !== undefined) data.folder = options.folder;
+        if (options.color !== undefined) data.color = options.color;
+        const pl = await ((game as any).playlists as any).createDocuments([data]);
+        const doc = Array.isArray(pl) ? pl[0] : pl;
+
+        let soundsCreated = 0;
+        for (const s of options.sounds || []) {
+          if (!s.path) {
+            throw new Error(`sound entry needs a "path": ${JSON.stringify(s)}`);
+          }
+          const sdata: Record<string, any> = { path: s.path };
+          if (s.name !== undefined) sdata.name = s.name;
+          if (s.volume !== undefined) sdata.volume = s.volume;
+          if (s.repeat !== undefined) sdata.repeat = s.repeat;
+          if (s.fade !== undefined) sdata.fade = s.fade;
+          await (doc as any).createEmbeddedDocuments('PlaylistSound', [sdata]);
+          soundsCreated++;
+        }
+        return {
+          success: true,
+          playlist: { id: doc.id, name: doc.name, mode: doc.mode },
+          soundsCreated,
+        };
+      }
+
+      if (options.action === 'update') {
+        const doc = this.findMusicDoc((game as any).playlists, options.playlist, 'playlist');
+        if (!doc) throw new Error('update requires a playlist identifier');
+        const patch = { ...(options.updates || {}) } as Record<string, any>;
+        for (const key of [
+          'name',
+          'mode',
+          'fade',
+          'description',
+          'sorting',
+          'folder',
+          'color',
+        ] as const) {
+          if ((options as any)[key] !== undefined) patch[key] = (options as any)[key];
+        }
+        if (Object.keys(patch).length) await doc.update(patch);
+        // Sound-level ops in the same call
+        let soundsTouched = 0;
+        for (const s of options.sounds || []) {
+          if (!s.path && !s.name && !s.id) continue;
+          const list = doc.sounds?.contents || [];
+          let snd: any = null;
+          if (s.id) snd = list.find((x: any) => x.id === s.id);
+          else {
+            const byPath = s.path ? list.filter((x: any) => x.path === s.path) : [];
+            const byName = s.name ? list.filter((x: any) => x.name === s.name) : [];
+            snd = byPath.length === 1 ? byPath[0] : byName.length === 1 ? byName[0] : null;
+          }
+          if (!snd) {
+            throw new Error(
+              `sound not found in playlist "${doc.name}" (need exact id or unique path/name)`
+            );
+          }
+          const spatch: Record<string, any> = {};
+          if (s.name !== undefined) spatch.name = s.name;
+          if (s.path !== undefined) spatch.path = s.path;
+          if (s.volume !== undefined) spatch.volume = s.volume;
+          if (s.repeat !== undefined) spatch.repeat = s.repeat;
+          if (s.fade !== undefined) spatch.fade = s.fade;
+          if (Object.keys(spatch).length) {
+            await snd.update(spatch);
+            soundsTouched++;
+          }
+        }
+        return {
+          success: true,
+          playlist: { id: doc.id, name: doc.name },
+          soundsUpdated: soundsTouched,
+        };
+      }
+
+      if (options.action === 'delete') {
+        const doc = this.findMusicDoc((game as any).playlists, options.playlist, 'playlist');
+        if (!doc) throw new Error('delete requires a playlist identifier');
+        const name = doc.name;
+        await doc.delete();
+        return { success: true, deleted: name };
+      }
+
+      throw new Error(`Unknown action: ${options.action}`);
+    } catch (error) {
+      throw new Error(
+        `Failed to manage playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Playback control. Supports playlist-level play/stop/cycle-mode and
+   * per-sound play/stop, all through the client Playlist API so the server
+   * and every connected client stay in sync.
+   */
+  async controlPlaylist(options: {
+    playlist: string;
+    command: 'play' | 'stop' | 'cycle-mode' | 'play-sound' | 'stop-sound';
+    sound?: string;
+  }): Promise<any> {
+    this.validateFoundryState();
+
+    try {
+      const pl = this.findMusicDoc((game as any).playlists, options.playlist, 'playlist');
+      if (!pl) throw new Error('playlist identifier is required');
+      const info = { id: pl.id, name: pl.name, mode: pl.mode };
+
+      switch (options.command) {
+        case 'play':
+          await pl.playAll();
+          return { success: true, action: 'play', playlist: info };
+        case 'stop':
+          await pl.stopAll();
+          return { success: true, action: 'stop', playlist: info };
+        case 'cycle-mode':
+          await pl.cycleMode();
+          return { success: true, action: 'cycle-mode', playlist: info, mode: pl.mode as number };
+        case 'play-sound':
+        case 'stop-sound': {
+          if (!options.sound) throw new Error(`command ${options.command} requires "sound"`);
+          const snd = this.findMusicDoc(pl.sounds, options.sound, 'playlistSound');
+          if (!snd) throw new Error(`sound not found: "${options.sound}"`);
+          if (options.command === 'play-sound') await pl.playSound(snd);
+          else await pl.stopSound(snd);
+          return {
+            success: true,
+            action: options.command,
+            playlist: info,
+            sound: { id: snd.id, name: snd.name, path: snd.path },
+          };
+        }
+        default:
+          throw new Error(`Unknown command: ${options.command}`);
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to control playlist: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
   // ===== PHASE 7: CHARACTER ENTITY AND TOKEN MANIPULATION METHODS =====
 
   /**

--- a/packages/foundry-module/src/data-access.ts
+++ b/packages/foundry-module/src/data-access.ts
@@ -7358,8 +7358,12 @@ export class FoundryDataAccess {
 
     try {
       const scene = this.findSceneByIdentifier(options.scene_identifier);
-      const playlistId = (scene as any).playlist || null;
-      const soundId = (scene as any).playlistSound || null;
+      // On a live client, scene.playlist / playlistSound are resolved
+      // documents after an update; normalize back to ids.
+      const plRaw = (scene as any).playlist;
+      const sndRaw = (scene as any).playlistSound;
+      const playlistId = typeof plRaw === 'string' ? plRaw : plRaw?.id || null;
+      const soundId = typeof sndRaw === 'string' ? sndRaw : sndRaw?.id || null;
       const playlistDoc = playlistId ? (game as any).playlists?.get(playlistId) || null : null;
       const soundDoc = playlistDoc && soundId ? playlistDoc.sounds?.get(soundId) || null : null;
 

--- a/packages/foundry-module/src/queries.ts
+++ b/packages/foundry-module/src/queries.ts
@@ -43,6 +43,11 @@ export class QueryHandlers {
     CONFIG.queries[`${modulePrefix}.getActiveScene`] = this.handleGetActiveScene.bind(this);
     CONFIG.queries[`${modulePrefix}.list-scenes`] = this.handleListScenes.bind(this);
     CONFIG.queries[`${modulePrefix}.switch-scene`] = this.handleSwitchScene.bind(this);
+    CONFIG.queries[`${modulePrefix}.get-scene-music`] = this.handleGetSceneMusic.bind(this);
+    CONFIG.queries[`${modulePrefix}.update-scene-music`] = this.handleUpdateSceneMusic.bind(this);
+    CONFIG.queries[`${modulePrefix}.list-playlists`] = this.handleListPlaylists.bind(this);
+    CONFIG.queries[`${modulePrefix}.manage-playlists`] = this.handleManagePlaylists.bind(this);
+    CONFIG.queries[`${modulePrefix}.control-playlist`] = this.handleControlPlaylist.bind(this);
 
     // World queries
     CONFIG.queries[`${modulePrefix}.getWorldInfo`] = this.handleGetWorldInfo.bind(this);
@@ -1071,6 +1076,88 @@ export class QueryHandlers {
     } catch (error) {
       throw new Error(
         `Failed to switch scene: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleGetSceneMusic(data: any): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+      if (!data?.scene_identifier) {
+        throw new Error('scene_identifier is required');
+      }
+      return await this.dataAccess.getSceneMusic(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to get scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleUpdateSceneMusic(data: any): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+      if (!data?.scene_identifier) {
+        throw new Error('scene_identifier is required');
+      }
+      return await this.dataAccess.updateSceneMusic(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to update scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleListPlaylists(data: any): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+      return await this.dataAccess.listPlaylists(data || {});
+    } catch (error) {
+      throw new Error(
+        `Failed to list playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleManagePlaylists(data: any): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+      if (!data?.action) {
+        throw new Error('action is required (create | update | delete | describe)');
+      }
+      return await this.dataAccess.managePlaylists(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to manage playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private async handleControlPlaylist(data: any): Promise<any> {
+    try {
+      const gmCheck = this.validateGMAccess();
+      if (!gmCheck.allowed) {
+        return { error: 'Access denied', success: false };
+      }
+      if (!data?.playlist || !data?.command) {
+        throw new Error('playlist and command are required');
+      }
+      return await this.dataAccess.controlPlaylist(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to control playlist: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/mcp-server/src/backend.ts
+++ b/packages/mcp-server/src/backend.ts
@@ -21,6 +21,7 @@ import { CharacterTools } from './tools/character.js';
 import { CompendiumTools } from './tools/compendium.js';
 
 import { SceneTools } from './tools/scene.js';
+import { PlaylistTools } from './tools/playlist.js';
 
 import { ActorCreationTools } from './tools/actor-creation.js';
 import { ActorManagementTools } from './tools/actor-management.js';
@@ -1191,6 +1192,7 @@ async function startBackend(): Promise<void> {
   const compendiumTools = new CompendiumTools({ foundryClient, logger, systemRegistry });
 
   const sceneTools = new SceneTools({ foundryClient, logger });
+  const playlistTools = new PlaylistTools({ foundryClient, logger });
 
   const actorCreationTools = new ActorCreationTools({ foundryClient, logger });
   const actorManagementTools = new ActorManagementTools({ foundryClient, logger, systemRegistry });
@@ -1444,6 +1446,8 @@ async function startBackend(): Promise<void> {
     ...tokenManipulationTools.getToolDefinitions(),
 
     ...mapGenerationTools.getToolDefinitions(),
+
+    ...playlistTools.getToolDefinitions(),
   ];
 
   // Start Foundry connector (owns app port 31415)
@@ -1753,6 +1757,33 @@ async function startBackend(): Promise<void> {
 
                 case 'switch-scene':
                   result = await mapGenerationTools.switchScene(args);
+
+                  break;
+
+                // Playlist management tools
+
+                case 'manage-playlists':
+                  result = await playlistTools.handleManagePlaylists(args);
+
+                  break;
+
+                case 'control-playlist':
+                  result = await playlistTools.handleControlPlaylist(args);
+
+                  break;
+
+                case 'get-scene-music':
+                  result = await sceneTools.handleGetSceneMusic(args);
+
+                  break;
+
+                case 'update-scene-music':
+                  result = await sceneTools.handleUpdateSceneMusic(args);
+
+                  break;
+
+                case 'list-playlists':
+                  result = await sceneTools.handleListPlaylists(args);
 
                   break;
 

--- a/packages/mcp-server/src/tools/playlist.ts
+++ b/packages/mcp-server/src/tools/playlist.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+import { FoundryClient } from '../foundry-client.js';
+import { Logger } from '../logger.js';
+
+export interface PlaylistToolsOptions {
+  foundryClient: FoundryClient;
+  logger: Logger;
+}
+
+const soundEntrySchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    path: z.string().optional(),
+    volume: z.number().min(0).max(1).optional(),
+    repeat: z.boolean().optional(),
+    fade: z.number().optional(),
+  })
+  .refine(s => s.id || s.path || s.name, {
+    message: 'sound entry needs at least one of id, name, path',
+  });
+
+export class PlaylistTools {
+  private foundryClient: FoundryClient;
+  private logger: Logger;
+
+  constructor({ foundryClient, logger }: PlaylistToolsOptions) {
+    this.foundryClient = foundryClient;
+    this.logger = logger.child({ component: 'PlaylistTools' });
+  }
+
+  getToolDefinitions() {
+    return [
+      {
+        name: 'manage-playlists',
+        description:
+          'Create, update, delete, or describe playlists. create: name (+mode/fade/description/sorting/folder/color) and optional sounds [{path, name?, volume?, repeat?, fade?}]. update: playlist identifier + fields and/or sounds to patch (matched by exact id or unique path/name within the playlist). delete: playlist identifier. describe: no identifier lists all playlists; with identifier returns the full playlist with all sounds.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              type: 'string',
+              enum: ['create', 'update', 'delete', 'describe'],
+              description: 'Operation to perform',
+            },
+            playlist: {
+              type: ['string', 'null'],
+              description:
+                'Playlist id or unique name (update/delete/describe); null with describe lists all',
+            },
+            name: { type: 'string', description: 'Playlist name (create) or new name (update)' },
+            mode: {
+              type: 'number',
+              description: 'Playback mode: 0 sequential, 1 shuffle, 2 soundboard',
+            },
+            fade: { type: 'number', description: 'Crossfade duration in ms' },
+            description: { type: 'string', description: 'Playlist description' },
+            sorting: {
+              type: 'string',
+              enum: ['a', 'm'],
+              description: 'Alphabetical or manual sound ordering',
+            },
+            folder: {
+              type: ['string', 'null'],
+              description: 'Playlist folder id (null = sidebar root)',
+            },
+            color: { type: ['string', 'null'], description: 'Folder color hex string' },
+            sounds: {
+              type: 'array',
+              description:
+                'Sounds for create (needs path) or patch (id or unique path/name) on update',
+              items: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string',
+                    description: 'Exact PlaylistSound id (update matching only)',
+                  },
+                  name: { type: 'string' },
+                  path: { type: 'string' },
+                  volume: { type: 'number', minimum: 0, maximum: 1 },
+                  repeat: { type: 'boolean' },
+                  fade: { type: 'number' },
+                },
+              },
+            },
+            updates: {
+              type: 'object',
+              description: 'Free-form patch merged into the playlist update (advanced)',
+            },
+          },
+          required: ['action'],
+        },
+      },
+      {
+        name: 'control-playlist',
+        description:
+          'Playback control for playlists and their sounds: play (playAll), stop (stopAll), cycle-mode (sequential -> shuffle -> soundboard), play-sound, stop-sound. Playlist and sound accept ids or unique names.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            playlist: { type: 'string', description: 'Playlist id or unique name' },
+            command: {
+              type: 'string',
+              enum: ['play', 'stop', 'cycle-mode', 'play-sound', 'stop-sound'],
+              description: 'Playback command',
+            },
+            sound: {
+              type: 'string',
+              description:
+                'Sound id or unique name within the playlist (play-sound / stop-sound only)',
+            },
+          },
+          required: ['playlist', 'command'],
+        },
+      },
+    ];
+  }
+
+  async handleManagePlaylists(args: any): Promise<any> {
+    const schema = z.object({
+      action: z.enum(['create', 'update', 'delete', 'describe']),
+      playlist: z.string().nullable().optional(),
+      name: z.string().optional(),
+      mode: z.number().int().min(0).max(2).optional(),
+      fade: z.number().optional(),
+      description: z.string().optional(),
+      sorting: z.enum(['a', 'm']).optional(),
+      folder: z.string().nullable().optional(),
+      color: z.string().nullable().optional(),
+      sounds: z.array(soundEntrySchema).optional(),
+      updates: z.record(z.any()).optional(),
+    });
+    const parsed = schema.parse(args);
+
+    this.logger.info('Managing playlists', { action: parsed.action, playlist: parsed.playlist });
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.manage-playlists', parsed);
+      return { success: true, ...result };
+    } catch (error) {
+      this.logger.error('Failed to manage playlists', error);
+      throw new Error(
+        `Failed to manage playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleControlPlaylist(args: any): Promise<any> {
+    const schema = z.object({
+      playlist: z.string().min(1),
+      command: z.enum(['play', 'stop', 'cycle-mode', 'play-sound', 'stop-sound']),
+      sound: z.string().optional(),
+    });
+    const parsed = schema.parse(args);
+    if ((parsed.command === 'play-sound' || parsed.command === 'stop-sound') && !parsed.sound) {
+      throw new Error(`command ${parsed.command} requires "sound"`);
+    }
+
+    this.logger.info('Controlling playlist', {
+      playlist: parsed.playlist,
+      command: parsed.command,
+    });
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.control-playlist', parsed);
+      return { success: true, ...result };
+    } catch (error) {
+      this.logger.error('Failed to control playlist', error);
+      throw new Error(
+        `Failed to control playlist: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/scene.ts
+++ b/packages/mcp-server/src/tools/scene.ts
@@ -49,6 +49,52 @@ export class SceneTools {
           properties: {},
         },
       },
+      {
+        name: 'get-scene-music',
+        description: 'Get the music binding of a scene (playlist and playlistSound, by id or name)',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scene_identifier: {
+              type: 'string',
+              description: 'Scene id or exact name',
+            },
+          },
+          required: ['scene_identifier'],
+        },
+      },
+      {
+        name: 'update-scene-music',
+        description:
+          'Set or clear the music binding of a scene. Pass playlist and optionally playlist_sound (ids or unique names, null to clear). Writes through the scene document API and syncs live to connected clients.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scene_identifier: {
+              type: 'string',
+              description: 'Scene id or exact name',
+            },
+            playlist: {
+              type: ['string', 'null'],
+              description: 'Playlist id or unique name, or null to clear',
+            },
+            playlist_sound: {
+              type: ['string', 'null'],
+              description: 'PlaylistSound id or unique name within the playlist, or null to clear',
+            },
+          },
+          required: ['scene_identifier'],
+        },
+      },
+      {
+        name: 'list-playlists',
+        description:
+          'List all playlists with their sounds (ids, names, paths) for resolving names to ids',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
     ];
   }
 
@@ -96,6 +142,61 @@ export class SceneTools {
       this.logger.error('Failed to get world information', error);
       throw new Error(
         `Failed to get world information: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleGetSceneMusic(args: any): Promise<any> {
+    const schema = z.object({ scene_identifier: z.string().min(1) });
+    const { scene_identifier } = schema.parse(args);
+
+    this.logger.info('Getting scene music', { scene_identifier });
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.get-scene-music', {
+        scene_identifier,
+      });
+      return { success: true, ...result };
+    } catch (error) {
+      this.logger.error('Failed to get scene music', error);
+      throw new Error(
+        `Failed to get scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleUpdateSceneMusic(args: any): Promise<any> {
+    const schema = z.object({
+      scene_identifier: z.string().min(1),
+      playlist: z.string().nullable().optional(),
+      playlist_sound: z.string().nullable().optional(),
+    });
+    const parsed = schema.parse(args);
+
+    this.logger.info('Updating scene music', { scene_identifier: parsed.scene_identifier });
+    try {
+      const result = await this.foundryClient.query(
+        'foundry-mcp-bridge.update-scene-music',
+        parsed
+      );
+      this.logger.info('Scene music updated', { scene_identifier: parsed.scene_identifier });
+      return { success: true, ...result };
+    } catch (error) {
+      this.logger.error('Failed to update scene music', error);
+      throw new Error(
+        `Failed to update scene music: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async handleListPlaylists(_args: any): Promise<any> {
+    this.logger.info('Listing playlists');
+    try {
+      const result = await this.foundryClient.query('foundry-mcp-bridge.list-playlists', {});
+      return { success: true, ...result };
+    } catch (error) {
+      this.logger.error('Failed to list playlists', error);
+      throw new Error(
+        `Failed to list playlists: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }


### PR DESCRIPTION
Closes #93. Adds scene music bindings plus full playlist management and playback to the bridge.

## Scene music (Closes #93)

- `get-scene-music` reads a scene's `playlist` / `playlistSound` (ids + names)
- `update-scene-music` sets or clears the binding by id or unique name. It writes through `scene.update()` with the core `playlist` / `playlistSound` ForeignDocumentFields, so the change syncs to connected clients without a reload - no server stop, no LevelDB surgery. Both identifiers are validated to exist before writing; a sound cannot be bound without its parent playlist (the same invariant the scene config UI enforces).

## Playlist management and playback

- `manage-playlists` (`create` | `update` | `delete` | `describe`): playlist CRUD on any system. `create` takes sounds inline (`path` required; optional `name`, `volume`, `repeat`, `fade`) via `createEmbeddedDocuments`. `update` patches playlist fields and/or individual sounds, matched by exact id or unique path/name inside the playlist, and refuses ambiguous matches. `describe` lists all playlists compactly without an identifier, or returns the full document with every sound.
- `control-playlist`: `play` / `stop` (playAll/stopAll), `cycle-mode` (sequential -> shuffle -> soundboard), and per-sound `play-sound` / `stop-sound` through the client Playlist API, so the server and every connected client stay in sync.

## Implementation notes

- Module side: five new query handlers in `queries.ts` with the same silent GM validation as every other handler; data access in `data-access.ts` reuses the `switchScene` lookup pattern and adds a shared `findMusicDoc` resolver (exact id -> exact name -> unique substring, else a clear error).
- Server side: new `tools/playlist.ts`; `tools/scene.ts` gains the scene-music tools; `backend.ts` registers both.
- GM-only, system-agnostic; no schema assumptions beyond the core `playlist` / `playlistSound` fields and the client `Playlist` API (`playSound`, `stopSound`, `playAll`, `stopAll`, `cycleMode`), all verified against the v14 source.

## Testing

- `npm run build -w @foundry-mcp/server` - clean
- `npm run typecheck` + `npm run build` in `@foundry-mcp/module` - clean
- `npm run test:mcp:schema` - PASS (tool schemas load, object input, no global additionalProperties)
- `npm test` - 153/153 passing
- Live-tested against Foundry 14.367 + OSE 2.3.0 (module + these changes deployed, resident backend, GM client connected): `list-playlists` returns all 12 world playlists, `update-scene-music` bound a combat scene to a combat track by name (verified with `get-scene-music`), `control-playlist` ran `play-sound` (audible playback confirmed at the table), `stop-sound`, and two `cycle-mode` steps, then the binding was cleared with `null` and the playlist mode restored. One live-session finding folded back into this PR: after a live `scene.update`, the runtime `scene.playlist` holds the resolved document rather than the id, so `get-scene-music` normalizes both shapes back to ids.
- `module.json` bumped to 0.8.4 so clients pick up the new build cleanly.

Happy to adjust naming/validation to house style - the surface is deliberately small: five tools, no new settings, no schema writes.
